### PR TITLE
feat(DEV-630): Vorlaufzeit für Buchungen – Phase 1 Backend

### DIFF
--- a/.cursor/settings.json
+++ b/.cursor/settings.json
@@ -1,0 +1,7 @@
+{
+  "plugins": {
+    "notion-workspace": {
+      "enabled": true
+    }
+  }
+}

--- a/.cursor/settings.json
+++ b/.cursor/settings.json
@@ -1,7 +1,0 @@
-{
-  "plugins": {
-    "notion-workspace": {
-      "enabled": true
-    }
-  }
-}

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -219,6 +219,14 @@ Example:
       "endTime": "18:00"
     }
   ],
+  "preparationLeadTimeMinutes": 120,
+  "serviceHours": [
+    {
+      "weekdays": [1, 2, 3, 4, 5],
+      "startTime": "08:00",
+      "endTime": "18:00"
+    }
+  ],
   "isSpecialOpeningHoursRelated": false,
   "specialOpeningHours": [
     {
@@ -306,6 +314,8 @@ Key fields of a bookable:
 | timePeriods           | Weekly repeating time windows when the bookable can be used.                                                                                               |
 | isOpeningHoursRelated | If `true`, availability is derived from `openingHours`.                                                                                                     |
 | openingHours          | Regular opening hours per weekday.                                                                                                                          |
+| preparationLeadTimeMinutes | Minimum preparation time in minutes before booking start (schedule-related only). Requires `serviceHours`.                                            |
+| serviceHours          | Service windows when preparation can take place (same structure as `openingHours`, independent of opening hours).                                          |
 | isSpecialOpeningHoursRelated | If `true`, `specialOpeningHours` override the regular opening hours for specific dates.                                                              |
 | specialOpeningHours   | Special opening hours for specific dates.                                                                                                                   |
 | isLongRange           | If `true`, long-range bookings (e.g. weeks/months) are enabled.                                                                                            |

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -314,8 +314,8 @@ Key fields of a bookable:
 | timePeriods           | Weekly repeating time windows when the bookable can be used.                                                                                               |
 | isOpeningHoursRelated | If `true`, availability is derived from `openingHours`.                                                                                                     |
 | openingHours          | Regular opening hours per weekday.                                                                                                                          |
-| preparationLeadTimeMinutes | Minimum preparation time in minutes before booking start (schedule-related only). Requires `serviceHours`.                                            |
-| serviceHours          | Service windows when preparation can take place (same structure as `openingHours`, independent of opening hours).                                          |
+| preparationLeadTimeMinutes | Minimum preparation time in minutes before booking start. Lead-time enforcement is active only when `isScheduleRelated` is `true`, `preparationLeadTimeMinutes` is greater than `0`, and `serviceHours` is non-empty. |
+| serviceHours          | Service windows when preparation can take place (same structure as `openingHours`, independent of opening hours). Only evaluated together with `preparationLeadTimeMinutes` on schedule-related bookables. |
 | isSpecialOpeningHoursRelated | If `true`, `specialOpeningHours` override the regular opening hours for specific dates.                                                              |
 | specialOpeningHours   | Special opening hours for specific dates.                                                                                                                   |
 | isLongRange           | If `true`, long-range bookings (e.g. weeks/months) are enabled.                                                                                            |

--- a/src/commons/availability/availability-rules/index.js
+++ b/src/commons/availability/availability-rules/index.js
@@ -7,6 +7,7 @@ const blockPeriodRules = require("./block-period-rules");
 const timePeriodRules = require("./time-period-rules");
 const permissionRules = require("./permission-rules");
 const maxBookingDateRules = require("./max-booking-date-rules");
+const minBookingLeadTimeRules = require("./min-booking-lead-time-rules");
 const { CAPACITY_MODES } = require("./types");
 
 module.exports = {
@@ -19,5 +20,6 @@ module.exports = {
   ...timePeriodRules,
   ...permissionRules,
   ...maxBookingDateRules,
+  ...minBookingLeadTimeRules,
   CAPACITY_MODES,
 };

--- a/src/commons/availability/availability-rules/min-booking-lead-time-rules.js
+++ b/src/commons/availability/availability-rules/min-booking-lead-time-rules.js
@@ -1,0 +1,23 @@
+const {
+  isLeadTimeConfigured,
+  hasSufficientPreparationLeadTime,
+} = require("../lead-time-calculator");
+
+/**
+ * @param {number} timeBegin
+ * @param {import("../../entities/bookable/bookable").Bookable|null|undefined} bookable
+ * @param {Date} [now]
+ * @returns {boolean}
+ */
+function isWithinMinBookingLeadTime(timeBegin, bookable, now = new Date()) {
+  if (!isLeadTimeConfigured(bookable)) {
+    return true;
+  }
+
+  return hasSufficientPreparationLeadTime(bookable, timeBegin, now);
+}
+
+module.exports = {
+  isLeadTimeConfigured,
+  isWithinMinBookingLeadTime,
+};

--- a/src/commons/availability/check-window-availability.js
+++ b/src/commons/availability/check-window-availability.js
@@ -10,6 +10,7 @@ const {
   isDurationAllowed,
   hasBookingPermission,
   isWithinMaxBookingAdvance,
+  isWithinMinBookingLeadTime,
   CAPACITY_MODES,
   isBlockPeriodBookingValid,
   isTimePeriodBookingValid,
@@ -252,6 +253,10 @@ async function checkWindowAvailability(
 
   if (!isWithinMaxBookingAdvance(timeBegin, tenant)) {
     return { available: false, reason: "max-booking-date" };
+  }
+
+  if (!isWithinMinBookingLeadTime(timeBegin, bookable)) {
+    return { available: false, reason: "insufficient-lead-time" };
   }
 
   return { available: true };

--- a/src/commons/availability/checkout-availability-checks.js
+++ b/src/commons/availability/checkout-availability-checks.js
@@ -13,6 +13,7 @@ const {
   getBookingDurationHours,
   hasBookingPermission,
   isWithinMaxBookingAdvance,
+  isWithinMinBookingLeadTime,
   CAPACITY_MODES,
   isBlockPeriodBookingValid,
   isTimePeriodBookingValid,
@@ -500,6 +501,26 @@ async function runMaxBookingDateCheck({ provider, originBookable, timeBegin }) {
   };
 }
 
+/**
+ * @param {Object} params
+ * @returns {Promise<Object>}
+ */
+async function runMinBookingLeadTimeCheck({ originBookable, timeBegin }) {
+  if (isWithinMinBookingLeadTime(timeBegin, originBookable)) {
+    return { checkType: CHECK_TYPES.INSUFFICIENT_LEAD_TIME, available: true };
+  }
+
+  const preparationLeadTimeMinutes = Number(
+    originBookable.preparationLeadTimeMinutes,
+  );
+
+  throw {
+    checkType: CHECK_TYPES.INSUFFICIENT_LEAD_TIME,
+    available: false,
+    message: `Die Buchung für das Objekt ${originBookable.title} erfordert eine Vorbereitungszeit von ${preparationLeadTimeMinutes} Minuten innerhalb der Servicezeiten.`,
+  };
+}
+
 module.exports = {
   getBookedAmountForBookableWindow,
   runPermissionCheck,
@@ -512,4 +533,5 @@ module.exports = {
   runTimePeriodCheck,
   runEventDateCheck,
   runMaxBookingDateCheck,
+  runMinBookingLeadTimeCheck,
 };

--- a/src/commons/availability/checkout-check-types.js
+++ b/src/commons/availability/checkout-check-types.js
@@ -8,6 +8,7 @@ const CHECK_TYPES = Object.freeze({
   EVENT_SEATS: "event-seats",
   CHILD_BOOKINGS: "child-bookings",
   MAX_BOOKING_DATE: "max-booking-date",
+  INSUFFICIENT_LEAD_TIME: "insufficient-lead-time",
   TIME_RELATION: "time-relation",
   PRICE_CATEGORY: "price-category",
   MAX_AMOUNT: "max-amount",

--- a/src/commons/availability/lead-time-calculator.js
+++ b/src/commons/availability/lead-time-calculator.js
@@ -1,0 +1,221 @@
+/**
+ * Preparation lead-time calculation for schedule-related bookables.
+ *
+ * A booking is allowed when, between now and timeBegin, at least one service
+ * window contains a contiguous preparation block of preparationLeadTimeMinutes
+ * that lies fully within that day's service hours and ends at or before
+ * timeBegin.
+ */
+
+/**
+ * @param {import("../entities/bookable/bookable").Bookable|Object|null|undefined} bookable
+ * @returns {boolean}
+ */
+function isLeadTimeConfigured(bookable) {
+  return (
+    bookable?.isScheduleRelated === true &&
+    Number(bookable.preparationLeadTimeMinutes) > 0 &&
+    Array.isArray(bookable.serviceHours) &&
+    bookable.serviceHours.length > 0
+  );
+}
+
+/**
+ * @param {string} timeStr
+ * @returns {number}
+ */
+function parseTimeToMinutes(timeStr) {
+  const [hours, minutes] = timeStr.split(":").map(Number);
+  return hours * 60 + minutes;
+}
+
+/**
+ * @param {Array<{ weekdays: number[], startTime: string, endTime: string }>} serviceHours
+ * @param {number} weekday
+ * @returns {Array<{ startMinutes: number, endMinutes: number }>}
+ */
+function getServiceWindowsForWeekday(serviceHours, weekday) {
+  const windows = [];
+
+  for (const entry of serviceHours) {
+    const weekdays = Array.isArray(entry.weekdays)
+      ? entry.weekdays
+      : [entry.weekdays];
+
+    if (!weekdays.includes(weekday)) {
+      continue;
+    }
+
+    windows.push({
+      startMinutes: parseTimeToMinutes(entry.startTime),
+      endMinutes: parseTimeToMinutes(entry.endTime),
+    });
+  }
+
+  return windows;
+}
+
+/**
+ * @param {import("../entities/bookable/bookable").Bookable|Object} bookable
+ * @param {number} timeBegin
+ * @param {Date} [now]
+ * @returns {boolean}
+ */
+function hasSufficientPreparationLeadTime(bookable, timeBegin, now = new Date()) {
+  if (!isLeadTimeConfigured(bookable)) {
+    return true;
+  }
+
+  const preparationMs =
+    Number(bookable.preparationLeadTimeMinutes) * 60 * 1000;
+  const nowMs = now.getTime();
+  const timeBeginMs = Number(timeBegin);
+
+  if (timeBeginMs <= nowMs) {
+    return false;
+  }
+
+  const cursor = new Date(now);
+  cursor.setHours(0, 0, 0, 0);
+
+  const bookingDay = new Date(timeBeginMs);
+  bookingDay.setHours(0, 0, 0, 0);
+
+  while (cursor.getTime() <= bookingDay.getTime()) {
+    const weekday = cursor.getDay();
+    const dayStartMs = cursor.getTime();
+    const windows = getServiceWindowsForWeekday(bookable.serviceHours, weekday);
+
+    for (const window of windows) {
+      const serviceStartMs = dayStartMs + window.startMinutes * 60 * 1000;
+      const serviceEndMs = dayStartMs + window.endMinutes * 60 * 1000;
+      const minBlockStart = Math.max(nowMs, serviceStartMs);
+
+      const latestBlockEnd = Math.min(timeBeginMs, serviceEndMs);
+      const blockStart = latestBlockEnd - preparationMs;
+
+      if (
+        blockStart >= minBlockStart &&
+        blockStart >= serviceStartMs &&
+        latestBlockEnd <= serviceEndMs &&
+        latestBlockEnd <= timeBeginMs
+      ) {
+        return true;
+      }
+
+      if (timeBeginMs >= serviceStartMs && timeBeginMs <= serviceEndMs) {
+        const blockEndAtBooking = timeBeginMs;
+        const blockStartAtBooking = blockEndAtBooking - preparationMs;
+
+        if (
+          blockStartAtBooking >= minBlockStart &&
+          blockStartAtBooking >= serviceStartMs &&
+          blockEndAtBooking <= serviceEndMs
+        ) {
+          return true;
+        }
+      }
+    }
+
+    cursor.setDate(cursor.getDate() + 1);
+  }
+
+  return false;
+}
+
+/**
+ * @param {import("../entities/bookable/bookable").Bookable|Object} bookable
+ * @param {Date} [now]
+ * @returns {number}
+ */
+function getEarliestBookableStart(bookable, now = new Date()) {
+  if (!isLeadTimeConfigured(bookable)) {
+    return now.getTime();
+  }
+
+  const preparationMs =
+    Number(bookable.preparationLeadTimeMinutes) * 60 * 1000;
+  const nowMs = now.getTime();
+  const candidates = new Set();
+
+  const cursor = new Date(now);
+  cursor.setHours(0, 0, 0, 0);
+
+  const searchEnd = new Date(now);
+  searchEnd.setDate(searchEnd.getDate() + 366);
+
+  while (cursor <= searchEnd) {
+    const weekday = cursor.getDay();
+    const dayStartMs = cursor.getTime();
+    const windows = getServiceWindowsForWeekday(bookable.serviceHours, weekday);
+
+    for (const window of windows) {
+      const serviceStartMs = dayStartMs + window.startMinutes * 60 * 1000;
+      const serviceEndMs = dayStartMs + window.endMinutes * 60 * 1000;
+
+      candidates.add(serviceStartMs + preparationMs);
+      candidates.add(serviceEndMs);
+    }
+
+    cursor.setDate(cursor.getDate() + 1);
+  }
+
+  const sortedCandidates = [...candidates]
+    .filter((candidate) => candidate >= nowMs)
+    .sort((a, b) => a - b);
+
+  for (const candidate of sortedCandidates) {
+    if (hasSufficientPreparationLeadTime(bookable, candidate, now)) {
+      return candidate;
+    }
+  }
+
+  return searchEnd.getTime();
+}
+
+/**
+ * Generates calendar periods marking slots before the earliest bookable start
+ * as unavailable. Returns an empty array when lead time is not configured.
+ *
+ * @param {Date} startDate
+ * @param {Date} endDate
+ * @param {import("../entities/bookable/bookable").Bookable|Object} bookable
+ * @param {Date} [now]
+ * @returns {Array<{ start: number, end: number, available: boolean }>}
+ */
+function generateTimePeriodsFromLeadTime(
+  startDate,
+  endDate,
+  bookable,
+  now = new Date(),
+) {
+  if (!isLeadTimeConfigured(bookable)) {
+    return [];
+  }
+
+  const earliestStart = getEarliestBookableStart(bookable, now);
+  const rangeStart = startDate.getTime();
+  const rangeEnd = endDate.getTime();
+
+  if (rangeEnd <= earliestStart) {
+    return [{ start: rangeStart, end: rangeEnd, available: false }];
+  }
+
+  if (rangeStart >= earliestStart) {
+    return [{ start: rangeStart, end: rangeEnd, available: true }];
+  }
+
+  return [
+    { start: rangeStart, end: earliestStart, available: false },
+    { start: earliestStart, end: rangeEnd, available: true },
+  ];
+}
+
+module.exports = {
+  isLeadTimeConfigured,
+  hasSufficientPreparationLeadTime,
+  getEarliestBookableStart,
+  generateTimePeriodsFromLeadTime,
+  getServiceWindowsForWeekday,
+  parseTimeToMinutes,
+};

--- a/src/commons/availability/lead-time-calculator.js
+++ b/src/commons/availability/lead-time-calculator.js
@@ -61,13 +61,16 @@ function getServiceWindowsForWeekday(serviceHours, weekday) {
  * @param {Date} [now]
  * @returns {boolean}
  */
-function hasSufficientPreparationLeadTime(bookable, timeBegin, now = new Date()) {
+function hasSufficientPreparationLeadTime(
+  bookable,
+  timeBegin,
+  now = new Date(),
+) {
   if (!isLeadTimeConfigured(bookable)) {
     return true;
   }
 
-  const preparationMs =
-    Number(bookable.preparationLeadTimeMinutes) * 60 * 1000;
+  const preparationMs = Number(bookable.preparationLeadTimeMinutes) * 60 * 1000;
   const nowMs = now.getTime();
   const timeBeginMs = Number(timeBegin);
 
@@ -126,15 +129,14 @@ function hasSufficientPreparationLeadTime(bookable, timeBegin, now = new Date())
 /**
  * @param {import("../entities/bookable/bookable").Bookable|Object} bookable
  * @param {Date} [now]
- * @returns {number}
+ * @returns {number|null}
  */
 function getEarliestBookableStart(bookable, now = new Date()) {
   if (!isLeadTimeConfigured(bookable)) {
     return now.getTime();
   }
 
-  const preparationMs =
-    Number(bookable.preparationLeadTimeMinutes) * 60 * 1000;
+  const preparationMs = Number(bookable.preparationLeadTimeMinutes) * 60 * 1000;
   const nowMs = now.getTime();
   const candidates = new Set();
 
@@ -154,6 +156,7 @@ function getEarliestBookableStart(bookable, now = new Date()) {
       const serviceEndMs = dayStartMs + window.endMinutes * 60 * 1000;
 
       candidates.add(serviceStartMs + preparationMs);
+      candidates.add(Math.max(nowMs, serviceStartMs) + preparationMs);
       candidates.add(serviceEndMs);
     }
 
@@ -170,20 +173,21 @@ function getEarliestBookableStart(bookable, now = new Date()) {
     }
   }
 
-  return searchEnd.getTime();
+  return null;
 }
 
 /**
- * Generates calendar periods marking slots before the earliest bookable start
- * as unavailable. Returns an empty array when lead time is not configured.
+ * Returns only the blocked periods before the earliest bookable start.
+ * When no valid service window exists within the search horizon, the full
+ * queried range is marked unavailable.
  *
  * @param {Date} startDate
  * @param {Date} endDate
  * @param {import("../entities/bookable/bookable").Bookable|Object} bookable
  * @param {Date} [now]
- * @returns {Array<{ start: number, end: number, available: boolean }>}
+ * @returns {Array<{ start: number, end: number }>}
  */
-function generateTimePeriodsFromLeadTime(
+function generateLeadTimeBlockedPeriods(
   startDate,
   endDate,
   bookable,
@@ -197,25 +201,22 @@ function generateTimePeriodsFromLeadTime(
   const rangeStart = startDate.getTime();
   const rangeEnd = endDate.getTime();
 
-  if (rangeEnd <= earliestStart) {
-    return [{ start: rangeStart, end: rangeEnd, available: false }];
+  if (earliestStart === null) {
+    return [{ start: rangeStart, end: rangeEnd }];
   }
 
   if (rangeStart >= earliestStart) {
-    return [{ start: rangeStart, end: rangeEnd, available: true }];
+    return [];
   }
 
-  return [
-    { start: rangeStart, end: earliestStart, available: false },
-    { start: earliestStart, end: rangeEnd, available: true },
-  ];
+  return [{ start: rangeStart, end: Math.min(earliestStart, rangeEnd) }];
 }
 
 module.exports = {
   isLeadTimeConfigured,
   hasSufficientPreparationLeadTime,
   getEarliestBookableStart,
-  generateTimePeriodsFromLeadTime,
+  generateLeadTimeBlockedPeriods,
   getServiceWindowsForWeekday,
   parseTimeToMinutes,
 };

--- a/src/commons/entities/bookable/bookable.js
+++ b/src/commons/entities/bookable/bookable.js
@@ -355,6 +355,8 @@ class Bookable {
       timePeriods: this.timePeriods,
       isOpeningHoursRelated: this.isOpeningHoursRelated,
       openingHours: this.openingHours,
+      preparationLeadTimeMinutes: this.preparationLeadTimeMinutes,
+      serviceHours: this.serviceHours,
       isSpecialOpeningHoursRelated: this.isSpecialOpeningHoursRelated,
       specialOpeningHours: this.specialOpeningHours,
       isLongRange: this.isLongRange,

--- a/src/commons/schemas/bookableSchema.js
+++ b/src/commons/schemas/bookableSchema.js
@@ -67,6 +67,33 @@ const blockPeriodSchemaDefinition = {
   },
 };
 
+const serviceHoursSchemaDefinition = {
+  weekdays: {
+    type: [Number],
+    required: true,
+    validate: {
+      validator: (value) =>
+        Array.isArray(value) &&
+        value.length > 0 &&
+        value.every(
+          (weekday) =>
+            Number.isInteger(weekday) && weekday >= 0 && weekday <= 6,
+        ),
+      message: "weekdays must contain integers between 0 and 6",
+    },
+  },
+  startTime: {
+    type: String,
+    required: true,
+    match: /^([01]\d|2[0-3]):[0-5]\d$/,
+  },
+  endTime: {
+    type: String,
+    required: true,
+    match: /^([01]\d|2[0-3]):[0-5]\d$/,
+  },
+};
+
 const bookableSchemaDefinition = {
   id: { type: String, required: true, unique: true },
   tenantId: { type: String, required: true, ref: "Tenant" },
@@ -120,7 +147,10 @@ const bookableSchemaDefinition = {
   isOpeningHoursRelated: { type: Boolean, default: false },
   openingHours: { type: [Object], default: [] },
   preparationLeadTimeMinutes: { type: Number, default: null, min: 0 },
-  serviceHours: { type: [Object], default: [] },
+  serviceHours: {
+    type: [new Schema(serviceHoursSchemaDefinition, { _id: false })],
+    default: [],
+  },
   isSpecialOpeningHoursRelated: { type: Boolean, default: false },
   specialOpeningHours: { type: [Object], default: [] },
   isLongRange: { type: Boolean, default: false },
@@ -216,4 +246,5 @@ const bookableSchemaDefinition = {
 module.exports = {
   bookableSchemaDefinition,
   blockPeriodSchemaDefinition,
+  serviceHoursSchemaDefinition,
 };

--- a/src/commons/schemas/bookableSchema.js
+++ b/src/commons/schemas/bookableSchema.js
@@ -119,6 +119,8 @@ const bookableSchemaDefinition = {
   timePeriods: { type: [Object], default: [] },
   isOpeningHoursRelated: { type: Boolean, default: false },
   openingHours: { type: [Object], default: [] },
+  preparationLeadTimeMinutes: { type: Number, default: null, min: 0 },
+  serviceHours: { type: [Object], default: [] },
   isSpecialOpeningHoursRelated: { type: Boolean, default: false },
   specialOpeningHours: { type: [Object], default: [] },
   isLongRange: { type: Boolean, default: false },

--- a/src/commons/services/calendar-service-v2.js
+++ b/src/commons/services/calendar-service-v2.js
@@ -9,10 +9,10 @@ const {
     mergePeriods,
   },
 } = require("./calendar-service");
-const { isBlockPeriodBookable } = require("../utilities/block-period-generator");
 const {
-  AvailabilityContext,
-} = require("./availability/availability-context");
+  isBlockPeriodBookable,
+} = require("../utilities/block-period-generator");
+const { AvailabilityContext } = require("./availability/availability-context");
 const {
   computeWindowAvailability,
 } = require("./availability/capacity-interval-calculator");
@@ -28,7 +28,7 @@ const {
   applyBookingDurationRules,
 } = require("./availability/availability-duration-filter");
 const {
-  generateTimePeriodsFromLeadTime,
+  generateLeadTimeBlockedPeriods,
 } = require("../availability/lead-time-calculator");
 const { NotFoundError } = require("../../errors/BaseError");
 const bunyan = require("bunyan");
@@ -128,11 +128,10 @@ class CalendarServiceV2 {
 
     const availableOpeningHoursPeriods = blockPeriodBookable
       ? []
-      : generateTimePeriodsFromOpeningHours(
-          startDate,
-          endDate,
-          [bookable, ...context.parentBookables],
-        );
+      : generateTimePeriodsFromOpeningHours(startDate, endDate, [
+          bookable,
+          ...context.parentBookables,
+        ]);
 
     const availableTimePeriods = blockPeriodBookable
       ? generateTimePeriodsFromBlockPeriods(startDate, endDate, bookable)
@@ -151,18 +150,17 @@ class CalendarServiceV2 {
       maxBookingAdvanceInMonths,
     );
 
-    const leadTimePeriods = generateTimePeriodsFromLeadTime(
-      startDate,
-      endDate,
-      bookable,
-    );
-
     const availablePeriods = mergePeriods(
       availableOpeningHoursPeriods,
       availableSpecialOpeningHoursPeriods,
       availableTimePeriods,
       maxBookingAdvancePeriods,
-      leadTimePeriods,
+    );
+
+    const leadTimeBlockedPeriods = generateLeadTimeBlockedPeriods(
+      startDate,
+      endDate,
+      bookable,
     );
 
     const items = [];
@@ -196,6 +194,11 @@ class CalendarServiceV2 {
         );
     items.push(
       ...closedPeriods.map((period) => ({
+        timeBegin: period.start,
+        timeEnd: period.end,
+        available: false,
+      })),
+      ...leadTimeBlockedPeriods.map((period) => ({
         timeBegin: period.start,
         timeEnd: period.end,
         available: false,

--- a/src/commons/services/calendar-service-v2.js
+++ b/src/commons/services/calendar-service-v2.js
@@ -27,6 +27,9 @@ const {
 const {
   applyBookingDurationRules,
 } = require("./availability/availability-duration-filter");
+const {
+  generateTimePeriodsFromLeadTime,
+} = require("../availability/lead-time-calculator");
 const { NotFoundError } = require("../../errors/BaseError");
 const bunyan = require("bunyan");
 
@@ -148,11 +151,18 @@ class CalendarServiceV2 {
       maxBookingAdvanceInMonths,
     );
 
+    const leadTimePeriods = generateTimePeriodsFromLeadTime(
+      startDate,
+      endDate,
+      bookable,
+    );
+
     const availablePeriods = mergePeriods(
       availableOpeningHoursPeriods,
       availableSpecialOpeningHoursPeriods,
       availableTimePeriods,
       maxBookingAdvancePeriods,
+      leadTimePeriods,
     );
 
     const items = [];

--- a/src/commons/services/checkout/item-checkout-service.js
+++ b/src/commons/services/checkout/item-checkout-service.js
@@ -23,6 +23,7 @@ const {
   runTimePeriodCheck,
   runEventDateCheck,
   runMaxBookingDateCheck,
+  runMinBookingLeadTimeCheck,
 } = require("../../availability/checkout-availability-checks");
 const {
   isTimeRelatedBookable,
@@ -684,6 +685,10 @@ class ItemCheckoutService {
     return runMaxBookingDateCheck(await this._availabilityParams());
   }
 
+  async checkMinBookingLeadTime() {
+    return runMinBookingLeadTimeCheck(await this._availabilityParams());
+  }
+
   async checkEventDate() {
     const provider = await this._getAvailabilityProvider();
     return runEventDateCheck({
@@ -748,6 +753,7 @@ class ItemCheckoutService {
         this.checkParentAvailability(),
         this.checkChildBookings(),
         this.checkMaxBookingDate(),
+        this.checkMinBookingLeadTime(),
       ]);
     }
 

--- a/src/commons/services/checkout/item-checkout-service.js
+++ b/src/commons/services/checkout/item-checkout-service.js
@@ -5,7 +5,10 @@ const bunyan = require("bunyan");
 const { getTenantAppById } = require("../../data-managers/tenant-manager");
 const HolidaysService = require("../holiday/holidays-service");
 const { formatISO } = require("date-fns");
-const { BOOKABLE_TYPES, Bookable } = require("../../entities/bookable/bookable");
+const {
+  BOOKABLE_TYPES,
+  Bookable,
+} = require("../../entities/bookable/bookable");
 const CouponService = require("../coupon-service");
 const providerRegistry = require("./providers/checkout-provider-registry");
 const { createClient } = require("../locker/clients/locker-client-registry");
@@ -770,6 +773,7 @@ class ItemCheckoutService {
       this.checkParentAvailability(),
       this.checkChildBookings(),
       this.checkMaxBookingDate(),
+      this.checkMinBookingLeadTime(),
     ]);
   }
 

--- a/src/platform/html-engine/html-engine.js
+++ b/src/platform/html-engine/html-engine.js
@@ -28,9 +28,7 @@ class HtmlEngine {
   }
 
   static async _checkoutUrl(bookableId, tenantId, instance) {
-    console.log("HtmlEngine._checkoutUrl", bookableId, tenantId, instance);
     const checkoutInstance = instance || (await InstanceManager.getInstance());
-    console.log("checkoutInstance", checkoutInstance);
     if (
       checkoutInstance &&
       !checkoutInstance.checkout.useLegacyCheckout &&

--- a/tests/lead-time-calculator.test.js
+++ b/tests/lead-time-calculator.test.js
@@ -1,0 +1,129 @@
+const assert = require("assert");
+const {
+  hasSufficientPreparationLeadTime,
+  getEarliestBookableStart,
+  generateTimePeriodsFromLeadTime,
+  isLeadTimeConfigured,
+} = require("../src/commons/availability/lead-time-calculator");
+
+const SERVICE_HOURS = [
+  {
+    weekdays: [1, 2, 3, 4, 5],
+    startTime: "08:00",
+    endTime: "18:00",
+  },
+];
+
+function bookable(overrides = {}) {
+  return {
+    isScheduleRelated: true,
+    preparationLeadTimeMinutes: 120,
+    serviceHours: SERVICE_HOURS,
+    ...overrides,
+  };
+}
+
+function at(isoString) {
+  return new Date(isoString).getTime();
+}
+
+describe("lead-time-calculator", () => {
+  it("treats unconfigured bookables as always allowed", () => {
+    assert.strictEqual(isLeadTimeConfigured({ isScheduleRelated: true }), false);
+    assert.strictEqual(
+      hasSufficientPreparationLeadTime(
+        { isScheduleRelated: true },
+        at("2026-06-15T10:00:00"),
+      ),
+      true,
+    );
+  });
+
+  it("blocks Friday 18:00 to Monday 08:00", () => {
+    const now = new Date("2026-06-12T18:00:00");
+    const timeBegin = at("2026-06-15T08:00:00");
+
+    assert.strictEqual(
+      hasSufficientPreparationLeadTime(bookable(), timeBegin, now),
+      false,
+    );
+  });
+
+  it("allows Friday 18:00 to Monday 10:00", () => {
+    const now = new Date("2026-06-12T18:00:00");
+    const timeBegin = at("2026-06-15T10:00:00");
+
+    assert.strictEqual(
+      hasSufficientPreparationLeadTime(bookable(), timeBegin, now),
+      true,
+    );
+  });
+
+  it("allows same-day Monday 09:00 to 11:00", () => {
+    const now = new Date("2026-06-15T09:00:00");
+    const timeBegin = at("2026-06-15T11:00:00");
+
+    assert.strictEqual(
+      hasSufficientPreparationLeadTime(bookable(), timeBegin, now),
+      true,
+    );
+  });
+
+  it("blocks same-day Monday 17:30 to 18:30", () => {
+    const now = new Date("2026-06-15T17:30:00");
+    const timeBegin = at("2026-06-15T18:30:00");
+
+    assert.strictEqual(
+      hasSufficientPreparationLeadTime(bookable(), timeBegin, now),
+      false,
+    );
+  });
+
+  it("returns Monday 10:00 as earliest bookable start after Friday 18:00", () => {
+    const now = new Date("2026-06-12T18:00:00");
+
+    assert.strictEqual(
+      getEarliestBookableStart(bookable(), now),
+      at("2026-06-15T10:00:00"),
+    );
+  });
+
+  it("marks calendar periods before earliest start as unavailable", () => {
+    const now = new Date("2026-06-12T18:00:00");
+    const startDate = new Date("2026-06-15T00:00:00");
+    const endDate = new Date("2026-06-15T23:59:59");
+    const periods = generateTimePeriodsFromLeadTime(
+      startDate,
+      endDate,
+      bookable(),
+      now,
+    );
+
+    assert.deepStrictEqual(periods, [
+      {
+        start: startDate.getTime(),
+        end: at("2026-06-15T10:00:00"),
+        available: false,
+      },
+      {
+        start: at("2026-06-15T10:00:00"),
+        end: endDate.getTime(),
+        available: true,
+      },
+    ]);
+  });
+
+  it("ignores lead time for non schedule-related bookables", () => {
+    const configured = bookable({ isScheduleRelated: false });
+
+    assert.strictEqual(isLeadTimeConfigured(configured), false);
+    assert.strictEqual(
+      hasSufficientPreparationLeadTime(
+        configured,
+        at("2026-06-15T08:00:00"),
+        new Date("2026-06-12T18:00:00"),
+      ),
+      true,
+    );
+  });
+});

--- a/tests/lead-time-calculator.test.js
+++ b/tests/lead-time-calculator.test.js
@@ -2,7 +2,7 @@ const assert = require("assert");
 const {
   hasSufficientPreparationLeadTime,
   getEarliestBookableStart,
-  generateTimePeriodsFromLeadTime,
+  generateLeadTimeBlockedPeriods,
   isLeadTimeConfigured,
 } = require("../src/commons/availability/lead-time-calculator");
 
@@ -29,7 +29,10 @@ function at(isoString) {
 
 describe("lead-time-calculator", () => {
   it("treats unconfigured bookables as always allowed", () => {
-    assert.strictEqual(isLeadTimeConfigured({ isScheduleRelated: true }), false);
+    assert.strictEqual(
+      isLeadTimeConfigured({ isScheduleRelated: true }),
+      false,
+    );
     assert.strictEqual(
       hasSufficientPreparationLeadTime(
         { isScheduleRelated: true },
@@ -88,11 +91,20 @@ describe("lead-time-calculator", () => {
     );
   });
 
+  it("returns Monday 11:00 as earliest start when booking same-day at 09:00", () => {
+    const now = new Date("2026-06-15T09:00:00");
+
+    assert.strictEqual(
+      getEarliestBookableStart(bookable(), now),
+      at("2026-06-15T11:00:00"),
+    );
+  });
+
   it("marks calendar periods before earliest start as unavailable", () => {
     const now = new Date("2026-06-12T18:00:00");
     const startDate = new Date("2026-06-15T00:00:00");
     const endDate = new Date("2026-06-15T23:59:59");
-    const periods = generateTimePeriodsFromLeadTime(
+    const periods = generateLeadTimeBlockedPeriods(
       startDate,
       endDate,
       bookable(),
@@ -103,14 +115,29 @@ describe("lead-time-calculator", () => {
       {
         start: startDate.getTime(),
         end: at("2026-06-15T10:00:00"),
-        available: false,
-      },
-      {
-        start: at("2026-06-15T10:00:00"),
-        end: endDate.getTime(),
-        available: true,
       },
     ]);
+  });
+
+  it("marks the full queried range unavailable when no valid window exists", () => {
+    const now = new Date("2026-06-12T18:00:00");
+    const startDate = new Date("2026-06-15T00:00:00");
+    const endDate = new Date("2026-06-15T23:59:59");
+    const impossibleBookable = bookable({
+      preparationLeadTimeMinutes: 600,
+      serviceHours: [{ weekdays: [1], startTime: "08:00", endTime: "10:00" }],
+    });
+
+    assert.strictEqual(getEarliestBookableStart(impossibleBookable, now), null);
+    assert.deepStrictEqual(
+      generateLeadTimeBlockedPeriods(
+        startDate,
+        endDate,
+        impossibleBookable,
+        now,
+      ),
+      [{ start: startDate.getTime(), end: endDate.getTime() }],
+    );
   });
 
   it("ignores lead time for non schedule-related bookables", () => {

--- a/tests/lead-time-checkout.test.js
+++ b/tests/lead-time-checkout.test.js
@@ -3,7 +3,9 @@ const sinon = require("sinon");
 const {
   runMinBookingLeadTimeCheck,
 } = require("../src/commons/availability/checkout-availability-checks");
-const { CHECK_TYPES } = require("../src/commons/availability/checkout-check-types");
+const {
+  CHECK_TYPES,
+} = require("../src/commons/availability/checkout-check-types");
 
 const SERVICE_HOURS = [
   {
@@ -58,8 +60,12 @@ describe("runMinBookingLeadTimeCheck", () => {
           timeBegin: new Date("2026-06-15T08:00:00").getTime(),
         }),
       (error) => {
-        assert.strictEqual(error.checkType, CHECK_TYPES.INSUFFICIENT_LEAD_TIME);
-        assert.match(error.message, /Vorbereitungszeit/);
+        assert.deepStrictEqual(error, {
+          checkType: CHECK_TYPES.INSUFFICIENT_LEAD_TIME,
+          available: false,
+          message:
+            "Die Buchung für das Objekt Meeting Room erfordert eine Vorbereitungszeit von 120 Minuten innerhalb der Servicezeiten.",
+        });
         return true;
       },
     );
@@ -71,6 +77,9 @@ describe("runMinBookingLeadTimeCheck", () => {
       timeBegin: Date.now(),
     });
 
-    assert.strictEqual(result.available, true);
+    assert.deepStrictEqual(result, {
+      checkType: CHECK_TYPES.INSUFFICIENT_LEAD_TIME,
+      available: true,
+    });
   });
 });

--- a/tests/lead-time-checkout.test.js
+++ b/tests/lead-time-checkout.test.js
@@ -1,0 +1,76 @@
+const assert = require("assert");
+const sinon = require("sinon");
+const {
+  runMinBookingLeadTimeCheck,
+} = require("../src/commons/availability/checkout-availability-checks");
+const { CHECK_TYPES } = require("../src/commons/availability/checkout-check-types");
+
+const SERVICE_HOURS = [
+  {
+    weekdays: [1, 2, 3, 4, 5],
+    startTime: "08:00",
+    endTime: "18:00",
+  },
+];
+
+function bookable(overrides = {}) {
+  return {
+    id: "room-1",
+    title: "Meeting Room",
+    isScheduleRelated: true,
+    preparationLeadTimeMinutes: 120,
+    serviceHours: SERVICE_HOURS,
+    ...overrides,
+  };
+}
+
+describe("runMinBookingLeadTimeCheck", () => {
+  let clock;
+
+  afterEach(() => {
+    if (clock) {
+      clock.restore();
+      clock = null;
+    }
+  });
+
+  it("passes when lead time is sufficient", async () => {
+    clock = sinon.useFakeTimers(new Date("2026-06-15T09:00:00").getTime());
+
+    const result = await runMinBookingLeadTimeCheck({
+      originBookable: bookable(),
+      timeBegin: new Date("2026-06-15T11:00:00").getTime(),
+    });
+
+    assert.deepStrictEqual(result, {
+      checkType: CHECK_TYPES.INSUFFICIENT_LEAD_TIME,
+      available: true,
+    });
+  });
+
+  it("rejects when lead time is insufficient", async () => {
+    clock = sinon.useFakeTimers(new Date("2026-06-12T18:00:00").getTime());
+
+    await assert.rejects(
+      () =>
+        runMinBookingLeadTimeCheck({
+          originBookable: bookable(),
+          timeBegin: new Date("2026-06-15T08:00:00").getTime(),
+        }),
+      (error) => {
+        assert.strictEqual(error.checkType, CHECK_TYPES.INSUFFICIENT_LEAD_TIME);
+        assert.match(error.message, /Vorbereitungszeit/);
+        return true;
+      },
+    );
+  });
+
+  it("skips unconfigured bookables", async () => {
+    const result = await runMinBookingLeadTimeCheck({
+      originBookable: bookable({ preparationLeadTimeMinutes: null }),
+      timeBegin: Date.now(),
+    });
+
+    assert.strictEqual(result.available, true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds preparation lead time (`preparationLeadTimeMinutes`) and independent service hours (`serviceHours`) to bookables for schedule-related bookings
- Implements service-hours-aware lead time validation in checkout and Calendar V2, reusing the existing availability architecture (analogous to `maxBookingAdvanceInMonths`)
- Manual bookings with `MANAGE_BOOKINGS` already bypass availability checks via `ManualBundleCheckoutService`

## Test plan
- [x] Unit tests for lead-time calculator (Friday→Monday, same-day, service-end boundary)
- [x] Checkout check tests (`runMinBookingLeadTimeCheck`)
- [x] Existing availability test suite passes (except unrelated pre-existing rule-engine timeouts)
- [x] Configure a bookable with `preparationLeadTimeMinutes: 120` and Mo–Fr 08:00–18:00 service hours
- [x] Verify Calendar V2 blocks Monday slots before 10:00 when booking on Friday 18:00
- [x] Verify checkout rejects insufficient lead time with German error message
- [x] Verify manual admin booking still works without lead-time block

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Bookables can now define `preparationLeadTimeMinutes` and per-weekday `serviceHours`, available in public bookable output.
  * Availability and checkout now enforce minimum lead time, returning `insufficient-lead-time` when booking is too soon.
* **Bug Fixes**
  * Calendar availability now marks lead-time blocked periods in addition to existing closed/unavailable windows, improving edge-case handling.
* **Documentation**
  * Updated bookable documentation with the new fields and JSON examples.
* **Tests**
  * Added unit tests for lead-time calculation and checkout lead-time validation.
* **Chores**
  * Removed stray debug logging from the HTML engine.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->