### PR TITLE
Fix/new email notification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smart-city-booking-backend",
-  "version": "3.2.10",
+  "version": "3.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "smart-city-booking-backend",
-      "version": "3.2.10",
+      "version": "3.2.11",
       "license": "GPL-3.0",
       "dependencies": {
         "@azure/msal-node": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-city-booking-backend",
-  "version": "3.2.10",
+  "version": "3.2.11",
   "description": "An open-source backend system for booking and managing resources in smart cities and regions.",
   "main": "src/server.js",
   "scripts": {

--- a/src/commons/schemas/tenantSchema.js
+++ b/src/commons/schemas/tenantSchema.js
@@ -33,6 +33,7 @@ const tenantSchemaDefinition = {
   maxBookingAdvanceInMonths: { type: Number, default: null },
   defaultEventCreationMode: { type: String, default: "" },
   enablePublicStatusView: { type: Boolean, default: false },
+  notifyOnNewBooking: { type: Boolean, default: true },
   ownerUserIds: { type: Array, default: [] },
   users: [
     {

--- a/src/commons/services/checkout/booking-service.js
+++ b/src/commons/services/checkout/booking-service.js
@@ -320,18 +320,22 @@ class BookingService {
           const isTicketBooking = bookableItems.some(isTicket);
 
           if (isTicketBooking) {
-            const eventIds = bookableItems.map(getEventForTicket).filter((id) => id !== null && id !== undefined);
+            const eventIds = bookableItems
+              .map(getEventForTicket)
+              .filter((id) => id !== null && id !== undefined);
             await sendEmailToOrganizer(eventIds, tenantId, booking);
           }
         }
 
         const tenant = await TenantManager.getTenant(booking.tenantId);
 
-        await MailController.sendIncomingBooking(
-          tenant.mail,
-          booking.id,
-          booking.tenantId,
-        );
+        if (tenant.notifyOnNewBooking) {
+          await MailController.sendIncomingBooking(
+            tenant.mail,
+            booking.id,
+            booking.tenantId,
+          );
+        }
       } catch (err) {
         logger.error(err);
       }
@@ -440,12 +444,15 @@ class BookingService {
         }
 
         const tenant = await TenantManager.getTenant(newGroupBooking.tenantId);
-        await MailController.sendIncomingBooking(
-          tenant.mail,
-          newGroupBooking.bookingIds,
-          newGroupBooking.tenantId,
-          true,
-        );
+
+        if (tenant.notifyOnNewBooking) {
+          await MailController.sendIncomingBooking(
+            tenant.mail,
+            newGroupBooking.bookingIds,
+            newGroupBooking.tenantId,
+            true,
+          );
+        }
       } catch (err) {
         logger.error(`Error while sending email: ${err}`);
       }
@@ -594,7 +601,9 @@ class BookingService {
       const isTicketBooking = bookableItems.some(isTicket);
 
       if (isTicketBooking) {
-        const eventIds = bookableItems.map(getEventForTicket).filter((id) => id !== null && id !== undefined);
+        const eventIds = bookableItems
+          .map(getEventForTicket)
+          .filter((id) => id !== null && id !== undefined);
         if (eventIds.length > 0) {
           await sendEmailToOrganizer(eventIds, tenantId, originBooking);
         }
@@ -712,7 +721,7 @@ class BookingService {
 
       await BookingManager.storeBooking(booking);
 
-      if(isRejection(booking, hookId)) {
+      if (isRejection(booking, hookId)) {
         await MailController.sendBookingRejection(
           booking.mail,
           booking.id,
@@ -772,9 +781,7 @@ class BookingService {
       await BookingManager.storeBooking(booking);
     }
 
-    if (
-      groupBooking.bookings.some((booking) => isRejection(booking, hookId))
-    ) {
+    if (groupBooking.bookings.some((booking) => isRejection(booking, hookId))) {
       await MailController.sendBookingRejection(
         groupBooking.bookings[0].mail,
         groupBooking.bookingIds,
@@ -1020,11 +1027,11 @@ function isRejection(booking, hookId) {
 }
 
 function isTicket(bookableItem) {
-  return bookableItem?._bookableUsed?.type === "ticket";
+  return bookableItem?.type === "ticket";
 }
 
 function getEventForTicket(bookableItem) {
-  return bookableItem?._bookableUsed?.eventId || null;
+  return bookableItem?.eventId || null;
 }
 
 async function sendEmailToOrganizer(eventIds, tenantId, booking) {

--- a/src/platform/api/controllers/tenant-controller.js
+++ b/src/platform/api/controllers/tenant-controller.js
@@ -205,6 +205,7 @@ class TenantController {
           "maxBookingAdvanceInMonths",
           "defaultEventCreationMode",
           "enablePublicStatusView",
+          "notifyOnNewBooking",
           "ownerUserIds",
           "users",
         ];


### PR DESCRIPTION
This pull request introduces a new tenant-level configuration option to control email notifications for new bookings. It adds the `notifyOnNewBooking` field to the tenant schema and ensures that notification emails are only sent if this flag is enabled. Additionally, it includes some code cleanup and minor refactoring in the booking service logic.

**Tenant notification configuration:**

* Added a new `notifyOnNewBooking` boolean field (defaulting to `true`) to the `tenantSchema` to allow tenants to control whether they receive email notifications for new bookings. (`src/commons/schemas/tenantSchema.js`, `src/platform/api/controllers/tenant-controller.js`) [[1]](diffhunk://#diff-bce0708e8a30673e019d35a63a70e9ac7ff2d8d54bff5767aa63599f8a5ec8faR36) [[2]](diffhunk://#diff-cc13d0e817fd611cf7a88e1dee11ba778d3dd2064f8abeb8d0577cec5023da65R208)

**Booking notification logic:**

* Updated booking-related service methods to check the `notifyOnNewBooking` flag before sending incoming booking emails to tenants, ensuring notifications are only sent when enabled. (`src/commons/services/checkout/booking-service.js`) [[1]](diffhunk://#diff-2172e2b3d697e93409b5b319773bcfea7c61a40d7f58a6e639f9b60d86fd77beL323-R338) [[2]](diffhunk://#diff-2172e2b3d697e93409b5b319773bcfea7c61a40d7f58a6e639f9b60d86fd77beR447-R455)

**Code cleanup and refactoring:**

* Simplified the logic for ticket bookings by removing references to the deprecated `_bookableUsed` property in favor of direct access to `type` and `eventId`. (`src/commons/services/checkout/booking-service.js`)
* Minor formatting improvements and code style adjustments for better readability in the booking service. (`src/commons/services/checkout/booking-service.js`) [[1]](diffhunk://#diff-2172e2b3d697e93409b5b319773bcfea7c61a40d7f58a6e639f9b60d86fd77beL597-R606) [[2]](diffhunk://#diff-2172e2b3d697e93409b5b319773bcfea7c61a40d7f58a6e639f9b60d86fd77beL775-R784)

**Other:**

* Bumped the project version from `3.2.10` to `3.2.11` in `package.json`.