### PR TITLE
Prüfen von ownership in Buchungen 

### DIFF
--- a/src/commons/services/permission-service.js
+++ b/src/commons/services/permission-service.js
@@ -45,7 +45,10 @@ class PermissionService {
    * @returns {boolean} - Returns true if the user is the owner of the object, otherwise false.
    */
   static _isOwner(object, userId, tenantId) {
-    return object.ownerUserId === userId && object.tenantId === tenantId;
+    return (
+      (object.ownerUserId === userId || object.assignedUserId === userId) &&
+      object.tenantId === tenantId
+    );
   }
 
   /**

--- a/src/platform/api/controllers/bookable-controller.js
+++ b/src/platform/api/controllers/bookable-controller.js
@@ -329,7 +329,7 @@ class BookableController {
 
       if (
         await PermissionService._allowUpdate(
-          bookable,
+          existingBookable,
           user.id,
           tenant,
           RolePermission.MANAGE_BOOKABLES,


### PR DESCRIPTION
Buchungen haben statt ownerUserId eine assignedUserId , die wurde zur Abfrage _isOwner in permission-service.js hinzufügt um eigene Buchungen zu löschen .

Außerdem wurde in updateBookable() im bookable-controller.js bei _allowUpdate bookable zu existingBookable geändert da bookable nicht die ownerUserId enthielt 