### PR TITLE
Refactor authenticateIfNeeded logic to support Keycloak token verification

### DIFF
--- a/src/commons/utilities/auth-utils.js
+++ b/src/commons/utilities/auth-utils.js
@@ -1,4 +1,8 @@
 const JwtHelper = require("./jwt-helper");
+const KeycloakVerifier = require("./keycloak-verifier");
+const jwt = require("jsonwebtoken");
+const { classifyToken } = require("./token-classifier");
+const UserManager = require("../data-managers/user-manager");
 
 /**
  * Authenticate request if condition is met
@@ -15,14 +19,70 @@ const authenticateIfNeeded = async (req, condition) => {
     throw new Error("Access token required");
   }
 
-  const token = authHeader.substring(7);
-  const decoded = await JwtHelper.verifyToken(token);
+  const token = JwtHelper.extractToken(authHeader);
 
-  // Normalize payload shape for controller code expecting user.id.
-  return {
-    ...decoded,
-    id: decoded.sub,
-  };
+  if (!token) {
+    return res.status(401).json({
+      success: false,
+      message: "Access token required",
+    });
+  }
+
+  const unverified = jwt.decode(token);
+
+  if (!unverified) {
+    return res.status(401).json({
+      success: false,
+      message: "Invalid token",
+    });
+  }
+
+  const tokenType = classifyToken(unverified);
+
+  if (tokenType === "keycloak") {
+    const decoded = await KeycloakVerifier.verifyToken(token);
+
+    let user;
+    try {
+      user = await UserManager.resolveKeycloakUser(decoded);
+    } catch (error) {
+      if (error.status === 404) {
+        return res.status(401).json({
+          success: false,
+          message: "User not found in local system",
+        });
+      }
+      throw error;
+    }
+
+    if (user.isSuspended) {
+      return res.status(403).json({
+        success: false,
+        message: "User account is suspended",
+      });
+    }
+
+    return user;
+  } else {
+    const decoded = JwtHelper.verifyToken(token);
+
+    const user = await UserManager.getUser(decoded.sub);
+    if (!user) {
+      return res.status(401).json({
+        success: false,
+        message: "User not found",
+      });
+    }
+
+    if (user.isSuspended) {
+      return res.status(403).json({
+        success: false,
+        message: "User account is suspended",
+      });
+    }
+
+    return user;
+  }
 };
 
 module.exports = { authenticateIfNeeded };

--- a/src/commons/utilities/auth-utils.js
+++ b/src/commons/utilities/auth-utils.js
@@ -14,75 +14,47 @@ const authenticateIfNeeded = async (req, condition) => {
   if (!condition) return null;
 
   const authHeader = req.headers.authorization;
-
-  if (!authHeader || !authHeader.startsWith("Bearer ")) {
-    throw new Error("Access token required");
-  }
-
   const token = JwtHelper.extractToken(authHeader);
 
-  if (!token) {
-    return res.status(401).json({
-      success: false,
-      message: "Access token required",
-    });
-  }
+  if (!token) return null;
 
   const unverified = jwt.decode(token);
-
-  if (!unverified) {
-    return res.status(401).json({
-      success: false,
-      message: "Invalid token",
-    });
-  }
+  if (!unverified) return null;
 
   const tokenType = classifyToken(unverified);
 
   if (tokenType === "keycloak") {
     const decoded = await KeycloakVerifier.verifyToken(token);
 
-    let user;
     try {
-      user = await UserManager.resolveKeycloakUser(decoded);
+      const user = await UserManager.resolveKeycloakUser(decoded);
+      if (!user || user.isSuspended) return null;
+
+      return {
+        id: user.id,
+        authType: "keycloak",
+        keycloakSub: decoded.sub,
+        jti: decoded.jti || null,
+        tokenVersion: null,
+        isLegacy: false,
+      };
     } catch (error) {
-      if (error.status === 404) {
-        return res.status(401).json({
-          success: false,
-          message: "User not found in local system",
-        });
-      }
+      if (error.status === 404) return null;
       throw error;
     }
-
-    if (user.isSuspended) {
-      return res.status(403).json({
-        success: false,
-        message: "User account is suspended",
-      });
-    }
-
-    return user;
-  } else {
-    const decoded = JwtHelper.verifyToken(token);
-
-    const user = await UserManager.getUser(decoded.sub);
-    if (!user) {
-      return res.status(401).json({
-        success: false,
-        message: "User not found",
-      });
-    }
-
-    if (user.isSuspended) {
-      return res.status(403).json({
-        success: false,
-        message: "User account is suspended",
-      });
-    }
-
-    return user;
   }
+
+  const decoded = JwtHelper.verifyToken(token);
+  const user = await UserManager.getUser(decoded.sub);
+  if (!user || user.isSuspended) return null;
+
+  return {
+    id: decoded.sub,
+    authType: "local",
+    jti: decoded.jti || null,
+    tokenVersion: decoded.v,
+    isLegacy: decoded.isLegacy || false,
+  };
 };
 
 module.exports = { authenticateIfNeeded };

--- a/src/commons/utilities/token-classifier.js
+++ b/src/commons/utilities/token-classifier.js
@@ -1,0 +1,18 @@
+/**
+ * Bestimmt anhand des Token-Payloads, ob es ein Keycloak-
+ * oder ein lokales Token ist.
+ */
+function classifyToken(decoded) {
+  // Keycloak-Tokens haben typischerweise "realm_access",
+  // "azp" (authorized party) und der Issuer enthält "/realms/"
+  if (
+    decoded.azp ||
+    decoded.realm_access ||
+    (decoded.iss && decoded.iss.includes("/realms/"))
+  ) {
+    return "keycloak";
+  }
+  return "local";
+}
+
+module.exports = { classifyToken };

--- a/src/middleware/auth-middleware.js
+++ b/src/middleware/auth-middleware.js
@@ -8,22 +8,7 @@ const logger = bunyan.createLogger({
   level: process.env.LOG_LEVEL || "info",
 });
 
-/**
- * Bestimmt anhand des Token-Payloads, ob es ein Keycloak-
- * oder ein lokales Token ist.
- */
-function classifyToken(decoded) {
-  // Keycloak-Tokens haben typischerweise "realm_access",
-  // "azp" (authorized party) und der Issuer enthält "/realms/"
-  if (
-    decoded.azp ||
-    decoded.realm_access ||
-    (decoded.iss && decoded.iss.includes("/realms/"))
-  ) {
-    return "keycloak";
-  }
-  return "local";
-}
+const { classifyToken } = require("../commons/utilities/token-classifier");
 
 const requireAuth = async (req, res, next) => {
   try {


### PR DESCRIPTION
## Fehlerbescheibung
Folgender Fehler besteht bei der Authentifizierung eines Keycloak users, bei Routen die noch die authenticateIfNeeded Methode nutzen:

```
{"name":"app","hostname":"a740566968a6","pid":428,"component":"RequestLogger","level":30,"method":"GET","url":"/api/default/bookables/4637ebe1-ca31-4ce0-a696-36af69b612b5/bookings?related=true&parent=true","path":"/api/default/bookables/4637ebe1-ca31-4ce0-a696-36af69b612b5/bookings","baseUrl":"","originalUrl":"/api/default/bookables/4637ebe1-ca31-4ce0-a696-36af69b612b5/bookings?related=true&parent=true","query":{"related":"true","parent":"true"},"params":{},"headers":{"host":"booking-backend:8083","user-agent":"GuzzleHttp/7","authorization":"[PRESENT]"},"ip":"::ffff:172.18.0.11","timestamp":"2026-07-07T17:57:42.788Z","msg":"GET /api/default/bookables/4637ebe1-ca31-4ce0-a696-36af69b612b5/bookings?related=true&parent=true","time":"2026-07-07T17:57:42.788Z","v":0}

{"name":"jwt-helper","hostname":"a740566968a6","pid":428,"level":50,"msg":"Token verification failed: invalid algorithm","time":"2026-07-07T17:57:42.800Z","v":0}

{"name":"booking-controller.js","hostname":"a740566968a6","pid":428,"level":50,"err":{"message":"invalid algorithm","name":"JsonWebTokenError","stack":"JsonWebTokenError: invalid algorithm\n    at /app/node_modules/jsonwebtoken/verify.js:145:19\n    at getSecret (/app/node_modules/jsonwebtoken/verify.js:97:14)\n    at module.exports [as verify] (/app/node_modules/jsonwebtoken/verify.js:101:10)\n    at JwtHelper.verifyToken (/app/src/commons/utilities/jwt-helper.js:108:27)\n    at authenticateIfNeeded (/app/src/commons/utilities/auth-utils.js:19:35)\n    at getRelatedBookings (/app/src/platform/api/controllers/booking-controller.js:219:28)\n    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)"},"msg":"invalid algorithm","time":"2026-07-07T17:57:42.800Z","v":0}
```

Das Problem besteht weil Keycloak-SSO User sich nicht per JWT-Token, der vom Backend generiert wurde, sondern mittels Keycloak-Access-Token authentifizieren. Die Methode authenticateIfNeeded, die zum Beispiel in BookingController.getRelatedBookings() genutzt wird, führte jedoch nur eine JWT-Token-Verifikation durch, anstatt einer Keycloak-Token Verifikation.

## Beschreibung der Lösung
Der Vorschlag zur Behebung des Fehlers passt die Logik der authenticateIfNeeded am Vorbild der Middleware-Methode optionalAuth an. Dazu wurde die classifyToken Methode in einen eigenen Utility-File verschoben und je nach Token-Typ wird dann entweder`JwtHelper.verifyToken(token)` oder `KeycloakVerifier.verifyToken(token)` durchgeführt und bei Erfolg der User anhand des Tokens resolved. So kann der Keycloak-Token wieder richtig verifiziert werden.

Kann eventuell die Methode authenticateIfNeeded zukünftig zu Gunsten von optionalAuth komplett entfallen oder die Logik der Methoden weiter zusammengefasst werden, um Code-Redundanz zwischen den beiden Methoden zu reduzieren?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sign-in and session handling for different token types by better detecting and classifying incoming bearer tokens.
  - Authentication now handles Keycloak-based tokens and standard/local tokens more reliably during verification.
  - When accounts are missing or suspended, users receive consistent outcomes (no access) with appropriate unauthorized/forbidden behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->