### PR TITLE
Fix/ allow update

### DIFF
--- a/src/platform/api/controllers/bookable-controller.js
+++ b/src/platform/api/controllers/bookable-controller.js
@@ -329,7 +329,7 @@ class BookableController {
 
       if (
         await PermissionService._allowUpdate(
-          existingBookable,
+          existingBookable || bookable,
           user.id,
           tenant,
           RolePermission.MANAGE_BOOKABLES,


### PR DESCRIPTION
In my fix/_isOwner PR I replaced bookable with existingBookable when calling _allowUpdate in updateBookable causing an error when trying to create a new bookable. Now bookable acts as an fallback when existingBookable is null . 