### PR TITLE
added booked event seats

### DIFF
--- a/src/commons/data-managers/booking-manager.js
+++ b/src/commons/data-managers/booking-manager.js
@@ -150,7 +150,10 @@ class BookingManager {
     timeEnd,
     bookingToIgnore = null,
   ) {
-    const relatedBookings = await BookingManager.getRelatedBookings(tenantId, bookableId);
+    const relatedBookings = await BookingManager.getRelatedBookings(
+      tenantId,
+      bookableId,
+    );
 
     return relatedBookings.filter(
       (booking) =>
@@ -214,6 +217,16 @@ class BookingManager {
 
     const bookableIds = bookables.map((b) => b.id);
     return await BookingManager.getRelatedBookingsBatch(tenantId, bookableIds);
+  }
+
+  static async getBookedSeatsCount(tenantId, eventId) {
+    const count = await BookingModel.countDocuments({
+      tenantId: tenantId,
+      isRejected: false,
+      "bookableItems._bookableUsed.eventId": eventId,
+    })
+
+    return count;
   }
 
   /**

--- a/src/commons/services/checkout/booking-service.js
+++ b/src/commons/services/checkout/booking-service.js
@@ -1166,6 +1166,10 @@ class BookingService {
 
     return bookings;
   }
+
+  static async getBookedSeatsCount(tenantId, eventId) {
+    return await BookingManager.getBookedSeatsCount(tenantId, eventId);
+  }
 }
 
 module.exports = BookingService;

--- a/src/platform/api/api-router-tenant-related.js
+++ b/src/platform/api/api-router-tenant-related.js
@@ -94,6 +94,11 @@ router.get(
   AuthenticationController.isSignedIn,
   EventController.countCheck,
 );
+router.get(
+  "/events/:id/count",
+  AuthenticationController.isSignedIn,
+  EventController.getBookedSeatsCount,
+);
 
 // BOOKINGS
 // ========

--- a/src/platform/api/controllers/event-controller.js
+++ b/src/platform/api/controllers/event-controller.js
@@ -4,6 +4,7 @@ const { RolePermission } = require("../../../commons/entities/role/role");
 const bunyan = require("bunyan");
 const EventService = require("../../../commons/services/event-service");
 const PermissionService = require("../../../commons/services/permission-service");
+const BookingService = require("../../../commons/services/checkout/booking-service");
 
 const logger = bunyan.createLogger({
   name: "event-controller.js",
@@ -51,6 +52,39 @@ class EventController {
       response.status(500).send("could not get event");
     }
   }
+
+  static async getBookedSeatsCount(request, response) {
+    try {
+      const tenant = request.params.tenant;
+      const id = request.params.id;
+      const user = request.user;
+
+      if (
+        await PermissionService._allowReadAny(
+          user.id,
+          tenant,
+          RolePermission.MANAGE_BOOKABLES,
+        )
+      ) {
+        if (id) {
+          const count = await BookingService.getBookedSeatsCount(tenant, id);
+          response.status(200).send({ bookedSeats: count });
+        } else {
+          logger.warn(`Could not get booked seats count. Missing ID.`);
+          response.sendStatus(400);
+        }
+      } else {
+        logger.warn(
+          `User ${user?.id} not allowed to get booked seats count for event ${id}`,
+        );
+        response.sendStatus(403);
+      }
+    } catch (err) {
+      logger.warn(err);
+      response.status(500).send("could not get booked seats count");
+    }
+  }
+
 
   /**
    * @obsolute Use createEvent and updateEvent instead.


### PR DESCRIPTION
This pull request adds a new API endpoint to retrieve the number of booked seats for a specific event. The main changes include implementing the backend logic to count booked seats, exposing this functionality through the service and controller layers, and adding the corresponding route.

**New booked seats count feature:**

* Added a new static method `getBookedSeatsCount` in `BookingManager` to count non-rejected bookings for a given event and tenant using the `BookingModel` query.
* Exposed the `getBookedSeatsCount` functionality through the `BookingService` class for use by controllers.

**API and controller integration:**

* Implemented `getBookedSeatsCount` in `EventController` to handle permission checks and respond with the booked seats count for an event.
* Registered the new `/events/:id/count` route in the API router, protected by authentication and linked to the new controller method.
* Imported `BookingService` in `EventController` to support the new endpoint.