### PR TITLE
removed rejected bookings from calendar

### DIFF
--- a/src/commons/utilities/calendar-occupancy-worker.js
+++ b/src/commons/utilities/calendar-occupancy-worker.js
@@ -43,7 +43,7 @@ async function fetchOccupancies(bookable, tenant) {
     }
 
     return bookings
-      .filter((booking) => !!booking.timeBegin && !!booking.timeEnd)
+      .filter((booking) => !!booking.timeBegin && !!booking.timeEnd && !booking.isRejected)
       .filter(
         (booking, index, self) =>
           self.findIndex((b) => b.id === booking.id) === index,


### PR DESCRIPTION
This pull request includes a small but important change to the `fetchOccupancies` function in `src/commons/utilities/calendar-occupancy-worker.js`. The change ensures that rejected bookings are filtered out from the list of bookings.

* [`src/commons/utilities/calendar-occupancy-worker.js`](diffhunk://#diff-d0d6fa77297c5881f0f813a0daa3396682852b4b0baa1e0861a8cc3a4653099bL46-R46): Modified the `fetchOccupancies` function to filter out bookings where `isRejected` is true.