### PR TITLE
Fix MongoDB partial index compatibility for invitation uniqueness

### DIFF
--- a/migrations/scripts/02-07-2026-normalize-membership-invitation-user-ids.js
+++ b/migrations/scripts/02-07-2026-normalize-membership-invitation-user-ids.js
@@ -204,7 +204,7 @@ module.exports = {
           type: "single",
           status: "active",
           usedCount: { $lt: 1 },
-          intendedUserId: { $exists: true, $ne: "" },
+          intendedUserId: { $exists: true, $type: "string", $gt: "" },
         },
       },
     );

--- a/src/commons/data-managers/models/invitationModel.js
+++ b/src/commons/data-managers/models/invitationModel.js
@@ -18,7 +18,7 @@ InvitationSchema.index(
       type: "single",
       status: "active",
       usedCount: { $lt: 1 },
-      intendedUserId: { $exists: true, $ne: "" },
+      intendedUserId: { $exists: true, $type: "string", $gt: "" },
     },
   },
 );


### PR DESCRIPTION
## Summary
- replace unsupported `$ne` condition in invitation partial indexes with `$type: "string"` and `$gt: ""`
- align both migration index creation and invitation model index definition
- prevent startup failure (`CannotCreateIndex`) on MongoDB versions that reject `$ne` in partial index expressions

## Test plan
- [ ] Deploy branch and start application
- [ ] Verify migration `02-07-2026-normalize-membership-invitation-user-ids` runs without index creation error
- [ ] Confirm invitation flows still prevent duplicate active single-use invitations per tenant + intended user

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened invitation validation for uniqueness checks so only non-empty string user IDs are included.
  * Reduced the chance of duplicate active invitations being accepted when the intended user ID is blank or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->