### PR TITLE
rename removeBooking to cancelBooking

### DIFF
--- a/src/platform/api/controllers/booking-controller.js
+++ b/src/platform/api/controllers/booking-controller.js
@@ -414,7 +414,7 @@ class BookingController {
             RolePermission.MANAGE_BOOKINGS,
           )
         ) {
-          await BookingService.removeBooking(tenant, id);
+          await BookingService.cancelBooking(tenant, id);
           await WorkflowService.removeTask(tenant, id);
           logger.info(`${tenant} -- removed booking ${id} by user ${user?.id}`);
           response.sendStatus(200);


### PR DESCRIPTION
Hi, ich habe gerade den develop Branch ausprobiert. Beim Versuch eine Buchung per API zu stornieren, habe ich folgenden Fehler erhalten:

{"name":"booking-controller.js","hostname":"da90b1e57387","pid":43,"level":50,"err":{"message":"BookingService.removeBooking is not a function","name":"TypeError","stack":"TypeError: BookingService.removeBooking is not a function\n    at removeBooking (/app/src/platform/api/controllers/booking-controller.js:417:32)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)"},"msg":"BookingService.removeBooking is not a function","time":"2025-07-16T14:55:43.799Z","v":0}

Hier wurde scheinbar versucht eine Methode BookingService.removeBooking aufzurufen. Die Methode BookingService.cancelBooking hieß mal removeBooking. Daher nehme ich an, dass eigentlich diese hier gemeint war. Scheint auch das zu tun was sie soll. Demnach hier mein Vorschlag für einen Fix.