### PR TITLE
added bcc receipt

### DIFF
--- a/src/commons/mail-service/mail-controller.js
+++ b/src/commons/mail-service/mail-controller.js
@@ -441,6 +441,8 @@ class MailController {
     bookingIds = Array.isArray(bookingIds) ? bookingIds : [bookingIds];
     const tenant = await TenantManager.getTenant(tenantId);
     const includeQRCode = tenant.enablePublicStatusView;
+    const receiptEnableBCC =
+      attachments && attachments.length > 0 ? tenant.receiptEnableBCC : false;
 
     const snippetTemplateString = `
     <div style="font-family: sans-serif;">
@@ -471,7 +473,7 @@ class MailController {
         title: `Vielen Dank für Ihre Buchung im  ${tenant.name}`,
         attachments,
         message: snippetHtml,
-        sendBCC: false,
+        sendBCC: receiptEnableBCC,
         addRejectionLink: true,
       });
     } else {
@@ -485,7 +487,7 @@ class MailController {
           message: snippetHtml,
           includeQRCode: includeQRCode,
           attachments,
-          sendBCC: false,
+          sendBCC: receiptEnableBCC,
           addRejectionLink: true,
         });
       }

--- a/src/commons/schemas/tenantSchema.js
+++ b/src/commons/schemas/tenantSchema.js
@@ -24,6 +24,7 @@ const tenantSchemaDefinition = {
   receiptTemplate: { type: String, default: "" },
   receiptNumberPrefix: { type: String, default: "" },
   receiptCount: { type: Object, default: {} },
+  receiptEnableBCC: { type: Boolean, default: false },
   invoiceTemplate: { type: String, default: "" },
   invoiceNumberPrefix: { type: String, default: "" },
   invoiceCount: { type: Object, default: {} },

--- a/src/platform/api/controllers/tenant-controller.js
+++ b/src/platform/api/controllers/tenant-controller.js
@@ -197,6 +197,7 @@ class TenantController {
           "noreplyGraphClientSecret",
           "receiptTemplate",
           "receiptNumberPrefix",
+          "receiptEnableBCC",
           "invoiceTemplate",
           "invoiceNumberPrefix",
           "paymentPurposeSuffix",


### PR DESCRIPTION
This pull request introduces a new tenant setting to control whether receipts sent via email should include a BCC recipient. The main changes add support for this feature in the tenant schema, API controller, and mail sending logic.

**Tenant Settings and Schema Updates:**
* Added `receiptEnableBCC` as a boolean field to the `tenantSchema`, defaulting to `false`, allowing tenants to configure BCC behavior for receipt emails.
* Included `receiptEnableBCC` in the list of tenant settings managed by the `TenantController`, ensuring it can be set and retrieved via the API.

**Mail Sending Logic:**
* Updated `MailController` to determine the `sendBCC` flag for receipt emails based on the new `receiptEnableBCC` setting and whether attachments are present.
* Modified both branches of the receipt email logic in `MailController` to use the dynamic `sendBCC` flag instead of always setting it to `false`. [[1]](diffhunk://#diff-7dbcae3c4922516d9f7b7c9d83e3432afce3dafd400c6f699fd393b191a68a15L474-R476) [[2]](diffhunk://#diff-7dbcae3c4922516d9f7b7c9d83e3432afce3dafd400c6f699fd393b191a68a15L488-R490)