### PR TITLE
if a event is in the past the ticket can't be checked out

### DIFF
--- a/src/commons/services/checkout/item-checkout-service.js
+++ b/src/commons/services/checkout/item-checkout-service.js
@@ -593,11 +593,55 @@ class ItemCheckoutService {
     return true;
   }
 
+  async checkEventDate() {
+    if (
+      this.originBookable.type === "ticket" &&
+      !!this.originBookable.eventId
+    ) {
+      const event = await EventManager.getEvent(
+        this.originBookable.eventId,
+        this.originBookable.tenantId,
+      );
+
+      if (!event) {
+        throw new Error(
+          `Die Veranstaltung für das Ticket ${this.originBookable.title} existiert nicht.`
+        );
+      }
+
+      const now = new Date();
+      const eventEndDate = event.information.endDate ? new Date(event.information.endDate) : null;
+
+      const eventDate = eventEndDate || (event.information.startDate ? new Date(event.information.startDate) : null);
+
+      if (!eventDate) {
+        return true;
+      }
+
+      if (eventEndDate && event.information.endTime) {
+        const [hours, minutes] = event.information.endTime.split(':').map(Number);
+        eventEndDate.setHours(hours, minutes, 0, 0);
+      } else if (!eventEndDate && event.information.startTime) {
+        const [hours, minutes] = event.information.startTime.split(':').map(Number);
+        eventDate.setHours(hours, minutes, 0, 0);
+      }
+
+      if (eventDate < now) {
+        throw new Error(
+          `Die Veranstaltung ${event.information.name} liegt in der Vergangenheit und kann nicht mehr gebucht werden.`
+        );
+      }
+    }
+
+    return true;
+  }
+
   async checkAll() {
     await this.checkPermissions();
     await this.checkOpeningHours();
     await this.checkBookingDuration();
     await this.checkAvailability();
+    await this.checkEventDate();
     await this.checkEventSeats();
     await this.checkParentAvailability();
     await this.checkChildBookings();

--- a/src/commons/services/checkout/item-checkout-service.js
+++ b/src/commons/services/checkout/item-checkout-service.js
@@ -595,7 +595,7 @@ class ItemCheckoutService {
 
   async checkEventDate() {
     if (
-      this.originBookable.type === "ticket" &&
+      this.originBookable.type === BOOKABLE_TYPES.TICKET &&
       !!this.originBookable.eventId
     ) {
       const event = await EventManager.getEvent(

--- a/src/platform/api/controllers/calendar-controller.js
+++ b/src/platform/api/controllers/calendar-controller.js
@@ -431,6 +431,7 @@ class CalendarController {
         await itemCheckoutService.checkPermissions();
         await itemCheckoutService.checkOpeningHours();
         await itemCheckoutService.checkAvailability();
+        await itemCheckoutService.checkEventDate();
         await itemCheckoutService.checkEventSeats();
         await itemCheckoutService.checkParentAvailability();
         await itemCheckoutService.checkChildBookings();


### PR DESCRIPTION
This pull request introduces a new method, `checkEventDate`, to validate event dates during the checkout process and integrates it into the relevant workflows. The changes ensure that events in the past cannot be booked, enhancing the robustness of the booking system.

### Enhancements to event validation:

* **New `checkEventDate` method in `ItemCheckoutService`:**  
  A method was added to validate whether an event associated with a ticket is in the past. It checks the event's start and end dates (and times, if provided) and throws an error if the event has already concluded. This ensures that tickets for past events cannot be booked. (`src/commons/services/checkout/item-checkout-service.js`, [src/commons/services/checkout/item-checkout-service.jsR596-R644](diffhunk://#diff-db6125299a1ce5eadfe2664471eb4220f214f8a77fd52aadf9b4bd111e5e4f7cR596-R644))

* **Integration of `checkEventDate` into `checkAll` in `ItemCheckoutService`:**  
  The `checkEventDate` method is now called as part of the `checkAll` validation process, ensuring that all necessary checks are performed during the checkout process. (`src/commons/services/checkout/item-checkout-service.js`, [src/commons/services/checkout/item-checkout-service.jsR596-R644](diffhunk://#diff-db6125299a1ce5eadfe2664471eb4220f214f8a77fd52aadf9b4bd111e5e4f7cR596-R644))

* **Update to `CalendarController` to include `checkEventDate`:**  
  The `checkEventDate` method is explicitly invoked in the calendar-related booking process, ensuring consistent validation across different parts of the application. (`src/platform/api/controllers/calendar-controller.js`, [src/platform/api/controllers/calendar-controller.jsR434](diffhunk://#diff-cfb9ad8bbf7cfa1d6481a1b548be9d75325523f800fe3ed12572f5730a918837R434))