### PR TITLE
new action version

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -80,7 +80,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use a newer version of the Docker build and push action.

Workflow update:

* [`.github/workflows/docker-publish.yml`](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L83-R83): Updated the `docker/build-push-action` from a specific commit reference (`0565240e2d4ab88bba5387d719585280857ece09`) to the more concise `v6` version, ensuring the workflow uses the latest stable release of version 6.