### PR TITLE
fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smart-city-booking-backend",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "smart-city-booking-backend",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "GPL-3.0",
       "dependencies": {
         "@azure/msal-node": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-city-booking-backend",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "An open-source backend system for booking and managing resources in smart cities and regions.",
   "main": "src/server.js",
   "scripts": {

--- a/src/platform/api/controllers/calendar-controller.js
+++ b/src/platform/api/controllers/calendar-controller.js
@@ -50,10 +50,18 @@ class CalendarController {
 
       const relatedIds = relatedBookables.map((rb) => rb.id);
 
-      let bookings = await BookingManager.getRelatedBookingsBatch(
-        tenant,
-        relatedIds,
-      );
+      relatedIds.push(bookable.id);
+
+      let bookings;
+
+      if (bookableIds && bookableIds.length > 0) {
+        bookings = await BookingManager.getRelatedBookingsBatch(
+          tenant,
+          relatedIds,
+        );
+      } else {
+        bookings = await BookingManager.getTenantBookings(tenant);
+      }
 
       const bookingMap = new Map();
       for (const booking of bookings) {


### PR DESCRIPTION
This pull request updates the logic for fetching bookings in the `CalendarController` to improve accuracy and flexibility based on the presence of specific `bookableIds`. The main change is the conditional selection between fetching related bookings or all tenant bookings.

Booking retrieval logic improvements:

* The code now checks if `bookableIds` is provided and non-empty; if so, it fetches only related bookings using `BookingManager.getRelatedBookingsBatch`, otherwise it fetches all tenant bookings using `BookingManager.getTenantBookings`.
* The current `bookable.id` is now included in the `relatedIds` array before fetching related bookings, ensuring the current bookable is considered in the results.