### PR TITLE
Fix: 403 bei `GET /api/:tenant/bookables/:id/bookings` trotz gueltigem JWT

### DIFF
--- a/src/commons/utilities/auth-utils.js
+++ b/src/commons/utilities/auth-utils.js
@@ -16,7 +16,13 @@ const authenticateIfNeeded = async (req, condition) => {
   }
 
   const token = authHeader.substring(7);
-  return await JwtHelper.verifyToken(token);
+  const decoded = await JwtHelper.verifyToken(token);
+
+  // Normalize payload shape for controller code expecting user.id.
+  return {
+    ...decoded,
+    id: decoded.sub,
+  };
 };
 
 module.exports = { authenticateIfNeeded };


### PR DESCRIPTION
# Fix: 403 bei `GET /api/:tenant/bookables/:id/bookings` trotz gueltigem JWT

## Problem
Nach der JWT-Umstellung liefert der Endpoint
`GET /api/default/bookables/:id/bookings?related=true&parent=true`
`403 Forbidden`, obwohl der Benutzer `super-admin` ist und `manageBookings.readAny` besitzt.

## Beobachtung
Authorization-Header ist vorhanden, Token ist gueltig, aber im API-Log erscheint:
- `user undefined`
- `hasPermission: false`
- `tenantPermissions: null`

## Ursache
`authenticateIfNeeded(...)` liefert das rohe JWT-Payload (mit `sub`),
Controller erwarten aber `user.id`.
Dadurch laeuft die Permission-Pruefung mit `undefined` als User-ID.

## Fix
Rueckgabe in `authenticateIfNeeded(...)` normalisiert:

```js
const decoded = await JwtHelper.verifyToken(token);
return {
  ...decoded,
  id: decoded.sub,
};
```

## Ergebnis
Permission-Pruefung erhaelt wieder eine gueltige User-ID.
Endpoints mit `manageBookings.readAny` entscheiden korrekt und geben nicht mehr faelschlich `403` zurueck.

## Verifikation
1. Vorher: gleicher Request -> `403`, Log mit `user undefined`.
2. Nachher: gleicher Request -> User-ID gesetzt, Permission-Check korrekt, bei ausreichenden Rechten `200`.
