### PR TITLE
fix doctype in email template

### DIFF
--- a/src/commons/mail-service/templates/default-generic-mail-template.temp.html
+++ b/src/commons/mail-service/templates/default-generic-mail-template.temp.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="de">
   <head>
     <style>


### PR DESCRIPTION
This pull request includes a small change to the `src/commons/mail-service/templates/default-generic-mail-template.temp.html` file. The change corrects the document type declaration to use uppercase "DOCTYPE".

* [`src/commons/mail-service/templates/default-generic-mail-template.temp.html`](diffhunk://#diff-808626c983cea566003589cbd65b944b80c1e2687e3418cc6f107df3ba741715L1-R1): Changed `<!doctype html>` to `<!DOCTYPE html>`.