### PR TITLE
Add manual collective invoice support for group bookings (DEV-791).

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 ## [Unreleased]
 
+### Added
+
+- Admins can manually create a collective invoice for all bookings in a group booking, with optional email delivery
+
 ## [4.1.3] — 2026-07-02
 
 ### Fixed

--- a/src/commons/services/booking-consitency-service.js
+++ b/src/commons/services/booking-consitency-service.js
@@ -86,6 +86,23 @@ function checkSamePaymentProvider(bookings) {
 }
 
 /**
+ * Ensures all bookings use invoice as payment provider.
+ *
+ * @param {Array<Object>} bookings - The list of bookings to check.
+ * @throws {ConsistencyError} If any booking does not use invoice payment.
+ */
+function checkInvoicePaymentProvider(bookings) {
+  const bad = bookings.find((b) => b.paymentProvider !== "invoice");
+  if (bad) {
+    throw new ConsistencyError(
+      "INVOICE_PAYMENT_REQUIRED",
+      "All bookings must use invoice payment provider",
+      { bookingId: bad.id },
+    );
+  }
+}
+
+/**
  * Ensures all bookings are paid.
  *
  * @param {Array<Object>} bookings - The list of bookings to check.
@@ -165,6 +182,7 @@ module.exports = {
   checkSameOwner,
   checkSameStatus,
   checkSamePaymentProvider,
+  checkInvoicePaymentProvider,
   checkPayedStatus,
   validatePaymentProviderRequirement,
   checkSameContactDetails,

--- a/src/commons/services/checkout/booking-service.js
+++ b/src/commons/services/checkout/booking-service.js
@@ -11,6 +11,7 @@ const {
   ManualBundleCheckoutService,
 } = require("./bundle-checkout-service");
 const ReceiptService = require("../payment/receipt-service");
+const InvoiceService = require("../payment/invoice-service");
 const LockerService = require("../locker/locker-service");
 const EventManager = require("../../data-managers/event-manager");
 const { isEmail } = require("validator");
@@ -28,6 +29,7 @@ const {
   checkSameContactDetails,
   checkSameStatus,
   checkSamePaymentProvider,
+  checkInvoicePaymentProvider,
   checkPayedStatus,
   validatePaymentProviderRequirement,
 } = require("../booking-consitency-service");
@@ -1398,6 +1400,65 @@ class BookingService {
     }
 
     return { success: true };
+  }
+
+  /**
+   * Creates an aggregated invoice for a group booking and attaches it to all bookings.
+   * @param {string} tenantId
+   * @param {string[]} bookingIds
+   * @param {string|null} groupBookingId
+   * @param {{ validate?: boolean }} [options]
+   * @returns {Promise<{ success: boolean, errors?: object[], invoice?: object, name?: string, invoiceId?: string, revision?: number, mail?: string, bookingIds?: string[] }>}
+   */
+  static async createAggregatedInvoice(
+    tenantId,
+    bookingIds,
+    groupBookingId = null,
+    { validate = true } = {},
+  ) {
+    const bookings = await BookingManager.getBookings(tenantId, bookingIds);
+
+    if (validate) {
+      const validator = new BookingConsistencyService([
+        checkSameContactDetails,
+        checkSameStatus,
+        checkSamePaymentProvider,
+        checkInvoicePaymentProvider,
+      ]);
+
+      const errors = validator.validate(bookings);
+      if (errors.length > 0) {
+        logger.error(
+          `${tenantId} -- bookings ${bookingIds} cannot create invoice: ${JSON.stringify(
+            errors,
+          )}`,
+        );
+        return { success: false, errors };
+      }
+    }
+
+    const {
+      invoice,
+      name,
+      invoiceId,
+      revision,
+      mail,
+      bookingIds: updatedBookingIds,
+    } = await InvoiceService.issueAggregatedInvoice(
+      tenantId,
+      bookings.map((b) => b.id),
+      groupBookingId,
+    );
+
+    return {
+      success: true,
+      invoice,
+      name,
+      invoiceId,
+      revision,
+      mail,
+      bookingIds: updatedBookingIds,
+    };
   }
 
   static async handleSingleBookingRequestConfirmation(

--- a/src/commons/services/payment/invoice-service.js
+++ b/src/commons/services/payment/invoice-service.js
@@ -122,6 +122,30 @@ class InvoiceService {
     }
   }
 
+  /**
+   * Creates an aggregated invoice and attaches it to all bookings in the group.
+   * @param {string} tenantId
+   * @param {string[]} bookingIds
+   * @param {string|null} [groupBookingId]
+   * @returns {Promise<{ invoice: object, name: string, invoiceId: string, revision: number, mail: string, bookingIds: string[] }>}
+   */
+  static async issueAggregatedInvoice(tenantId, bookingIds, groupBookingId) {
+    const bookings = await BookingManager.getBookings(tenantId, bookingIds);
+    const invoiceData = await InvoiceService.createAggregatedInvoice(
+      tenantId,
+      bookingIds,
+      groupBookingId,
+    );
+
+    await _attachAggregatedInvoiceToBookings(bookings, invoiceData);
+
+    return {
+      ...invoiceData,
+      mail: bookings[0].mail,
+      bookingIds: bookings.map((b) => b.id),
+    };
+  }
+
   static async getInvoice(tenantId, invoiceName) {
     try {
       return await NextcloudManager.getFile({
@@ -147,6 +171,23 @@ class InvoiceService {
 }
 
 module.exports = InvoiceService;
+
+async function _attachAggregatedInvoiceToBookings(
+  bookings,
+  { name, invoiceId, revision, timeCreated },
+) {
+  for (const booking of bookings) {
+    booking.attachments.push({
+      type: "invoice",
+      name,
+      invoiceId,
+      revision,
+      timeCreated,
+      aggregated: true,
+    });
+    await BookingManager.storeBooking(booking);
+  }
+}
 
 async function _createInvoiceNumber(tenantId, bookingId) {
   const tenant = await TenantManager.getTenant(tenantId);

--- a/src/commons/services/payment/providers/InvoicePaymentService.js
+++ b/src/commons/services/payment/providers/InvoicePaymentService.js
@@ -120,42 +120,23 @@ class InvoicePaymentService extends PaymentService {
   }
 
   async createAggregatedInvoice() {
-    const bookings = [];
-    for (const bookingId of this.bookingIds) {
-      const booking = await BookingManager.getBooking(bookingId, this.tenantId);
-      bookings.push(booking);
-    }
-
-    const { invoice, name, invoiceId, revision, timeCreated } =
-      await InvoiceService.createAggregatedInvoice(
-        this.tenantId,
-        this.bookingIds,
-        this.groupBookingId,
-      );
-
-    for (const booking of bookings) {
-      booking.attachments.push({
-        type: "invoice",
-        name,
-        invoiceId,
-        revision,
-        timeCreated,
-        aggregated: true,
-      });
-      await BookingManager.storeBooking(booking);
-    }
+    const result = await InvoiceService.issueAggregatedInvoice(
+      this.tenantId,
+      this.bookingIds,
+      this.groupBookingId,
+    );
 
     const attachments = [
       {
-        filename: name,
-        content: invoice.buffer,
+        filename: result.name,
+        content: result.invoice.buffer,
         contentType: "application/pdf",
       },
     ];
 
     try {
       await MailController.sendInvoice(
-        bookings[0].mail,
+        result.mail,
         this.bookingIds,
         this.tenantId,
         attachments,
@@ -167,9 +148,9 @@ class InvoicePaymentService extends PaymentService {
 
     return {
       bookingIds: this.bookingIds,
-      name,
-      invoiceId,
-      revision,
+      name: result.name,
+      invoiceId: result.invoiceId,
+      revision: result.revision,
     };
   }
 
@@ -232,40 +213,22 @@ class InvoicePaymentService extends PaymentService {
   }
 
   async aggregatedPaymentRequest() {
-    const bookings = [];
-    for (const bookingId of this.bookingIds) {
-      const booking = await BookingManager.getBooking(bookingId, this.tenantId);
-      bookings.push(booking);
-    }
-
-    const { invoice, name, invoiceId, revision, timeCreated } =
-      await InvoiceService.createAggregatedInvoice(
-        this.tenantId,
-        this.bookingIds,
-        this.groupBookingId,
-      );
-
-    for (const booking of bookings) {
-      booking.attachments.push({
-        type: "invoice",
-        name,
-        invoiceId,
-        revision,
-        timeCreated,
-      });
-      await BookingManager.storeBooking(booking);
-    }
+    const result = await InvoiceService.issueAggregatedInvoice(
+      this.tenantId,
+      this.bookingIds,
+      this.groupBookingId,
+    );
 
     const attachments = [
       {
-        filename: name,
-        content: invoice.buffer,
+        filename: result.name,
+        content: result.invoice.buffer,
         contentType: "application/pdf",
       },
     ];
     await MailController.sendInvoiceAfterBookingApproval(
-      bookings[0].mail,
-      bookings.map((b) => b.id),
+      result.mail,
+      result.bookingIds,
       this.tenantId,
       attachments,
       true,

--- a/src/platform/api/api-router-tenant-related.js
+++ b/src/platform/api/api-router-tenant-related.js
@@ -285,6 +285,11 @@ router.post(
   AuthenticationController.isSignedIn,
   GroupBookingController.createGroupBookingReceipt,
 );
+router.post(
+  "/group-bookings/:id/invoice",
+  AuthenticationController.isSignedIn,
+  GroupBookingController.createGroupBookingInvoice,
+);
 
 // CHECKOUT
 // ========

--- a/src/platform/api/controllers/group-booking-controller.js
+++ b/src/platform/api/controllers/group-booking-controller.js
@@ -4,6 +4,8 @@ const PermissionsService = require("../../../commons/services/permission-service
 const { RolePermission } = require("../../../commons/entities/role/role");
 const BookingService = require("../../../commons/services/checkout/booking-service");
 const WorkflowService = require("../../../commons/services/workflow/workflow-service");
+const TenantManager = require("../../../commons/data-managers/tenant-manager");
+const MailController = require("../../../commons/mail-service/mail-controller");
 
 const logger = bunyan.createLogger({
   name: "group-booking-controller.js",
@@ -400,6 +402,99 @@ class GroupBookingController {
         );
         res.status(403).send({
           message: "User not allowed to create group booking receipt",
+        });
+      }
+    } catch (error) {
+      res.status(500).send({ message: error.message });
+    }
+  }
+
+  static async createGroupBookingInvoice(req, res) {
+    try {
+      const tenantId = req.params.tenant;
+      const user = req.user;
+      const groupBookingId = req.params.id;
+      const shouldSendEmail = req.query.sendEmail !== "false";
+
+      const groupBooking = await GroupBookingManager.getGroupBooking(
+        tenantId,
+        groupBookingId,
+      );
+
+      if (
+        user &&
+        (await PermissionsService._allowUpdate(
+          groupBooking,
+          user.id,
+          tenantId,
+          RolePermission.MANAGE_BOOKINGS,
+        ))
+      ) {
+        const invoiceApp = await TenantManager.getTenantApp(tenantId, "invoice");
+        if (!invoiceApp || !invoiceApp.active) {
+          return res.status(400).send({
+            message: "Invoice app not found or inactive.",
+          });
+        }
+
+        const result = await BookingService.createAggregatedInvoice(
+          tenantId,
+          groupBooking.bookingIds,
+          groupBookingId,
+        );
+
+        if (!result.success) {
+          return res.status(200).json({
+            success: false,
+            data: null,
+            errors: result.errors,
+          });
+        }
+
+        if (shouldSendEmail) {
+          const attachments = [
+            {
+              filename: result.name,
+              content: result.invoice.buffer,
+              contentType: "application/pdf",
+            },
+          ];
+
+          try {
+            await MailController.sendInvoice(
+              result.mail,
+              result.bookingIds,
+              tenantId,
+              attachments,
+              true,
+            );
+          } catch (err) {
+            logger.error(
+              "Error while sending aggregated invoice:",
+              groupBookingId,
+              err,
+            );
+          }
+        }
+
+        const updatedGroupBooking = await GroupBookingManager.getGroupBooking(
+          tenantId,
+          groupBookingId,
+          true,
+        );
+
+        return res.status(200).json({
+          success: true,
+          data: updatedGroupBooking,
+          errors: [],
+        });
+      } else {
+        logger.error(
+          { tenantId: tenantId, user: user.id },
+          "User not allowed to create group booking invoice",
+        );
+        res.status(403).send({
+          message: "User not allowed to create group booking invoice",
         });
       }
     } catch (error) {


### PR DESCRIPTION
Enable admins to create and optionally email a collective invoice for all bookings in a group, and centralize aggregated invoice persistence to avoid circular dependency issues during group booking commit.