### PR TITLE
disabled bcc

### DIFF
--- a/src/commons/mail-service/mail-controller.js
+++ b/src/commons/mail-service/mail-controller.js
@@ -239,7 +239,7 @@ class MailController {
       message: `<p>Im Folgenden senden wir Ihnen die Details Ihrer Buchung.</p><br>`,
       includeQRCode: includeQRCode,
       attachments,
-      sendBCC: true,
+      sendBCC: false,
       addRejectionLink: true,
     });
   }
@@ -268,7 +268,7 @@ class MailController {
       message: message,
       includeQRCode: false,
       attachments,
-      sendBCC: true,
+      sendBCC: false,
       addRejectionLink: false,
     });
   }
@@ -319,7 +319,7 @@ class MailController {
       message: `<p>Im Folgenden senden wir Ihnen die Details Ihrer Buchung.</p><br>`,
       includeQRCode: includeQRCode,
       attachments: undefined,
-      sendBCC: true,
+      sendBCC: false,
       addRejectionLink: true,
     });
   }
@@ -338,7 +338,7 @@ class MailController {
       message: `<p>Vielen Dank für Ihre Buchungsanfrage im ${tenant.name}. Wir haben Ihre Anfrage erhalten und bearbeiten diese schnellstmöglich.</p><br>`,
       includeQRCode: includeQRCode,
       attachments: undefined,
-      sendBCC: true,
+      sendBCC: false,
       addRejectionLink: true,
     });
   }
@@ -361,7 +361,7 @@ class MailController {
       message: `<p>Vielen Dank für Ihre Buchung bei ${tenant.name}. Bitte überweisen Sie zur Vervollständigung Ihrer Buchung den im Anhang aufgeführten Betrag auf das angegebene Konto.</p><br>`,
       includeQRCode: includeQRCode,
       attachments,
-      sendBCC: true,
+      sendBCC: false,
       addRejectionLink: true,
     });
   }


### PR DESCRIPTION
This pull request includes changes to the `MailController` class in the `src/commons/mail-service/mail-controller.js` file. The primary change is the modification of the `sendBCC` parameter to `false` in multiple methods.

Changes to `MailController`:

* [`src/commons/mail-service/mail-controller.js`](diffhunk://#diff-7dbcae3c4922516d9f7b7c9d83e3432afce3dafd400c6f699fd393b191a68a15L242-R242): Modified the `sendBCC` parameter to `false` in various methods to stop sending blind carbon copies. [[1]](diffhunk://#diff-7dbcae3c4922516d9f7b7c9d83e3432afce3dafd400c6f699fd393b191a68a15L242-R242) [[2]](diffhunk://#diff-7dbcae3c4922516d9f7b7c9d83e3432afce3dafd400c6f699fd393b191a68a15L271-R271) [[3]](diffhunk://#diff-7dbcae3c4922516d9f7b7c9d83e3432afce3dafd400c6f699fd393b191a68a15L322-R322) [[4]](diffhunk://#diff-7dbcae3c4922516d9f7b7c9d83e3432afce3dafd400c6f699fd393b191a68a15L341-R341) [[5]](diffhunk://#diff-7dbcae3c4922516d9f7b7c9d83e3432afce3dafd400c6f699fd393b191a68a15L364-R364)