### PR TITLE
Changed default parameters for event tickets

### DIFF
--- a/src/commons/services/event-service.js
+++ b/src/commons/services/event-service.js
@@ -21,7 +21,9 @@ class EventService {
         type: "ticket",
         title: event.information.name,
         description: event.information.teaserText,
-        amount: Number(event.attendees.maxAttendees),
+        isBookable: true,
+        isPublic: true,
+        autoCommitBooking: true,
       });
       await BookableManager.storeBookable(ticket);
     }


### PR DESCRIPTION
If events are created including automatic ticket creation, we do not need the amount parameter, since the amount is derived from the event while checkout. The Tickets then should be public, bookable and auto commit.