### PR TITLE
Fix invitation email case-insensitive matching and deduplicate records

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,9 +7,20 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 ## [Unreleased]
 
+### Added
+
+- User ID normalization utility for case-insensitive email/user matching across invitation and membership flows
+- Migration `02-07-2026-normalize-membership-invitation-user-ids` to normalize invitation/membership user IDs and deduplicate conflicting membership and single-use invitation records
+
 ### Changed
 
 - Preparation lead time (`preparationLeadTimeMinutes` / `serviceHours`) now also applies to time-period- and block-period-related bookables, not only schedule-related ones
+
+### Fixed
+
+- Invitation acceptance, rejection, and verification now compare intended user IDs case-insensitively
+- Tenant user onboarding and invitation resend endpoints now normalize user IDs before membership/invitation lookups
+- Prevent creating duplicate active single-use invitations for the same tenant and intended user
 
 ## [4.1.1] — 2026-07-01
 

--- a/migrations/scripts/02-07-2026-normalize-membership-invitation-user-ids.js
+++ b/migrations/scripts/02-07-2026-normalize-membership-invitation-user-ids.js
@@ -1,5 +1,7 @@
 function normalizeUserId(userId) {
-  return String(userId || "").trim().toLowerCase();
+  return String(userId || "")
+    .trim()
+    .toLowerCase();
 }
 
 function getMembershipTimestamp(membership) {
@@ -17,8 +19,7 @@ function isAcceptedMembership(membership) {
  */
 function pickMembershipToKeep(memberships) {
   const accepted = memberships.filter(isAcceptedMembership);
-  const candidates =
-    accepted.length > 0 ? accepted : [...memberships];
+  const candidates = accepted.length > 0 ? accepted : [...memberships];
 
   return candidates.sort(
     (a, b) => getMembershipTimestamp(b) - getMembershipTimestamp(a),
@@ -30,9 +31,7 @@ function getInvitationTimestamp(invitation) {
 }
 
 function isConsumedInvitation(invitation) {
-  return (
-    (invitation.usedCount || 0) >= 1 || invitation.status === "exhausted"
-  );
+  return (invitation.usedCount || 0) >= 1 || invitation.status === "exhausted";
 }
 
 function isActiveSingleInvitation(invitation) {
@@ -95,13 +94,12 @@ module.exports = {
 
       const toKeep = pickMembershipToKeep(group);
       const toDelete = group.filter(
-        (membership) =>
-          membership._id.toString() !== toKeep._id.toString(),
+        (membership) => membership._id.toString() !== toKeep._id.toString(),
       );
 
       for (const membership of toDelete) {
         console.log(
-          `  Removing duplicate membership ${membership._id} (${membership.userId}, status=${membership.status}) – keeping ${toKeep._id} (${toKeep.userId}, status=${toKeep.status}) for ${key}`,
+          `  Removing duplicate membership ${membership._id} (status=${membership.status}) - keeping ${toKeep._id} (status=${toKeep.status}) for ${key}`,
         );
         await Membership.deleteOne({ _id: membership._id });
         deletedDuplicates += 1;
@@ -153,13 +151,12 @@ module.exports = {
 
       const toKeep = pickInvitationToKeep(group);
       const toDelete = group.filter(
-        (invitation) =>
-          invitation._id.toString() !== toKeep._id.toString(),
+        (invitation) => invitation._id.toString() !== toKeep._id.toString(),
       );
 
       for (const invitation of toDelete) {
         console.log(
-          `  Removing duplicate invitation ${invitation._id} (token=${invitation.token}, status=${invitation.status}) – keeping ${toKeep._id} (token=${toKeep.token}, status=${toKeep.status}) for ${key}`,
+          `  Removing duplicate invitation ${invitation._id} (status=${invitation.status}) - keeping ${toKeep._id} (status=${toKeep.status}) for ${key}`,
         );
         await Invitation.deleteOne({ _id: invitation._id });
         await Membership.updateMany(

--- a/migrations/scripts/02-07-2026-normalize-membership-invitation-user-ids.js
+++ b/migrations/scripts/02-07-2026-normalize-membership-invitation-user-ids.js
@@ -1,0 +1,198 @@
+function normalizeUserId(userId) {
+  return String(userId || "").trim().toLowerCase();
+}
+
+function getMembershipTimestamp(membership) {
+  return new Date(membership.updatedAt || membership.createdAt || 0).getTime();
+}
+
+function isAcceptedMembership(membership) {
+  return membership.status === "active";
+}
+
+/**
+ * When duplicate memberships exist for the same tenant + email (case variants):
+ * - Prefer an accepted (active) membership over any non-accepted one.
+ * - If none are accepted, keep the newest record.
+ */
+function pickMembershipToKeep(memberships) {
+  const accepted = memberships.filter(isAcceptedMembership);
+  const candidates =
+    accepted.length > 0 ? accepted : [...memberships];
+
+  return candidates.sort(
+    (a, b) => getMembershipTimestamp(b) - getMembershipTimestamp(a),
+  )[0];
+}
+
+function getInvitationTimestamp(invitation) {
+  return new Date(invitation.updatedAt || invitation.createdAt || 0).getTime();
+}
+
+function isConsumedInvitation(invitation) {
+  return (
+    (invitation.usedCount || 0) >= 1 || invitation.status === "exhausted"
+  );
+}
+
+function isActiveSingleInvitation(invitation) {
+  return (
+    invitation.type === "single" &&
+    invitation.status === "active" &&
+    (invitation.usedCount || 0) < 1
+  );
+}
+
+/**
+ * When duplicate single-use invitations exist for the same tenant + email:
+ * - Prefer a consumed invitation over an unused duplicate.
+ * - If none are consumed, keep the newest active invitation.
+ * - Otherwise keep the newest record.
+ */
+function pickInvitationToKeep(invitations) {
+  const consumed = invitations.filter(isConsumedInvitation);
+  if (consumed.length > 0) {
+    return consumed.sort(
+      (a, b) => getInvitationTimestamp(b) - getInvitationTimestamp(a),
+    )[0];
+  }
+
+  const active = invitations.filter(isActiveSingleInvitation);
+  const candidates = active.length > 0 ? active : [...invitations];
+
+  return candidates.sort(
+    (a, b) => getInvitationTimestamp(b) - getInvitationTimestamp(a),
+  )[0];
+}
+
+module.exports = {
+  name: "02-07-2026-normalize-membership-invitation-user-ids",
+  pickMembershipToKeep,
+  pickInvitationToKeep,
+  normalizeUserId,
+
+  up: async function (mongoose) {
+    const Membership = mongoose.model("Membership");
+    const Invitation = mongoose.model("Invitation");
+
+    const allMemberships = await Membership.find({}).lean();
+    const groups = new Map();
+
+    for (const membership of allMemberships) {
+      const key = `${membership.tenantId}::${normalizeUserId(membership.userId)}`;
+      if (!groups.has(key)) {
+        groups.set(key, []);
+      }
+      groups.get(key).push(membership);
+    }
+
+    let deletedDuplicates = 0;
+
+    for (const [key, group] of groups) {
+      if (group.length <= 1) {
+        continue;
+      }
+
+      const toKeep = pickMembershipToKeep(group);
+      const toDelete = group.filter(
+        (membership) =>
+          membership._id.toString() !== toKeep._id.toString(),
+      );
+
+      for (const membership of toDelete) {
+        console.log(
+          `  Removing duplicate membership ${membership._id} (${membership.userId}, status=${membership.status}) – keeping ${toKeep._id} (${toKeep.userId}, status=${toKeep.status}) for ${key}`,
+        );
+        await Membership.deleteOne({ _id: membership._id });
+        deletedDuplicates += 1;
+      }
+    }
+
+    console.log(`Removed ${deletedDuplicates} duplicate membership(s)`);
+
+    const membershipsToNormalize = await Membership.find({
+      userId: { $exists: true, $ne: "" },
+    });
+
+    let normalizedMemberships = 0;
+
+    for (const membership of membershipsToNormalize) {
+      const normalizedUserId = normalizeUserId(membership.userId);
+      if (membership.userId !== normalizedUserId) {
+        await Membership.updateOne(
+          { _id: membership._id },
+          { $set: { userId: normalizedUserId } },
+        );
+        normalizedMemberships += 1;
+      }
+    }
+
+    console.log(`Normalized ${normalizedMemberships} membership userId(s)`);
+
+    const singleInvitations = await Invitation.find({
+      type: "single",
+      intendedUserId: { $exists: true, $nin: [null, ""] },
+    }).lean();
+
+    const invitationGroups = new Map();
+
+    for (const invitation of singleInvitations) {
+      const key = `${invitation.tenantId}::${normalizeUserId(invitation.intendedUserId)}`;
+      if (!invitationGroups.has(key)) {
+        invitationGroups.set(key, []);
+      }
+      invitationGroups.get(key).push(invitation);
+    }
+
+    let deletedInvitationDuplicates = 0;
+
+    for (const [key, group] of invitationGroups) {
+      if (group.length <= 1) {
+        continue;
+      }
+
+      const toKeep = pickInvitationToKeep(group);
+      const toDelete = group.filter(
+        (invitation) =>
+          invitation._id.toString() !== toKeep._id.toString(),
+      );
+
+      for (const invitation of toDelete) {
+        console.log(
+          `  Removing duplicate invitation ${invitation._id} (token=${invitation.token}, status=${invitation.status}) – keeping ${toKeep._id} (token=${toKeep.token}, status=${toKeep.status}) for ${key}`,
+        );
+        await Invitation.deleteOne({ _id: invitation._id });
+        await Membership.updateMany(
+          { tenantId: invitation.tenantId },
+          { $pull: { invitations: { token: invitation.token } } },
+        );
+        deletedInvitationDuplicates += 1;
+      }
+    }
+
+    console.log(
+      `Removed ${deletedInvitationDuplicates} duplicate invitation(s)`,
+    );
+
+    const invitationsToNormalize = await Invitation.find({
+      intendedUserId: { $exists: true, $nin: [null, ""] },
+    });
+
+    let normalizedInvitations = 0;
+
+    for (const invitation of invitationsToNormalize) {
+      const normalizedUserId = normalizeUserId(invitation.intendedUserId);
+      if (invitation.intendedUserId !== normalizedUserId) {
+        await Invitation.updateOne(
+          { _id: invitation._id },
+          { $set: { intendedUserId: normalizedUserId } },
+        );
+        normalizedInvitations += 1;
+      }
+    }
+
+    console.log(
+      `Normalized ${normalizedInvitations} invitation intendedUserId(s)`,
+    );
+  },
+};

--- a/migrations/scripts/02-07-2026-normalize-membership-invitation-user-ids.js
+++ b/migrations/scripts/02-07-2026-normalize-membership-invitation-user-ids.js
@@ -191,5 +191,22 @@ module.exports = {
     console.log(
       `Normalized ${normalizedInvitations} invitation intendedUserId(s)`,
     );
+
+    // Build invitation indexes after deduplication/normalization so startup
+    // cannot fail on legacy duplicates before this migration has run.
+    await Invitation.collection.createIndex({ token: 1 }, { unique: true });
+    await Invitation.collection.createIndex(
+      { tenantId: 1, intendedUserId: 1 },
+      {
+        unique: true,
+        collation: { locale: "en", strength: 2 },
+        partialFilterExpression: {
+          type: "single",
+          status: "active",
+          usedCount: { $lt: 1 },
+          intendedUserId: { $exists: true, $ne: "" },
+        },
+      },
+    );
   },
 };

--- a/src/commons/data-managers/invitation-manager.js
+++ b/src/commons/data-managers/invitation-manager.js
@@ -1,4 +1,5 @@
 const InvitationModel = require("./models/invitationModel");
+const { normalizeUserId } = require("../utilities/user-id-utils");
 
 class InvitationManager {
   static async getInvitationsByTenantID(tenantID) {
@@ -17,14 +18,14 @@ class InvitationManager {
   static async getInvitationsByTenantIDAndUserID(tenantID, userID) {
     const rawInvitation = await InvitationModel.find({
       tenantId: tenantID,
-      intendedUserId: userID,
+      intendedUserId: normalizeUserId(userID),
     });
     return rawInvitation.map((raw) => raw.toEntity());
   }
 
   static async getInvitationByUserID(userID) {
     const rawInvitation = await InvitationModel.find({
-      intendedUserId: userID,
+      intendedUserId: normalizeUserId(userID),
     });
     return rawInvitation.map((raw) => raw.toEntity());
   }

--- a/src/commons/data-managers/membership-manager.js
+++ b/src/commons/data-managers/membership-manager.js
@@ -1,5 +1,6 @@
 const MembershipModel = require("./models/membershipModel");
 const Membership = require("../entities/tenant/membership");
+const { normalizeUserId } = require("../utilities/user-id-utils");
 
 class MembershipManager {
   static async getMemberships() {
@@ -13,7 +14,9 @@ class MembershipManager {
   }
 
   static async getMembershipsByUserID(userID) {
-    const rawMembership = await MembershipModel.find({ userId: userID });
+    const rawMembership = await MembershipModel.find({
+      userId: normalizeUserId(userID),
+    });
     if (!rawMembership) return [];
     return rawMembership.map((raw) => raw.toEntity());
   }
@@ -21,7 +24,7 @@ class MembershipManager {
   static async getMembershipByTenantAndUserID(tenantID, userID) {
     const rawMembership = await MembershipModel.findOne({
       tenantId: tenantID,
-      userId: userID,
+      userId: normalizeUserId(userID),
     });
     if (!rawMembership) {
       return null;
@@ -48,21 +51,21 @@ class MembershipManager {
 
   static async addRoleToMembership(tenantID, userID, role) {
     await MembershipModel.updateOne(
-      { tenantId: tenantID, userId: userID },
+      { tenantId: tenantID, userId: normalizeUserId(userID) },
       { $addToSet: { roles: role } },
     );
   }
 
   static async setRolesForMembership(tenantID, userID, roles) {
     await MembershipModel.updateOne(
-      { tenantId: tenantID, userId: userID },
+      { tenantId: tenantID, userId: normalizeUserId(userID) },
       { $set: { roles: roles } },
     );
   }
 
   static async removeRoleFromMembership(tenantID, userID, role) {
     await MembershipModel.updateOne(
-      { tenantId: tenantID, userId: userID },
+      { tenantId: tenantID, userId: normalizeUserId(userID) },
       { $pull: { roles: role } },
     );
   }
@@ -70,13 +73,13 @@ class MembershipManager {
   static async removeMembership(tenantID, userID) {
     await MembershipModel.deleteOne({
       tenantId: tenantID,
-      userId: userID,
+      userId: normalizeUserId(userID),
     });
   }
 
   static async updateMembership(tenantID, userID, updates) {
     await MembershipModel.updateOne(
-      { tenantId: tenantID, userId: userID },
+      { tenantId: tenantID, userId: normalizeUserId(userID) },
       { $set: updates },
     );
   }
@@ -84,8 +87,8 @@ class MembershipManager {
   static async reassignUserId(previousUserId, newUserId, session = null) {
     const options = session ? { session } : {};
     await MembershipModel.updateMany(
-      { userId: previousUserId },
-      { $set: { userId: newUserId } },
+      { userId: normalizeUserId(previousUserId) },
+      { $set: { userId: normalizeUserId(newUserId) } },
       options,
     );
   }

--- a/src/commons/data-managers/models/invitationModel.js
+++ b/src/commons/data-managers/models/invitationModel.js
@@ -8,6 +8,18 @@ const InvitationSchema = new Schema(invitationSchemaDefinition, {
 });
 
 InvitationSchema.index({ token: 1 }, { unique: true });
+InvitationSchema.index(
+  { tenantId: 1, intendedUserId: 1 },
+  {
+    unique: true,
+    partialFilterExpression: {
+      type: "single",
+      status: "active",
+      usedCount: { $lt: 1 },
+      intendedUserId: { $exists: true, $ne: "" },
+    },
+  },
+);
 
 InvitationSchema.methods.toEntity = function () {
   const Invitation = require("../../entities/tenant/invitation");

--- a/src/commons/data-managers/models/invitationModel.js
+++ b/src/commons/data-managers/models/invitationModel.js
@@ -5,6 +5,7 @@ const { Schema } = mongoose;
 
 const InvitationSchema = new Schema(invitationSchemaDefinition, {
   timestamps: true,
+  autoIndex: false,
 });
 
 InvitationSchema.index({ token: 1 }, { unique: true });
@@ -12,6 +13,7 @@ InvitationSchema.index(
   { tenantId: 1, intendedUserId: 1 },
   {
     unique: true,
+    collation: { locale: "en", strength: 2 },
     partialFilterExpression: {
       type: "single",
       status: "active",

--- a/src/commons/entities/tenant/invitation.js
+++ b/src/commons/entities/tenant/invitation.js
@@ -8,7 +8,11 @@ class Invitation {
 
     Object.keys(invitationSchemaDefinition).forEach((key) => {
       if (params[key] !== undefined) {
-        this[key] = params[key];
+        if (key === "intendedUserId" && typeof params[key] === "string") {
+          this[key] = params[key].trim().toLowerCase();
+        } else {
+          this[key] = params[key];
+        }
       }
     });
   }

--- a/src/commons/entities/tenant/membership.js
+++ b/src/commons/entities/tenant/membership.js
@@ -8,7 +8,11 @@ class Membership {
 
     Object.keys(membershipSchemaDefinition).forEach((key) => {
       if (params[key] !== undefined) {
-        this[key] = params[key];
+        if (key === "userId" && typeof params[key] === "string") {
+          this[key] = params[key].trim().toLowerCase();
+        } else {
+          this[key] = params[key];
+        }
       }
     });
   }

--- a/src/commons/services/invitation-service.js
+++ b/src/commons/services/invitation-service.js
@@ -65,10 +65,25 @@ class InvitationService {
       challenges: challengeRefs,
     });
 
-    return await InvitationManager.createInvitation(
-      params.tenantId,
-      invitation,
-    );
+    try {
+      return await InvitationManager.createInvitation(
+        params.tenantId,
+        invitation,
+      );
+    } catch (error) {
+      if (
+        params.type === "single" &&
+        params.intendedUserId &&
+        isDuplicateSingleInvitationError(error)
+      ) {
+        throw {
+          message: "Active invitation already exists for this user",
+          code: 409,
+        };
+      }
+
+      throw error;
+    }
   }
 
   static async sendInvitationMail(tenantID, token, recipientEmail = null) {
@@ -513,7 +528,10 @@ class InvitationService {
     for (const membership of memberships) {
       if (membership.status === "suspended") continue;
       for (const invite of membership.invitations || []) {
-        if (invite.status === "pending" || invite.status === "pending_approval") {
+        if (
+          invite.status === "pending" ||
+          invite.status === "pending_approval"
+        ) {
           membershipTokens.add(invite.token);
         }
       }
@@ -768,6 +786,10 @@ class InvitationService {
 }
 
 module.exports = InvitationService;
+
+function isDuplicateSingleInvitationError(error) {
+  return error && error.code === 11000;
+}
 
 function validateInvitation(invitation, tenantID, userID = null) {
   if (!invitation) {

--- a/src/commons/services/invitation-service.js
+++ b/src/commons/services/invitation-service.js
@@ -5,6 +5,7 @@ const crypto = require("crypto");
 const InvitationManager = require("../data-managers/invitation-manager");
 const ChallengeManager = require("../data-managers/challenge-manager");
 const ChallengeService = require("./challenge/challenge-service");
+const { normalizeUserId, userIdsMatch } = require("../utilities/user-id-utils");
 
 class InvitationService {
   static async createInvitation(
@@ -20,6 +21,30 @@ class InvitationService {
   ) {
     if (!params.tenantId) {
       throw new Error("Tenant ID is required to create an invitation");
+    }
+
+    if (params.intendedUserId) {
+      params.intendedUserId = normalizeUserId(params.intendedUserId);
+    }
+
+    if (params.type === "single" && params.intendedUserId) {
+      const existingInvitations =
+        await InvitationManager.getInvitationsByTenantIDAndUserID(
+          params.tenantId,
+          params.intendedUserId,
+        );
+      const activeDuplicate = existingInvitations.find(
+        (invitation) =>
+          invitation.type === "single" &&
+          invitation.status === "active" &&
+          invitation.usedCount < 1,
+      );
+      if (activeDuplicate) {
+        throw {
+          message: "Active invitation already exists for this user",
+          code: 409,
+        };
+      }
     }
 
     const token = crypto.randomBytes(32).toString("hex");
@@ -442,7 +467,7 @@ class InvitationService {
 
     if (
       invitation &&
-      invitation.intendedUserId === userID &&
+      userIdsMatch(invitation.intendedUserId, userID) &&
       invitation.type === "single"
     ) {
       await InvitationManager.deleteInvitation(tenantID, token);
@@ -524,7 +549,7 @@ class InvitationService {
 
     validateInvitation(invitation, tenantID, userID);
 
-    if (invitation.intendedUserId !== userID) {
+    if (!userIdsMatch(invitation.intendedUserId, userID)) {
       throw new Error("This invitation is not intended for you");
     }
 
@@ -776,7 +801,7 @@ function validateInvitation(invitation, tenantID, userID = null) {
   if (
     userID &&
     invitation.intendedUserId &&
-    invitation.intendedUserId !== userID
+    !userIdsMatch(invitation.intendedUserId, userID)
   ) {
     throw { message: "This invitation is not intended for you", code: 403 };
   }

--- a/src/commons/utilities/user-id-utils.js
+++ b/src/commons/utilities/user-id-utils.js
@@ -1,0 +1,21 @@
+/**
+ * Normalize a user identifier (email) for storage and comparison.
+ * @param {string} userId
+ * @returns {string}
+ */
+function normalizeUserId(userId) {
+  return String(userId || "").trim().toLowerCase();
+}
+
+/**
+ * Case-insensitive comparison of two user identifiers.
+ * @param {string} a
+ * @param {string} b
+ * @returns {boolean}
+ */
+function userIdsMatch(a, b) {
+  if (a == null || b == null) return false;
+  return normalizeUserId(a) === normalizeUserId(b);
+}
+
+module.exports = { normalizeUserId, userIdsMatch };

--- a/src/platform/api/controllers/invitation-controller.js
+++ b/src/platform/api/controllers/invitation-controller.js
@@ -2,6 +2,7 @@ const InvitationService = require("../../../commons/services/invitation-service"
 const PermissionService = require("../../../commons/services/permission-service");
 const { RolePermission } = require("../../../commons/entities/role/role");
 const TenantManager = require("../../../commons/data-managers/tenant-manager");
+const { normalizeUserId } = require("../../../commons/utilities/user-id-utils");
 const bunyan = require("bunyan");
 
 const logger = bunyan.createLogger({
@@ -80,7 +81,9 @@ class InvitationController {
         challenges,
       } = request.body;
 
-      const sanitizedUserId = intendedUserId?.toLowerCase()?.trim();
+      const sanitizedUserId = intendedUserId
+        ? normalizeUserId(intendedUserId)
+        : null;
 
       if (
         !(await PermissionService._allowUpdateAny(
@@ -236,6 +239,11 @@ class InvitationController {
       const tenantID = request.params.tenant;
       const user = request.user;
       const { userId: userID } = request.body;
+      const normalizedUserId = normalizeUserId(userID);
+
+      if (!normalizedUserId) {
+        return response.status(400).send("User ID is required");
+      }
 
       if (
         !(await PermissionService._allowUpdateAny(
@@ -249,7 +257,7 @@ class InvitationController {
           .send("Forbidden: You don't have permission to resend invitations.");
       }
 
-      await InvitationService.resendInvitationMail(tenantID, userID);
+      await InvitationService.resendInvitationMail(tenantID, normalizedUserId);
 
       response
         .status(200)

--- a/src/platform/api/controllers/tenant-controller.js
+++ b/src/platform/api/controllers/tenant-controller.js
@@ -21,6 +21,10 @@ const {
 const {
   mergeDefaultMailSnippets,
 } = require("../../../commons/mail-service/templates/default-mail-snippets");
+const {
+  normalizeUserId,
+  userIdsMatch,
+} = require("../../../commons/utilities/user-id-utils");
 
 const logger = bunyan.createLogger({
   name: "tenant-controller.js",
@@ -414,8 +418,12 @@ class TenantController {
 
       const roles = body.roles;
       const challenges = body.challenges || [];
-      const userId = body.userId;
+      const userId = normalizeUserId(body.userId);
       const type = body.type || "manually";
+
+      if (!userId) {
+        return response.status(400).send("User ID is required");
+      }
 
       if (
         await PermissionService._allowUpdateAny(
@@ -427,7 +435,9 @@ class TenantController {
         const membership =
           await MembershipManager.getMembershipsByTenantID(tenantId);
 
-        const userAlreadyInTenant = membership.find((m) => m.userId === userId);
+        const userAlreadyInTenant = membership.find((m) =>
+          userIdsMatch(m.userId, userId),
+        );
         if (userAlreadyInTenant) {
           return response.status(400).send("User already in tenant");
         }
@@ -493,7 +503,9 @@ class TenantController {
       }
     } catch (error) {
       logger.error(error);
-      response.status(500).send("Could not add user to tenant");
+      response
+        .status(error.code || 500)
+        .send(error.message || "Could not add user to tenant");
     }
   }
 
@@ -663,8 +675,12 @@ class TenantController {
   static async addOwner(request, response) {
     try {
       const tenantId = request.params.id;
-      const { userId } = request.body;
+      const userId = normalizeUserId(request.body.userId);
       const user = request.user;
+
+      if (!userId) {
+        return response.status(400).send("User ID is required");
+      }
 
       if (
         (await PermissionService._isTenantOwner(user.id, tenantId)) ||

--- a/tests/user-id-utils.test.js
+++ b/tests/user-id-utils.test.js
@@ -21,6 +21,12 @@ describe("user-id-utils", () => {
     expect(userIdsMatch("A@test.de", "a@test.de")).to.equal(true);
     expect(userIdsMatch("a@test.de", "b@test.de")).to.equal(false);
   });
+
+  it("normalizes nullish user ids to an empty string", () => {
+    expect(normalizeUserId(null)).to.equal("");
+    expect(normalizeUserId(undefined)).to.equal("");
+    expect(userIdsMatch(null, undefined)).to.equal(false);
+  });
 });
 
 describe("Invitation entity", () => {

--- a/tests/user-id-utils.test.js
+++ b/tests/user-id-utils.test.js
@@ -1,0 +1,121 @@
+const { expect } = require("chai");
+const {
+  normalizeUserId,
+  userIdsMatch,
+} = require("../src/commons/utilities/user-id-utils");
+const Invitation = require("../src/commons/entities/tenant/invitation");
+const Membership = require("../src/commons/entities/tenant/membership");
+const {
+  pickMembershipToKeep,
+  pickInvitationToKeep,
+} = require("../migrations/scripts/02-07-2026-normalize-membership-invitation-user-ids");
+
+describe("user-id-utils", () => {
+  it("normalizes email to lowercase and trims whitespace", () => {
+    expect(normalizeUserId("  A.Beispiel@Musterstadt.de  ")).to.equal(
+      "a.beispiel@musterstadt.de",
+    );
+  });
+
+  it("matches user ids case-insensitively", () => {
+    expect(userIdsMatch("A@test.de", "a@test.de")).to.equal(true);
+    expect(userIdsMatch("a@test.de", "b@test.de")).to.equal(false);
+  });
+});
+
+describe("Invitation entity", () => {
+  it("lowercases intendedUserId on construction", () => {
+    const invitation = new Invitation({
+      intendedUserId: "A.Beispiel@Musterstadt.de",
+      tenantId: "tenant-1",
+      token: "token",
+      type: "single",
+    });
+
+    expect(invitation.intendedUserId).to.equal("a.beispiel@musterstadt.de");
+  });
+});
+
+describe("Membership entity", () => {
+  it("lowercases userId on construction", () => {
+    const membership = new Membership({
+      userId: "A.Beispiel@Musterstadt.de",
+      tenantId: "tenant-1",
+      source: "invite",
+    });
+
+    expect(membership.userId).to.equal("a.beispiel@musterstadt.de");
+  });
+});
+
+describe("membership duplicate resolution", () => {
+  it("keeps the accepted membership when one is active and one is pending", () => {
+    const active = {
+      _id: "1",
+      status: "active",
+      createdAt: new Date("2026-01-01"),
+    };
+    const pending = {
+      _id: "2",
+      status: "pending",
+      createdAt: new Date("2026-06-01"),
+    };
+
+    expect(pickMembershipToKeep([pending, active])._id).to.equal("1");
+  });
+
+  it("keeps the newest membership when none are accepted", () => {
+    const older = {
+      _id: "1",
+      status: "pending",
+      createdAt: new Date("2026-01-01"),
+    };
+    const newer = {
+      _id: "2",
+      status: "pending",
+      createdAt: new Date("2026-06-01"),
+    };
+
+    expect(pickMembershipToKeep([older, newer])._id).to.equal("2");
+  });
+});
+
+describe("invitation duplicate resolution", () => {
+  it("keeps the consumed invitation when one is used and one is still active", () => {
+    const consumed = {
+      _id: "1",
+      type: "single",
+      status: "exhausted",
+      usedCount: 1,
+      createdAt: new Date("2026-01-01"),
+    };
+    const active = {
+      _id: "2",
+      type: "single",
+      status: "active",
+      usedCount: 0,
+      createdAt: new Date("2026-06-01"),
+    };
+
+    expect(pickInvitationToKeep([active, consumed])._id).to.equal("1");
+  });
+
+  it("keeps the newest active invitation when none are consumed", () => {
+    const older = {
+      _id: "1",
+      type: "single",
+      status: "active",
+      usedCount: 0,
+      createdAt: new Date("2026-01-01"),
+    };
+    const newer = {
+      _id: "2",
+      type: "single",
+      status: "active",
+      usedCount: 0,
+      createdAt: new Date("2026-06-01"),
+    };
+
+    expect(pickInvitationToKeep([older, newer])._id).to.equal("2");
+  });
+});


### PR DESCRIPTION
## Summary
- normalize user IDs (email identifiers) consistently across invitation, membership, controller, and manager layers
- prevent duplicate active single-use invitations for the same tenant/user at creation time
- add migration `02-07-2026-normalize-membership-invitation-user-ids` to normalize existing IDs and deduplicate conflicting memberships/invitations (including cleanup of stale membership invitation tokens)
- add/extend tests for normalization and duplicate-resolution selection logic
- document these changes in `docs/CHANGELOG.md`

## Test plan
- [x] `npx mocha tests/user-id-utils.test.js`
- [x] run full backend test suite in CI
- [x] validate migration behavior on staging dataset with case-variant invitation/membership duplicates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consistent user ID normalization across invitation creation/management, membership actions, and resend flows.
  * Added safeguards to prevent duplicate active single-use invitations per tenant and intended user.
* **Bug Fixes**
  * Invitation acceptance, rejection, verification, and resend now match intended users case-insensitively and ignore whitespace.
  * Membership and tenant member/owner actions now correctly identify users despite case/spacing differences.
  * Existing conflicting invitations and memberships are deduplicated and normalized.
* **Changed**
  * Preparation lead time now applies to time-period and block-period bookables.
* **Tests**
  * Added coverage for user ID normalization and duplicate resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->