### PR TITLE
Feat/improved user management

### DIFF
--- a/src/commons/data-managers/membership-manager.js
+++ b/src/commons/data-managers/membership-manager.js
@@ -2,6 +2,11 @@ const MembershipModel = require("./models/membershipModel");
 const Membership = require("../entities/tenant/membership");
 
 class MembershipManager {
+  static async getMemberships() {
+    const rawMemberships = await MembershipModel.find({});
+    return rawMemberships.map((raw) => raw.toEntity());
+  }
+
   static async getMembershipsByTenantID(tenantID) {
     const rawMemberships = await MembershipModel.find({ tenantId: tenantID });
     return rawMemberships.map((raw) => raw.toEntity());

--- a/src/platform/api/api-router.js
+++ b/src/platform/api/api-router.js
@@ -169,6 +169,12 @@ router.get(
 // MEMBERSHIPS
 // ===========
 router.get(
+  "/memberships",
+  AuthenticationController.isSignedIn,
+  MembershipController.getMemberships,
+);
+
+router.get(
   "/memberships/my/pending",
   AuthenticationController.isSignedIn,
   MembershipController.getMyPendingMemberships,

--- a/src/platform/api/controllers/membership-controller.js
+++ b/src/platform/api/controllers/membership-controller.js
@@ -1,6 +1,8 @@
 const MembershipService = require("../../../commons/services/membership/membership-service");
+const MembershipManager = require("../../../commons/data-managers/membership-manager");
 
 const bunyan = require("bunyan");
+const PermissionService = require("../../../commons/services/permission-service");
 
 const logger = bunyan.createLogger({
   name: "membership-controller.js",
@@ -8,6 +10,30 @@ const logger = bunyan.createLogger({
 });
 
 class MembershipController {
+  static async getMemberships(request, response) {
+    try {
+      const user = request.user;
+
+
+      const hasPermission = await PermissionService._isInstanceOwner(user);
+
+      if (!hasPermission) {
+        return response.sendStatus(403);
+      }
+
+
+      const memberships = await MembershipManager.getMemberships();
+
+
+      response.status(200).send(memberships);
+    } catch (error) {
+      logger.error(error);
+      return response
+        .status(error.code || 500)
+        .send(error.message || "Could not retrieve memberships");
+    }
+  }
+
   static async getMyPendingMemberships(request, response) {
     try {
       const user = request.user;

--- a/src/platform/api/controllers/membership-controller.js
+++ b/src/platform/api/controllers/membership-controller.js
@@ -14,8 +14,7 @@ class MembershipController {
     try {
       const user = request.user;
 
-
-      const hasPermission = await PermissionService._isInstanceOwner(user);
+      const hasPermission = await PermissionService._isInstanceOwner(user.id);
 
       if (!hasPermission) {
         return response.sendStatus(403);


### PR DESCRIPTION
This pull request adds a new API endpoint to retrieve all memberships, restricted to users with instance owner permissions. It introduces a new method in the membership manager to fetch all memberships and updates the controller and router accordingly.

**New API Endpoint for Memberships:**

* Added a `GET /memberships` endpoint in `api-router.js`, protected by authentication and available only to instance owners.
* Implemented the `getMemberships` controller method in `membership-controller.js`, which checks for instance owner permissions before retrieving all memberships and returning them in the response.

**Data Manager Enhancements:**

* Added a new static method `getMemberships` to `membership-manager.js` to fetch and map all membership records from the database.