### PR TITLE
changed receiptNumberPrefix to invoiceNumberPrefix

### DIFF
--- a/src/commons/services/payment/invoice-service.js
+++ b/src/commons/services/payment/invoice-service.js
@@ -175,7 +175,7 @@ async function _createInvoiceNumber(tenantId, bookingId) {
     invoiceId = await IdGenerator.next(tenantId, 4, "invoice");
   }
 
-  const invoiceNumber = `${tenant.receiptNumberPrefix ? tenant.receiptNumberPrefix + "-" : ""}${invoiceId}-${revision}`;
+  const invoiceNumber = `${tenant.invoiceNumberPrefix ? tenant.invoiceNumberPrefix + "-" : ""}${invoiceId}-${revision}`;
 
   return {
     invoiceNumber,


### PR DESCRIPTION
This pull request makes a small but important change to the logic for generating invoice numbers in `invoice-service.js`. The code now uses the `invoiceNumberPrefix` field instead of the `receiptNumberPrefix` field when constructing the invoice number.

- Updated invoice number generation to use `tenant.invoiceNumberPrefix` instead of `tenant.receiptNumberPrefix` in `_createInvoiceNumber` (`src/commons/services/payment/invoice-service.js`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed invoice number generation to use the appropriate invoice number prefix instead of the receipt number prefix. The invoice number is now properly formatted to include the configured prefix when available, along with the invoice ID and revision number, ensuring consistent and accurate invoice identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->