### PR TITLE
Optimize booking list authorization by short-circuiting readAny permission check

### DIFF
--- a/src/platform/api/controllers/booking-controller.js
+++ b/src/platform/api/controllers/booking-controller.js
@@ -75,18 +75,30 @@ class BookingController {
           await BookingController._populate(bookings);
         }
 
-        const allowedBookings = [];
-        for (const booking of bookings) {
-          if (
-            user &&
-            (await PermissionsService._allowRead(
-              booking,
-              user.id,
-              tenant,
-              RolePermission.MANAGE_BOOKINGS,
-            ))
-          ) {
-            allowedBookings.push(booking);
+        // Check once whether the user has readAny permission; if so, avoid per-booking checks
+        const hasReadAny = await UserManager.hasPermission(
+          user.id,
+          tenant,
+          RolePermission.MANAGE_BOOKINGS,
+          "readAny",
+        );
+
+        let allowedBookings = [];
+        if (hasReadAny) {
+          allowedBookings = bookings;
+        } else {
+          for (const booking of bookings) {
+            if (
+              user &&
+              (await PermissionsService._allowRead(
+                booking,
+                user.id,
+                tenant,
+                RolePermission.MANAGE_BOOKINGS,
+              ))
+            ) {
+              allowedBookings.push(booking);
+            }
           }
         }
 


### PR DESCRIPTION
Background / why this change is needed
- Symptom: GET /bookings (e.g. ?public=false&populate=false) took ~90s for ~1,800 bookings.
- Root cause: Authorization logic performed a permission check for each booking; those repeated lookups/logic scaled linearly and dominated response time.

What changed
- Add a single global permission check using UserManager.hasPermission (Bookings -> ReadAny) at the start of the bookings listing flow.
- If the check passes, skip per-booking authorization and return the bookings directly.
- If the check fails, fall back to the existing per-booking authorization logic.
- No changes to authorization granularity for users who lack ReadAny — per-booking checks remain intact.

Files touched
- src/platform/api/controllers/booking-controller.js (authorization flow updated)

Performance impact
- Reported improvement: reduced request time from ~90s to <1s for ~1,800 bookings in the reported scenario.
- This removes redundant permission work for authorized users and scales much better.