### PR TITLE
Fix/getOccupancy für isolierte Bookables im DLC-Kontext

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ The backend offers both public and protected API routes.
   - **id** (path): ID of the bookable resource
   - **timeBegin** (query, optional): Start time for the occupancy check (timestamp)
   - **timeEnd** (query, optional): End time for the occupancy check (timestamp)
-
+  - **ignoreRelatedEntities** (query, optional): If set to true, related entities are ignored in the occupancy calculation (default: false)
   _Response:_ JSON object containing:
   - **bookableId**: ID of the bookable resource
   - **title**: Title of the bookable resource

--- a/src/commons/services/bookable-service.js
+++ b/src/commons/services/bookable-service.js
@@ -124,7 +124,12 @@ class BookableService {
         remaining: lowestAvailability?.remaining ?? null,
       };
     } catch (error) {
-      return this._createUnavailableResponse();
+      const occupancyData = this._extractOccupancyFromFailedCheck(error);
+
+      return {
+        isAvailable: false,
+        ...occupancyData,
+      };
     }
   }
 

--- a/src/commons/services/bookable-service.js
+++ b/src/commons/services/bookable-service.js
@@ -24,6 +24,7 @@ class BookableService {
    * @param {Date} params.timeBegin - The start time of the occupancy check period.
    * @param {Date} params.timeEnd - The end time of the occupancy check period.
    * @param {string|null} [params.userId=null] - The identifier of the user requesting the occupancy, if applicable.
+   * @param {boolean} [ignoreRelatedEntities=false] - A flag indicating whether to only check the availability of the bookable item itself, ignoring related entities.
    * @return {Promise<Object>} A promise that resolves to an object containing occupancy details, including the bookable ID, title, and availability data. In case of an error, it returns an error response object.
    */
   static async getOccupancy({
@@ -32,6 +33,7 @@ class BookableService {
     timeBegin,
     timeEnd,
     userId = null,
+    ignoreRelatedEntities = false,
   }) {
     let checkoutService = null;
     try {
@@ -49,8 +51,10 @@ class BookableService {
 
       await checkoutService.init(bookable);
 
-      const occupancyData =
-        await this._performAvailabilityCheck(checkoutService);
+      const occupancyData = await this._performAvailabilityCheck(
+        checkoutService,
+        ignoreRelatedEntities,
+      );
 
       return {
         bookableId,
@@ -72,11 +76,23 @@ class BookableService {
    * Performs an availability check using the provided checkout service and processes the results.
    *
    * @param {Object} checkoutService - The service used to perform the availability check. Must include a `checkAll` method and optionally a `hasEvent` flag.
+   * @param {boolean} ignoreRelatedEntities - A flag indicating whether to only check the availability of the bookable item itself, ignoring related entities.
    * @return {Promise<Object>} A promise that resolves to an object indicating availability status. If available, includes capacity details; otherwise, includes occupancy data or an unavailable response.
    */
-  static async _performAvailabilityCheck(checkoutService) {
+  static async _performAvailabilityCheck(
+    checkoutService,
+    ignoreRelatedEntities = false,
+  ) {
     try {
-      const checkResults = await checkoutService.checkAll(false);
+      let checkResults = [];
+      if (ignoreRelatedEntities) {
+        // Only check the availability of the bookable itself.
+        checkResults = await Promise.allSettled([
+          await checkoutService.checkAvailability(),
+        ]);
+      } else {
+        checkResults = await checkoutService.checkAll(false);
+      }
       if (!checkResults || !Array.isArray(checkResults)) {
         return this._createUnavailableResponse();
       }
@@ -102,7 +118,7 @@ class BookableService {
       );
 
       return {
-        isAvailable: true,
+        isAvailable: lowestAvailability?.available ?? false,
         totalCapacity: lowestAvailability?.totalCapacity ?? null,
         booked: lowestAvailability?.booked ?? null,
         remaining: lowestAvailability?.remaining ?? null,

--- a/src/platform/api/controllers/bookable-controller.js
+++ b/src/platform/api/controllers/bookable-controller.js
@@ -479,6 +479,8 @@ class BookableController {
       const { tenant: tenantId, id: bookableId } = request.params;
       const { timeBegin, timeEnd } = request.query;
       const user = request.user;
+      const ignoreRelatedEntities =
+        request.query.ignoreRelatedEntities === "true";
 
       if (!bookableId) {
         logger.warn(
@@ -493,6 +495,7 @@ class BookableController {
         timeBegin,
         timeEnd,
         userId: user?.id,
+        ignoreRelatedEntities,
       });
 
       response.status(200).send(occupancy);


### PR DESCRIPTION
Hi @Marvin-Anders , danke dass du dich dem PR #113 gewidmet hattest. Ich kam leider erst jetzt dazu die Änderungen, die du in #142 vorgenommen hast zu reviewen.

Leider funtioniert der Endpunkt in unserer Umgebung nicht so wie wir ihn uns vorgestellt haben. Wir nutzen ihn im DLC,
- um Statistiken dazu zu erstellen, welche Termine wie häufig gebucht wurden
- vor einer Buchung DLC-Angebote zu filtern, die bereits ausgebucht oder noch buchbar sind
- Nutzerinnen anzuzeigen wie viele Tickets noch maximal buchbar sind, wenn diese für eine Gruppe buchen möchten, jedoch nicht genug Platz für alle ist.

Allerdings liefert uns der Endpunkt für manche Buchungen negative Werte für die Anzahl noch buchbarer Plätze, während available dennoch true ist. Ich versuche mal einen solchen Fall, wie er im DLC zu Stande kommt zu illustrieren:

Das Bookingtool nutzen wir so, dass ein DLC-Lernangebot im Bookingtool einem Event entspricht. Ein solches Event wird zum Beispiel an zwei verschiedenen Tagen angeboten. Für jeden dieser zwei Termine erstellen wir jeweils ein Bookable, das dann so als Termin auf dem DLC buchbar ist. Der erste Termin könnte für eine Gruppe von maximal 80 Personen ausgelegt sein, während der zweite Termin für 100 Teilnehmerinnen ausgelegt ist. Die Kapazität des Events spielt für uns hierbei keine Rolle, da Bookables eigene Kapazitäten haben können. Wir setzen daher die Kapzität des Events auf 0, um die Availability-Checks bei Buchungen gegen die Event-Kapazität zu umgehen, sodass allein die Bookable-Kapazität nicht überschritten werden darf.

Der erste Termin wurde nun von 78 Personen gebucht. Der zweiter Termin bisher von 51 Personen.
Wenn wir nun erfahren wollen, wie viele Plätze in einem einzelnen dieser Termine noch vorhanden sind, dann rufen wir den `bookable/:id/occupancy` Endpunkt mit der Bookable-Id auf, die mit dem entsprechenden Termin des DLC-Angebots verknüpft ist.

Wir erwarten folgendes Ergebnis:

```
{"available":true,"totalCapacity":100,"booked":51,"remaining":49}
```

Tatsächlich bekommen wir aktuell aber:

```
{"available":true,"totalCapacity":null,"booked":129,"remaining":-129}
```

Wobei 129 scheinbar der aggregierten Menge (78+51) der gebuchten Plätze von beiden Terminen entspricht, wo wir uns eigentlich nur für die 51 gebuchten Plätze des zweiten Termins interessiert hatten. In meinen Tests waren es vorallem die Checks `EVENT_SEATS` und `CHILD_BOOKINGS`, die unvorhergesehene Resultate verursacht hatten.

Die zusätzlichen Features des Endpunktes auch verwandte Entitäten und Zeitspannen zu berücksichtigen, benötigen wir für unsere Anwendungsszenarien nicht und führen, wie oben illustriert, zu Fehlern. Daher schlage ich folgende Lösung vor.

Ich habe einen zusätzlichen optionalen Query-Parameter hinzugefügt `ignoreRelatedEvents` der standardmäßig false ist, sodass die Methode im Normlafall weiter so funktioniert wie du in #143 umgesetzt hast. Wenn dieser Parameter auf true gesetzt wird, dann wird in der Methode `BookableService->_performAvailabilityCheck()` nun nicht mehr alle Checks des ItemCheckoutServices genutzt, sondern nur noch der Check `ItemCheckoutService->checkAvailability()`. Dessen Ergebnis entspricht immer genau den von uns erwarteten Werten und würde für unsere Zwecke vollkommen ausreichen.

Außerdem habe ich eine Fehler korrigiert, wobei `BookableService->_createUnavailableResponse()` null Werte geliefrt hat, wenn ein Termin ausgebucht ist. Weil hier der Check `ItemCheckoutService->checkAvailability()` in diesem Fall die Werte als Fehler wirft. Als Lösung habe ich im catch die Methode `BookableService->_extractOccupancyFromFailedCheck` eingesetzt, sodass in diesem Fall dennoch die totalCapcity, booked und remaining Werte ausgegeben werden können.

Würde mich freuen, wenn du dir das nochmal anschauen könntest. Vielleicht sagst du auch, dass wir das Booking-Tool so wie wir es nutzen, falsch einsetzen, was zu den Fehler führt und hast einen Gegenvorschlag wie das Problem anders angegangen werden kann.