### PR TITLE
If no assigned locker is found return empty array

### DIFF
--- a/src/commons/services/locker/locker-service.js
+++ b/src/commons/services/locker/locker-service.js
@@ -705,7 +705,7 @@ class LockerService {
    * @returns {Array} An array of locker units that have been assigned.
    */
   static assignedLocker(booking) {
-    return booking.lockerInfo;
+    return booking.lockerInfo || [];
   }
 }
 


### PR DESCRIPTION
This pull request includes a small but important change to the `LockerService` class in the `src/commons/services/locker/locker-service.js` file. The change ensures that the `assignedLocker` method returns an empty array if no locker information is available, improving the method's robustness.

* [`src/commons/services/locker/locker-service.js`](diffhunk://#diff-4c2605f9a5e3d0a63f9a82681baa3043c87080f48071883018c3348c31ede2bdL708-R708): Modified the `assignedLocker` method to return an empty array when `booking.lockerInfo` is undefined or null.