### PR TITLE
fixed number - string issue

### DIFF
--- a/src/commons/services/checkout/item-checkout-service.js
+++ b/src/commons/services/checkout/item-checkout-service.js
@@ -10,7 +10,6 @@ const { formatISO } = require("date-fns");
 const { BOOKABLE_TYPES } = require("../../entities/bookable/bookable");
 const CouponService = require("../coupon-service");
 
-
 const logger = bunyan.createLogger({
   name: "item-checkout-service.js",
   level: process.env.LOG_LEVEL,
@@ -702,8 +701,8 @@ class ItemCheckoutService {
       if (
         await OpeningHoursManager.hasOpeningHoursConflict(
           b,
-          this.timeBegin,
-          this.timeEnd,
+          Number(this.timeBegin),
+          Number(this.timeEnd),
         )
       ) {
         throw {

--- a/src/commons/utilities/opening-hours-manager.js
+++ b/src/commons/utilities/opening-hours-manager.js
@@ -14,8 +14,8 @@ class OpeningHoursManager {
    * Checks if there is a conflict between the booking time and the opening hours or special opening hours of the bookable object.
    *
    * @param {Object} bookable - The bookable object containing opening hours and special opening hours.
-   * @param {string} timeBegin - The start time of the booking in ISO format.
-   * @param {string} timeEnd - The end time of the booking in ISO format.
+   * @param {Number} timeBegin - The start time of the booking in ISO format.
+   * @param {Number} timeEnd - The end time of the booking in ISO format.
    * @returns {Promise<boolean>} - Returns a promise that resolves to true if there is a conflict, otherwise false.
    */
   static async hasOpeningHoursConflict(bookable, timeBegin, timeEnd) {


### PR DESCRIPTION
This pull request updates the way booking times are handled when checking for opening hours conflicts by ensuring that the times are consistently treated as numbers instead of strings. This change helps prevent type-related bugs and clarifies the expected data format.

**Refactoring for type consistency:**

* Updated the `hasOpeningHoursConflict` method in `OpeningHoursManager` to expect `timeBegin` and `timeEnd` as numbers rather than strings, and adjusted the JSDoc accordingly.
* Modified the call to `hasOpeningHoursConflict` in `ItemCheckoutService` to explicitly cast `this.timeBegin` and `this.timeEnd` to numbers before passing them as arguments.