### PR TITLE
Fix: SSO role mapping fails

### DIFF
--- a/src/commons/services/sso/sso-service.js
+++ b/src/commons/services/sso/sso-service.js
@@ -136,7 +136,10 @@ class SsoService {
       const newRole = await processRole(role);
       if (newRole) {
         newRoles.push({
+          tenantId: newRole.tenantId,
           role: newRole.role,
+          action: newRole.action,
+          needsInvite: newRole.needsInvite,
           status: "active",
           source: "keycloak",
         });
@@ -158,19 +161,45 @@ function extractRoles(obj) {
 }
 
 async function updateTenantRoles(roles, userId) {
-  for (const { tenantId, role, action, needsInvite } of roles) {
-    if (action === "add") {
-      if (needsInvite) {
-        await MembershipManager.addMembership(tenantId, { userId });
-      }
-      const newRole = {
-        role: role,
+  // Group roles by tenantId to handle multiple roles for the same tenant
+  const rolesByTenant = {};
+  for (const roleObj of roles) {
+    if (!rolesByTenant[roleObj.tenantId]) {
+      rolesByTenant[roleObj.tenantId] = [];
+    }
+    rolesByTenant[roleObj.tenantId].push(roleObj);
+  }
+
+  // Process each tenant's roles
+  for (const tenantId in rolesByTenant) {
+    const tenantRoles = rolesByTenant[tenantId];
+
+    // Check if membership exists
+    const membership = await MembershipManager.getMembershipByTenantAndUserID(
+      tenantId,
+      userId,
+    );
+
+    // If any role needs to create membership and it doesn't exist, create it once
+    if (!membership && tenantRoles.some((r) => r.needsInvite)) {
+      await MembershipManager.addMembership(tenantId, {
+        userId,
+        source: "manually",
         status: "active",
-        source: "keycloak",
-      };
-      await MembershipManager.addRoleToMembership(tenantId, userId, newRole);
-    } else if (action === "remove") {
-      await MembershipManager.removeRoleFromMembership(tenantId, userId, role);
+      });
+    }
+
+    // Now add all roles for this tenant
+    for (const { role, action } of tenantRoles) {
+      if (action === "add") {
+        await MembershipManager.addRoleToMembership(tenantId, userId, role);
+      } else if (action === "remove") {
+        await MembershipManager.removeRoleFromMembership(
+          tenantId,
+          userId,
+          role,
+        );
+      }
     }
   }
 }

--- a/src/commons/services/sso/sso-service.js
+++ b/src/commons/services/sso/sso-service.js
@@ -108,7 +108,7 @@ class SsoService {
 
       if (
         keycloakRoles.includes(role.keycloakRole) &&
-        !userRoles.some((r) => r.role === role.tenantRoleId)
+        !userRoles.some((r) => r === role.tenantRoleId)
       ) {
         if (!roles.find((tRole) => tRole.id === role.tenantRoleId)) {
           return;
@@ -120,7 +120,7 @@ class SsoService {
         };
       } else if (
         !keycloakRoles.includes(role.keycloakRole) &&
-        userRoles.some((r) => r.role === role.tenantRoleId)
+        userRoles.some((r) => r === role.tenantRoleId)
       ) {
         return {
           tenantId: role.tenantId,


### PR DESCRIPTION
## Problem
Nach der Migration zu Membership-basierten Rollen funktioniert das Rolle-Mapping bei SSO-Logins nicht korrekt:
1. Neue Benutzer, die sich über Keycloak anmelden, erhalten keine Memberships mit Rollen
2. Existing Benutzer, deren Keycloak-Rollen sich ändern, haben keine Rollenaktualisierung

## Beobachtung
- Memberships werden nicht erstellt/aktualisiert während des SSO-Login/Signup
- Bei mehreren Rollen pro Tenant: `E11000 duplicate key error` beim Erstellen der Membership
- Rollen-Entfernung funktioniert nicht, wenn Keycloak-Rollen entzogen werden

## Ursache
Mehrere Fehler in der SSO-Service-Logik:

1. **Verlust von Rolle-Metadaten**: Bei der Konstruktion von `newRoles` wurden nur `role`, `status` und `source` gespeichert. `tenantId` und `action` waren `undefined`. Dies führte dazu, dass `updateTenantRoles()` nicht wusste, welche Tenant betroffen ist oder ob es um Add/Remove geht.

2. **Mehrfaches Membership-Erstellen**: Wenn ein Benutzer mehrere Rollen pro Tenant zugewiesen bekam, wurde für jede Rolle versucht, die Membership zu erstellen → E11000 duplicate key error.

3. **Falscher Rollen-Vergleich**: Array `membership.roles` enthält Strings (Rollen-IDs), aber der Code verglich `r.role === role.tenantRoleId` statt `r === role.tenantRoleId`. Dadurch wurde die Bedingung zum Entfernen von Rollen niemals erfüllt.

## Fix

### 1. Vollständige Rolle-Metadaten bewahren
```js
newRoles.push({
  tenantId: newRole.tenantId,      // ← hinzugefügt
  role: newRole.role,
  action: newRole.action,          // ← hinzugefügt
  needsInvite: newRole.needsInvite, // ← hinzugefügt
  status: "active",
  source: "keycloak",
});
```

### 2. Rollen nach Tenant gruppieren und Membership einmalig erstellen
```js
async function updateTenantRoles(roles, userId) {
  // Gruppiere Rollen pro Tenant
  const rolesByTenant = {};
  for (const roleObj of roles) {
    if (!rolesByTenant[roleObj.tenantId]) {
      rolesByTenant[roleObj.tenantId] = [];
    }
    rolesByTenant[roleObj.tenantId].push(roleObj);
  }

  // Pro Tenant: Membership einmalig erstellen, dann alle Rollen hinzufügen/entfernen
  for (const tenantId in rolesByTenant) {
    const tenantRoles = rolesByTenant[tenantId];
    const membership = await MembershipManager.getMembershipByTenantAndUserID(tenantId, userId);
    
    if (!membership && tenantRoles.some((r) => r.needsInvite)) {
      await MembershipManager.addMembership(tenantId, {
        userId,
        source: "manually",
        status: "active",
      });
    }

    for (const { role, action } of tenantRoles) {
      if (action === "add") {
        await MembershipManager.addRoleToMembership(tenantId, userId, role);
      } else if (action === "remove") {
        await MembershipManager.removeRoleFromMembership(tenantId, userId, role);
      }
    }
  }
}
```

### 3. Korrekter Rollen-Vergleich
```js
// Vorher: userRoles.some((r) => r.role === role.tenantRoleId)
// Nachher:
userRoles.some((r) => r === role.tenantRoleId)

// und entsprechend bei Remove:
!keycloakRoles.includes(role.keycloakRole) &&
userRoles.some((r) => r === role.tenantRoleId)
```

## Ergebnis
- Neue Benutzer erhalten sofort Memberships mit allen konfigurierten Rollen
- Mehrere Rollen pro Tenant werden ohne Fehler erstellt
- Rollenaktualisierungen beim Login funktionieren (Add und Remove)
- Keycloak-Rollen-Änderungen werden korrekt synchronisiert

## Verifikation

### Test 1: Neue User mit mehreren Rollen
1. Neuer Benutzer mit 3 Keycloak-Rollen (davon 2 gemappt) meldet sich an
2. In MongoDB: 1 active Membership mit 2 Rollen in der `roles`-Array
3. User hat Zugriff auf alle Funktionen gemäß den Rollen

### Test 2: Rollenentfernung
1. Existing User mit Trainer-Rolle meldet sich an → hat Trainer-Rolle
2. Trainer-Rolle in Keycloak entfernt
3. User meldet sich erneut an
4. In MongoDB: Trainer-Rolle ist aus der `roles`-Array entfernt, User behält nur defaultUserRole
5. User hat keinen Zugriff auf Trainer-Funktionen mehr

### Test 3: Rollenhinzufügen
1. Existing User ohne bestimmte Rolle meldet sich an
2. Neue Rolle in Keycloak hinzugefügt
3. User meldet sich erneut an
4. In MongoDB: Neue Rolle ist in der `roles`-Array hinzugefügt
5. User hat Zugriff auf die neuen Funktionen