### PR TITLE
DEV-630 Phase 2: Booking buffer times for capacity checks

### DIFF
--- a/docs/entities.md
+++ b/docs/entities.md
@@ -227,6 +227,8 @@ Example:
       "endTime": "18:00"
     }
   ],
+  "bufferTimeBeforeMinutes": 0,
+  "bufferTimeAfterMinutes": 30,
   "isSpecialOpeningHoursRelated": false,
   "specialOpeningHours": [
     {
@@ -316,6 +318,8 @@ Key fields of a bookable:
 | openingHours          | Regular opening hours per weekday.                                                                                                                          |
 | preparationLeadTimeMinutes | Minimum preparation time in minutes before booking start. Lead-time enforcement is active only when `isScheduleRelated` is `true`, `preparationLeadTimeMinutes` is greater than `0`, and `serviceHours` is non-empty. |
 | serviceHours          | Service windows when preparation can take place (same structure as `openingHours`, independent of opening hours). Only evaluated together with `preparationLeadTimeMinutes` on schedule-related bookables. |
+| bufferTimeBeforeMinutes | Optional capacity buffer before each booking (minutes). Active only when `isScheduleRelated` is `true` and value is greater than `0`. Blocks back-to-back bookings in calendar and checkout capacity checks. |
+| bufferTimeAfterMinutes | Optional capacity buffer after each booking (minutes). Active only when `isScheduleRelated` is `true` and value is greater than `0`. |
 | isSpecialOpeningHoursRelated | If `true`, `specialOpeningHours` override the regular opening hours for specific dates.                                                              |
 | specialOpeningHours   | Special opening hours for specific dates.                                                                                                                   |
 | isLongRange           | If `true`, long-range bookings (e.g. weeks/months) are enabled.                                                                                            |

--- a/src/commons/availability/availability-rules/capacity-rules.js
+++ b/src/commons/availability/availability-rules/capacity-rules.js
@@ -2,6 +2,7 @@ const {
   getBookedAmountForBookable,
   sumBookedAmount,
 } = require("./booking-amount");
+const { expandBlockedInterval } = require("../booking-buffer");
 const { CAPACITY_MODES } = require("./types");
 const {
   combineAdjacentIntervals,
@@ -54,6 +55,8 @@ function evaluateOriginCapacity({
  * @param {number} params.requestedAmount
  * @param {import("./types").CapacityMode} [params.mode]
  * @param {boolean} [params.useTimeOverlap]
+ * @param {number} [params.bufferBeforeMs]
+ * @param {number} [params.bufferAfterMs]
  * @returns {import("./types").AvailabilityInterval[]}
  */
 function evaluateCapacityIntervals({
@@ -65,6 +68,8 @@ function evaluateCapacityIntervals({
   requestedAmount,
   mode = CAPACITY_MODES.ADDITIVE,
   useTimeOverlap = true,
+  bufferBeforeMs = 0,
+  bufferAfterMs = 0,
 }) {
   if (!capacity) {
     return [
@@ -109,8 +114,14 @@ function evaluateCapacityIntervals({
       start = windowStart;
       end = windowEnd;
     } else {
-      start = Math.max(start, windowStart);
-      end = Math.min(end, windowEnd);
+      const blocked = expandBlockedInterval(
+        start,
+        end,
+        bufferBeforeMs,
+        bufferAfterMs,
+      );
+      start = Math.max(blocked.timeBegin, windowStart);
+      end = Math.min(blocked.timeEnd, windowEnd);
       if (start >= end) {
         continue;
       }

--- a/src/commons/availability/availability-rules/parent-child-rules.js
+++ b/src/commons/availability/availability-rules/parent-child-rules.js
@@ -2,6 +2,7 @@ const {
   getBookedAmountForBookableSet,
   sumBookedAmountForBookableSet,
 } = require("./booking-amount");
+const { expandBlockedInterval } = require("../booking-buffer");
 const { evaluateOriginCapacity } = require("./capacity-rules");
 const { CAPACITY_MODES } = require("./types");
 const {
@@ -71,6 +72,8 @@ function evaluateChildCapacity({
  * @param {import("../../entities/bookable/bookable").Bookable[]} params.relatedBookables
  * @param {number} params.requestedAmount
  * @param {boolean} params.useTimeOverlap
+ * @param {number} [params.bufferBeforeMs]
+ * @param {number} [params.bufferAfterMs]
  * @returns {import("./types").AvailabilityInterval[]}
  */
 function evaluateTicketParentCapacityIntervals({
@@ -81,6 +84,8 @@ function evaluateTicketParentCapacityIntervals({
   relatedBookables,
   requestedAmount,
   useTimeOverlap,
+  bufferBeforeMs = 0,
+  bufferAfterMs = 0,
 }) {
   const capacity = parentBookable.amount;
   if (!capacity) {
@@ -125,8 +130,14 @@ function evaluateTicketParentCapacityIntervals({
       start = windowStart;
       end = windowEnd;
     } else {
-      start = Math.max(start, windowStart);
-      end = Math.min(end, windowEnd);
+      const blocked = expandBlockedInterval(
+        start,
+        end,
+        bufferBeforeMs,
+        bufferAfterMs,
+      );
+      start = Math.max(blocked.timeBegin, windowStart);
+      end = Math.min(blocked.timeEnd, windowEnd);
       if (start >= end) {
         continue;
       }

--- a/src/commons/availability/booking-buffer.js
+++ b/src/commons/availability/booking-buffer.js
@@ -1,0 +1,104 @@
+/**
+ * Capacity buffer around schedule-related bookings (back-to-back prevention).
+ * Mirrors the IFBS LocationBuffer overlap model: existing bookings block
+ * [timeBegin - bufferBefore, timeEnd + bufferAfter].
+ */
+
+/**
+ * @param {import("../entities/bookable/bookable").Bookable|Object} bookable
+ * @returns {{ beforeMs: number, afterMs: number }}
+ */
+function getBookingBufferMs(bookable) {
+  if (!bookable?.isScheduleRelated) {
+    return { beforeMs: 0, afterMs: 0 };
+  }
+
+  return {
+    beforeMs:
+      Math.max(0, Number(bookable.bufferTimeBeforeMinutes) || 0) * 60 * 1000,
+    afterMs:
+      Math.max(0, Number(bookable.bufferTimeAfterMinutes) || 0) * 60 * 1000,
+  };
+}
+
+/**
+ * @param {import("../entities/bookable/bookable").Bookable|Object} bookable
+ * @returns {boolean}
+ */
+function isBookingBufferConfigured(bookable) {
+  const { beforeMs, afterMs } = getBookingBufferMs(bookable);
+  return beforeMs > 0 || afterMs > 0;
+}
+
+/**
+ * @param {number|null|undefined} timeBegin
+ * @param {number|null|undefined} timeEnd
+ * @param {number} beforeMs
+ * @param {number} afterMs
+ * @returns {{ timeBegin: number|null|undefined, timeEnd: number|null|undefined }}
+ */
+function expandBlockedInterval(timeBegin, timeEnd, beforeMs, afterMs) {
+  if (timeBegin == null || timeEnd == null) {
+    return { timeBegin, timeEnd };
+  }
+
+  return {
+    timeBegin: timeBegin - beforeMs,
+    timeEnd: timeEnd + afterMs,
+  };
+}
+
+/**
+ * @param {number} requestBegin
+ * @param {number} requestEnd
+ * @param {number|null|undefined} bookingBegin
+ * @param {number|null|undefined} bookingEnd
+ * @param {number} beforeMs
+ * @param {number} afterMs
+ * @returns {boolean}
+ */
+function overlapsBufferedInterval(
+  requestBegin,
+  requestEnd,
+  bookingBegin,
+  bookingEnd,
+  beforeMs,
+  afterMs,
+) {
+  if (bookingBegin == null || bookingEnd == null) {
+    return true;
+  }
+
+  const blocked = expandBlockedInterval(
+    bookingBegin,
+    bookingEnd,
+    beforeMs,
+    afterMs,
+  );
+
+  return requestBegin < blocked.timeEnd && requestEnd > blocked.timeBegin;
+}
+
+/**
+ * Widens a query window so bookings whose buffer extends into the request are included.
+ *
+ * @param {number} timeBegin
+ * @param {number} timeEnd
+ * @param {number} beforeMs
+ * @param {number} afterMs
+ * @returns {{ timeBegin: number, timeEnd: number }}
+ */
+function widenQueryWindow(timeBegin, timeEnd, beforeMs, afterMs) {
+  return {
+    timeBegin: timeBegin - afterMs,
+    timeEnd: timeEnd + beforeMs,
+  };
+}
+
+module.exports = {
+  getBookingBufferMs,
+  isBookingBufferConfigured,
+  expandBlockedInterval,
+  overlapsBufferedInterval,
+  widenQueryWindow,
+};

--- a/src/commons/availability/check-window-availability.js
+++ b/src/commons/availability/check-window-availability.js
@@ -1,4 +1,9 @@
 const OpeningHoursManager = require("../utilities/opening-hours-manager");
+const BookingManager = require("../data-managers/booking-manager");
+const {
+  getBookingBufferMs,
+  widenQueryWindow,
+} = require("./booking-buffer");
 const {
   isTimeRelatedBookable,
   sumBookedAmount,
@@ -41,8 +46,27 @@ async function getBookingsForCapacityCheck(
   { useTimeOverlap = isTimeRelatedBookable(bookable) } = {},
 ) {
   if (useTimeOverlap) {
-    return resolve(
-      provider.getConcurrentBookings(bookable.id, timeBegin, timeEnd),
+    const buffer = getBookingBufferMs(bookable);
+    const queryWindow = widenQueryWindow(
+      timeBegin,
+      timeEnd,
+      buffer.beforeMs,
+      buffer.afterMs,
+    );
+    const bookings = await resolve(
+      provider.getConcurrentBookings(
+        bookable.id,
+        queryWindow.timeBegin,
+        queryWindow.timeEnd,
+      ),
+    );
+
+    return BookingManager.filterConcurrentBookings(
+      bookings,
+      timeBegin,
+      timeEnd,
+      null,
+      buffer,
     );
   }
 

--- a/src/commons/availability/check-window-availability.js
+++ b/src/commons/availability/check-window-availability.js
@@ -1,9 +1,6 @@
 const OpeningHoursManager = require("../utilities/opening-hours-manager");
 const BookingManager = require("../data-managers/booking-manager");
-const {
-  getBookingBufferMs,
-  widenQueryWindow,
-} = require("./booking-buffer");
+const { getBookingBufferMs, widenQueryWindow } = require("./booking-buffer");
 const {
   isTimeRelatedBookable,
   sumBookedAmount,
@@ -133,7 +130,10 @@ async function checkWindowAvailability(
     return { available: false, reason: "permission" };
   }
 
-  if (isTimeRelatedBookable(bookable) && !shouldSkipOpeningHoursCheck(bookable)) {
+  if (
+    isTimeRelatedBookable(bookable) &&
+    !shouldSkipOpeningHoursCheck(bookable)
+  ) {
     const parentBookables = await resolve(provider.getParentBookables());
 
     for (const candidate of [bookable, ...parentBookables]) {

--- a/src/commons/data-managers/booking-manager.js
+++ b/src/commons/data-managers/booking-manager.js
@@ -1,4 +1,9 @@
 const { isRangeOverlap } = require("range-overlap");
+const {
+  getBookingBufferMs,
+  overlapsBufferedInterval,
+  widenQueryWindow,
+} = require("../availability/booking-buffer");
 const { Booking } = require("../entities/booking/booking");
 const BookingModel = require("./models/bookingModel");
 const BookableModel = require("./models/bookableModel");
@@ -239,6 +244,7 @@ class BookingManager {
    * @param {number} timeBegin
    * @param {number} timeEnd
    * @param {string|null} bookingToIgnore
+   * @param {{ beforeMs?: number, afterMs?: number }} [buffer]
    * @returns {Booking[]}
    */
   static filterConcurrentBookings(
@@ -246,19 +252,38 @@ class BookingManager {
     timeBegin,
     timeEnd,
     bookingToIgnore = null,
+    buffer = { beforeMs: 0, afterMs: 0 },
   ) {
-    return bookings.filter(
-      (booking) =>
-        isRangeOverlap(
-          booking.timeBegin,
-          booking.timeEnd,
+    const { beforeMs = 0, afterMs = 0 } = buffer;
+    const useBuffer = beforeMs > 0 || afterMs > 0;
+    const queryWindow = useBuffer
+      ? widenQueryWindow(timeBegin, timeEnd, beforeMs, afterMs)
+      : { timeBegin, timeEnd };
+
+    return bookings.filter((booking) => {
+      if (booking.isRejected || booking.id === bookingToIgnore) {
+        return false;
+      }
+
+      if (useBuffer) {
+        return overlapsBufferedInterval(
           timeBegin,
           timeEnd,
-          true,
-        ) &&
-        !booking.isRejected &&
-        booking.id !== bookingToIgnore,
-    );
+          booking.timeBegin,
+          booking.timeEnd,
+          beforeMs,
+          afterMs,
+        );
+      }
+
+      return isRangeOverlap(
+        booking.timeBegin,
+        booking.timeEnd,
+        queryWindow.timeBegin,
+        queryWindow.timeEnd,
+        true,
+      );
+    });
   }
 
   /**

--- a/src/commons/data-managers/booking-manager.js
+++ b/src/commons/data-managers/booking-manager.js
@@ -1,15 +1,12 @@
 const { isRangeOverlap } = require("range-overlap");
 const {
-  getBookingBufferMs,
   overlapsBufferedInterval,
   widenQueryWindow,
 } = require("../availability/booking-buffer");
 const { Booking } = require("../entities/booking/booking");
 const BookingModel = require("./models/bookingModel");
 const BookableModel = require("./models/bookableModel");
-const {
-  BookableManager,
-} = require("./bookable-manager");
+const { BookableManager } = require("./bookable-manager");
 
 /**
  * Data Manager for Booking objects.
@@ -35,46 +32,46 @@ class BookingManager {
     }, new Map());
 
     await Promise.all(
-      [...bookingsByTenant.entries()].map(async ([tenantId, tenantBookings]) => {
-        const { instanceFields, tenantFields } =
-          await BookableManager.getCustomFieldDefinitions(tenantId);
+      [...bookingsByTenant.entries()].map(
+        async ([tenantId, tenantBookings]) => {
+          const { instanceFields, tenantFields } =
+            await BookableManager.getCustomFieldDefinitions(tenantId);
 
-        const bookableIds = [
-          ...new Set(
-            tenantBookings.flatMap((booking) =>
-              booking.bookableItems.map((item) => item.bookableId),
-            ),
-          ),
-        ];
-
-        const bookables = await BookableManager.getBookablesByIds(
-          tenantId,
-          bookableIds,
-        );
-        const bookableFieldsById = new Map(
-          bookables.map((bookable) => [
-            bookable.id,
-            bookable.customFieldDefinitions || [],
-          ]),
-        );
-
-        for (const booking of tenantBookings) {
-          const bookingBookableIds = [
+          const bookableIds = [
             ...new Set(
-              booking.bookableItems.map((item) => item.bookableId),
+              tenantBookings.flatMap((booking) =>
+                booking.bookableItems.map((item) => item.bookableId),
+              ),
             ),
           ];
-          const bookableFields = bookingBookableIds.flatMap(
-            (bookableId) => bookableFieldsById.get(bookableId) || [],
+
+          const bookables = await BookableManager.getBookablesByIds(
+            tenantId,
+            bookableIds,
+          );
+          const bookableFieldsById = new Map(
+            bookables.map((bookable) => [
+              bookable.id,
+              bookable.customFieldDefinitions || [],
+            ]),
           );
 
-          booking.enrichCustomFields({
-            instanceFields,
-            tenantFields,
-            bookableFields,
-          });
-        }
-      }),
+          for (const booking of tenantBookings) {
+            const bookingBookableIds = [
+              ...new Set(booking.bookableItems.map((item) => item.bookableId)),
+            ];
+            const bookableFields = bookingBookableIds.flatMap(
+              (bookableId) => bookableFieldsById.get(bookableId) || [],
+            );
+
+            booking.enrichCustomFields({
+              instanceFields,
+              tenantFields,
+              bookableFields,
+            });
+          }
+        },
+      ),
     );
 
     return bookings;
@@ -405,7 +402,11 @@ class BookingManager {
     return result.length > 0 ? result[0].totalSeats : 0;
   }
 
-  static async reassignUserReferences(previousUserId, newUserId, session = null) {
+  static async reassignUserReferences(
+    previousUserId,
+    newUserId,
+    session = null,
+  ) {
     const options = session ? { session } : {};
 
     await BookingModel.updateMany(

--- a/src/commons/entities/bookable/bookable.js
+++ b/src/commons/entities/bookable/bookable.js
@@ -357,6 +357,8 @@ class Bookable {
       openingHours: this.openingHours,
       preparationLeadTimeMinutes: this.preparationLeadTimeMinutes,
       serviceHours: this.serviceHours,
+      bufferTimeBeforeMinutes: this.bufferTimeBeforeMinutes,
+      bufferTimeAfterMinutes: this.bufferTimeAfterMinutes,
       isSpecialOpeningHoursRelated: this.isSpecialOpeningHoursRelated,
       specialOpeningHours: this.specialOpeningHours,
       isLongRange: this.isLongRange,

--- a/src/commons/schemas/bookableSchema.js
+++ b/src/commons/schemas/bookableSchema.js
@@ -151,6 +151,8 @@ const bookableSchemaDefinition = {
     type: [new Schema(serviceHoursSchemaDefinition, { _id: false })],
     default: [],
   },
+  bufferTimeBeforeMinutes: { type: Number, default: null, min: 0 },
+  bufferTimeAfterMinutes: { type: Number, default: null, min: 0 },
   isSpecialOpeningHoursRelated: { type: Boolean, default: false },
   specialOpeningHours: { type: [Object], default: [] },
   isLongRange: { type: Boolean, default: false },

--- a/src/commons/services/availability/capacity-interval-calculator.js
+++ b/src/commons/services/availability/capacity-interval-calculator.js
@@ -13,7 +13,9 @@ const {
   widenQueryWindow,
 } = require("../../availability/booking-buffer");
 const BookingManager = require("../../data-managers/booking-manager");
-const { CAPACITY_MODES } = require("../../availability/availability-rules/types");
+const {
+  CAPACITY_MODES,
+} = require("../../availability/availability-rules/types");
 const { intersectAvailability } = require("./availability-interval-merger");
 
 /** @deprecated Use evaluateCapacityIntervals from availability-rules */

--- a/src/commons/services/availability/capacity-interval-calculator.js
+++ b/src/commons/services/availability/capacity-interval-calculator.js
@@ -8,6 +8,11 @@ const {
 const {
   evaluateTicketParentCapacityIntervals,
 } = require("../../availability/availability-rules/parent-child-rules");
+const {
+  getBookingBufferMs,
+  widenQueryWindow,
+} = require("../../availability/booking-buffer");
+const BookingManager = require("../../data-managers/booking-manager");
 const { CAPACITY_MODES } = require("../../availability/availability-rules/types");
 const { intersectAvailability } = require("./availability-interval-merger");
 
@@ -33,8 +38,29 @@ function getBookingsForCapacityCheck(
   windowStart,
   windowEnd,
 ) {
-  if (isTimeRelatedBookable(originBookable)) {
-    return context.getConcurrentBookings(bookable.id, windowStart, windowEnd);
+  const useTimeOverlap = isTimeRelatedBookable(originBookable);
+
+  if (useTimeOverlap) {
+    const buffer = getBookingBufferMs(bookable);
+    const queryWindow = widenQueryWindow(
+      windowStart,
+      windowEnd,
+      buffer.beforeMs,
+      buffer.afterMs,
+    );
+    const bookings = context.getConcurrentBookings(
+      bookable.id,
+      queryWindow.timeBegin,
+      queryWindow.timeEnd,
+    );
+
+    return BookingManager.filterConcurrentBookings(
+      bookings,
+      windowStart,
+      windowEnd,
+      null,
+      buffer,
+    );
   }
 
   return context.getRelatedBookings(bookable.id);
@@ -110,6 +136,7 @@ function computeWindowAvailability(
 ) {
   const useTimeOverlap = isTimeRelatedBookable(originBookable);
   const constraintSets = [];
+  const originBuffer = getBookingBufferMs(originBookable);
 
   constraintSets.push(
     evaluateCapacityIntervals({
@@ -127,10 +154,14 @@ function computeWindowAvailability(
       requestedAmount: amount,
       mode: CAPACITY_MODES.ADDITIVE,
       useTimeOverlap,
+      bufferBeforeMs: originBuffer.beforeMs,
+      bufferAfterMs: originBuffer.afterMs,
     }),
   );
 
   for (const parentBookable of context.parentBookables) {
+    const parentBuffer = getBookingBufferMs(parentBookable);
+
     if (originBookable.type === "ticket") {
       constraintSets.push(
         evaluateTicketParentCapacityIntervals({
@@ -147,6 +178,8 @@ function computeWindowAvailability(
           relatedBookables: context.getRelatedBookablesFor(parentBookable.id),
           requestedAmount: amount,
           useTimeOverlap,
+          bufferBeforeMs: parentBuffer.beforeMs,
+          bufferAfterMs: parentBuffer.afterMs,
         }),
       );
     } else {
@@ -166,6 +199,8 @@ function computeWindowAvailability(
           requestedAmount: 1,
           mode: CAPACITY_MODES.EXCLUSIVE,
           useTimeOverlap,
+          bufferBeforeMs: parentBuffer.beforeMs,
+          bufferAfterMs: parentBuffer.afterMs,
         }),
       );
     }
@@ -175,6 +210,8 @@ function computeWindowAvailability(
     if (childBookable.id === originBookable.id) {
       continue;
     }
+
+    const childBuffer = getBookingBufferMs(childBookable);
 
     constraintSets.push(
       evaluateCapacityIntervals({
@@ -192,6 +229,8 @@ function computeWindowAvailability(
         requestedAmount: amount,
         mode: CAPACITY_MODES.ADDITIVE,
         useTimeOverlap,
+        bufferBeforeMs: childBuffer.beforeMs,
+        bufferAfterMs: childBuffer.afterMs,
       }),
     );
   }

--- a/tests/booking-buffer.test.js
+++ b/tests/booking-buffer.test.js
@@ -5,22 +5,18 @@ const {
   overlapsBufferedInterval,
   expandBlockedInterval,
 } = require("../src/commons/availability/booking-buffer");
-const { evaluateCapacityIntervals } = require("../src/commons/availability/availability-rules/capacity-rules");
+const {
+  evaluateCapacityIntervals,
+} = require("../src/commons/availability/availability-rules/capacity-rules");
 const BookingManager = require("../src/commons/data-managers/booking-manager");
-
-function bookable(overrides = {}) {
-  return {
-    isScheduleRelated: true,
-    bufferTimeBeforeMinutes: 0,
-    bufferTimeAfterMinutes: 30,
-    ...overrides,
-  };
-}
 
 describe("booking-buffer", () => {
   it("ignores buffer for non schedule-related bookables", () => {
     assert.deepStrictEqual(
-      getBookingBufferMs({ isScheduleRelated: false, bufferTimeAfterMinutes: 30 }),
+      getBookingBufferMs({
+        isScheduleRelated: false,
+        bufferTimeAfterMinutes: 30,
+      }),
       { beforeMs: 0, afterMs: 0 },
     );
     assert.strictEqual(

--- a/tests/booking-buffer.test.js
+++ b/tests/booking-buffer.test.js
@@ -1,0 +1,155 @@
+const assert = require("assert");
+const {
+  getBookingBufferMs,
+  isBookingBufferConfigured,
+  overlapsBufferedInterval,
+  expandBlockedInterval,
+} = require("../src/commons/availability/booking-buffer");
+const { evaluateCapacityIntervals } = require("../src/commons/availability/availability-rules/capacity-rules");
+const BookingManager = require("../src/commons/data-managers/booking-manager");
+
+function bookable(overrides = {}) {
+  return {
+    isScheduleRelated: true,
+    bufferTimeBeforeMinutes: 0,
+    bufferTimeAfterMinutes: 30,
+    ...overrides,
+  };
+}
+
+describe("booking-buffer", () => {
+  it("ignores buffer for non schedule-related bookables", () => {
+    assert.deepStrictEqual(
+      getBookingBufferMs({ isScheduleRelated: false, bufferTimeAfterMinutes: 30 }),
+      { beforeMs: 0, afterMs: 0 },
+    );
+    assert.strictEqual(
+      isBookingBufferConfigured({
+        isScheduleRelated: false,
+        bufferTimeAfterMinutes: 30,
+      }),
+      false,
+    );
+  });
+
+  it("expands blocked intervals like IFBS LocationBuffer", () => {
+    const blocked = expandBlockedInterval(3_600_000, 7_200_000, 0, 1_800_000);
+    assert.deepStrictEqual(blocked, {
+      timeBegin: 3_600_000,
+      timeEnd: 9_000_000,
+    });
+  });
+
+  it("detects overlap when only the after-buffer collides", () => {
+    assert.strictEqual(
+      overlapsBufferedInterval(
+        11 * 60 * 60 * 1000,
+        12 * 60 * 60 * 1000,
+        10 * 60 * 60 * 1000,
+        11 * 60 * 60 * 1000,
+        0,
+        30 * 60 * 1000,
+      ),
+      true,
+    );
+    assert.strictEqual(
+      overlapsBufferedInterval(
+        11.5 * 60 * 60 * 1000,
+        12.5 * 60 * 60 * 1000,
+        10 * 60 * 60 * 1000,
+        11 * 60 * 60 * 1000,
+        0,
+        30 * 60 * 1000,
+      ),
+      false,
+    );
+  });
+
+  it("detects overlap when only the before-buffer collides", () => {
+    assert.strictEqual(
+      overlapsBufferedInterval(
+        11 * 60 * 60 * 1000,
+        12 * 60 * 60 * 1000,
+        12 * 60 * 60 * 1000,
+        13 * 60 * 60 * 1000,
+        30 * 60 * 1000,
+        0,
+      ),
+      true,
+    );
+  });
+});
+
+describe("capacity buffer intervals", () => {
+  it("extends unavailable periods by after-buffer", () => {
+    const bookings = [
+      {
+        id: "b1",
+        isRejected: false,
+        timeBegin: 10 * 60 * 60 * 1000,
+        timeEnd: 11 * 60 * 60 * 1000,
+        bookableItems: [{ bookableId: "room-a", amount: 1 }],
+      },
+    ];
+
+    const intervals = evaluateCapacityIntervals({
+      windowStart: 9 * 60 * 60 * 1000,
+      windowEnd: 13 * 60 * 60 * 1000,
+      bookings,
+      bookableId: "room-a",
+      capacity: 1,
+      requestedAmount: 1,
+      mode: "exclusive",
+      useTimeOverlap: true,
+      bufferBeforeMs: 0,
+      bufferAfterMs: 30 * 60 * 1000,
+    });
+
+    assert.deepStrictEqual(intervals, [
+      {
+        timeBegin: 9 * 60 * 60 * 1000,
+        timeEnd: 10 * 60 * 60 * 1000,
+        available: true,
+      },
+      {
+        timeBegin: 10 * 60 * 60 * 1000,
+        timeEnd: 11.5 * 60 * 60 * 1000,
+        available: false,
+      },
+      {
+        timeBegin: 11.5 * 60 * 60 * 1000,
+        timeEnd: 13 * 60 * 60 * 1000,
+        available: true,
+      },
+    ]);
+  });
+
+  it("filters concurrent bookings with buffer-aware overlap", () => {
+    const bookings = [
+      {
+        id: "b1",
+        isRejected: false,
+        timeBegin: 10 * 60 * 60 * 1000,
+        timeEnd: 11 * 60 * 60 * 1000,
+        bookableItems: [{ bookableId: "room-a", amount: 1 }],
+      },
+    ];
+
+    const withoutBuffer = BookingManager.filterConcurrentBookings(
+      bookings,
+      11 * 60 * 60 * 1000,
+      12 * 60 * 60 * 1000,
+    );
+    assert.deepStrictEqual(withoutBuffer, []);
+
+    const withBuffer = BookingManager.filterConcurrentBookings(
+      bookings,
+      11 * 60 * 60 * 1000,
+      12 * 60 * 60 * 1000,
+      null,
+      { beforeMs: 0, afterMs: 30 * 60 * 1000 },
+    );
+    assert.strictEqual(withBuffer.length, 1);
+    assert.strictEqual(withBuffer[0].id, "b1");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `bufferTimeBeforeMinutes` and `bufferTimeAfterMinutes` to the Bookable schema for schedule-related capacity buffering
- Introduces `booking-buffer.js` with IFBS-style overlap logic (expand existing bookings by before/after buffer)
- Integrates buffers into calendar capacity intervals (`capacity-interval-calculator`) and checkout/window availability checks
- Documents new fields in `docs/entities.md` and adds unit tests

## Test plan
- [x] `npm test -- tests/booking-buffer.test.js`
- [x] `npm test -- tests/availability-phase2.test.js tests/lead-time-calculator.test.js tests/lead-time-checkout.test.js`
- [x] Manual: configure buffer on a schedule-related bookable → verify calendar blocks back-to-back slots
- [x] Manual: checkout rejects slot that violates after-buffer of existing booking




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for booking buffers on schedule-related items, including configurable time before/after bookings.
  * Availability checks now account for buffered time when calculating overlaps and capacity.
  * Public bookable data now includes the new buffer settings.

* **Bug Fixes**
  * Improved booking conflict detection so nearby bookings are treated more accurately.
  * Availability queries now include bookings whose buffered time affects the requested window.

* **Documentation**
  * Updated entity documentation to describe the new buffer fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->