### PR TITLE
added different email for reject and cancel booking

### DIFF
--- a/src/commons/mail-service/mail-controller.js
+++ b/src/commons/mail-service/mail-controller.js
@@ -253,6 +253,35 @@ class MailController {
   ) {
     const tenant = await TenantManager.getTenant(tenantId);
 
+    let message = `<p>Die nachfolgende Buchung wurde abgelehnt:</p>`;
+    if (reason) {
+      reason = sanitizeReason(reason);
+      message += `<p><strong>Ablehnungsgrund</strong>: ${reason}</p>`;
+    }
+
+    await this._sendBookingMail({
+      address,
+      bookingId,
+      tenantId,
+      subject: `Abgelehnt: Ihre Buchungsanfrage im ${tenant.name} wurde abgelehnt`,
+      title: `Ihre Buchungsanfrage im ${tenant.name} wurde abgelehnt`,
+      message: message,
+      includeQRCode: false,
+      attachments,
+      sendBCC: true,
+      addRejectionLink: false,
+    });
+  }
+
+  static async sendBookingCancel(
+    address,
+    bookingId,
+    tenantId,
+    reason,
+    attachments = undefined,
+  ) {
+    const tenant = await TenantManager.getTenant(tenantId);
+
     let message = `<p>Die nachfolgende Buchung wurde storniert:</p>`;
     if (reason) {
       reason = sanitizeReason(reason);

--- a/src/commons/services/checkout/booking-service.js
+++ b/src/commons/services/checkout/booking-service.js
@@ -339,12 +339,28 @@ class BookingService {
 
       await BookingManager.storeBooking(booking);
 
-      await MailController.sendBookingRejection(
-        booking.mail,
-        booking.id,
-        booking.tenantId,
-        reason,
-      );
+      if (!booking.isCommitted && !hookId) {
+        await MailController.sendBookingRejection(
+          booking.mail,
+          booking.id,
+          booking.tenantId,
+          reason,
+        );
+        logger.info(
+          `${tenantId} -- booking ${booking.id} rejected and sent booking rejection to ${booking.mail}`,
+        );
+      } else {
+        await MailController.sendBookingCancel(
+          booking.mail,
+          booking.id,
+          booking.tenantId,
+          reason,
+        );
+        logger.info(
+          `${tenantId} -- booking ${booking.id} canceled and sent booking rejection to ${booking.mail}`,
+        );
+      }
+
       logger.info(
         `${tenantId} -- booking ${booking.id} rejected and sent booking rejection to ${booking.mail}`,
       );


### PR DESCRIPTION
This pull request introduces changes to the mail notification system in the booking service. The key updates include the addition of a new method to handle booking cancellations and modifications to the booking rejection logic.

### Mail Notification Enhancements:

* [`src/commons/mail-service/mail-controller.js`](diffhunk://#diff-7dbcae3c4922516d9f7b7c9d83e3432afce3dafd400c6f699fd393b191a68a15R256-R284): Added a new static method `sendBookingCancel` to send cancellation emails with an optional reason and attachments.
* [`src/commons/mail-service/mail-controller.js`](diffhunk://#diff-7dbcae3c4922516d9f7b7c9d83e3432afce3dafd400c6f699fd393b191a68a15R256-R284): Updated the existing method to send booking rejection emails, including a reason if provided.

### Booking Service Updates:

* [`src/commons/services/checkout/booking-service.js`](diffhunk://#diff-2172e2b3d697e93409b5b319773bcfea7c61a40d7f58a6e639f9b60d86fd77beR342-R363): Modified the booking process to differentiate between booking rejections and cancellations. If a booking is not committed and no hook ID is present, a rejection email is sent; otherwise, a cancellation email is sent.
* [`src/commons/services/checkout/booking-service.js`](diffhunk://#diff-2172e2b3d697e93409b5b319773bcfea7c61a40d7f58a6e639f9b60d86fd77beR342-R363): Added logging to capture whether a booking was rejected or canceled and the corresponding email notification was sent.