### PR TITLE
Fix assignedUserId for manual admin bookings (DEV-799)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Manual admin bookings now set `assignedUserId` from the booking email so the assigned user can see the booking in their personal booking list
+
 ## [4.1.4] — 2026-07-03
 
 ### Added

--- a/src/commons/services/checkout/bundle-checkout-service.js
+++ b/src/commons/services/checkout/bundle-checkout-service.js
@@ -6,6 +6,7 @@ const { BookableManager } = require("../../data-managers/bookable-manager");
 const BookingManager = require("../../data-managers/booking-manager");
 const CouponManager = require("../../data-managers/coupon-manager");
 const LockerService = require("../locker/locker-service");
+const { primaryEmailFromMail } = require("../../utilities/checkout-utils");
 
 /**
  * Class representing a bundle checkout service.
@@ -517,6 +518,7 @@ class ManualBundleCheckoutService extends BundleCheckoutService {
 
   async prepareBooking(options = {}) {
     const booking = await super.prepareBooking(options);
+    booking.assignedUserId = primaryEmailFromMail(this.email);
     booking.internalComments = this.internalComments;
     booking.rejectionReason = this.rejectionReason;
 

--- a/src/commons/utilities/checkout-utils.js
+++ b/src/commons/utilities/checkout-utils.js
@@ -1,6 +1,19 @@
 const { v4: uuidv4 } = require("uuid");
 const UserManager = require("../data-managers/user-manager");
 
+function primaryEmailFromMail(mail) {
+  if (!mail) {
+    return "";
+  }
+
+  const primary = mail
+    .split(/[,\n]+/)
+    .map((email) => email.trim())
+    .filter(Boolean)[0];
+
+  return primary ? primary.toLowerCase() : "";
+}
+
 async function resolveCheckoutId(checkoutId, userID, tenantId) {
     if (checkoutId) {
     return { checkoutId, generated: false };
@@ -20,4 +33,4 @@ async function resolveCheckoutId(checkoutId, userID, tenantId) {
   return { checkoutId: "01" + uuidv4(), generated: true };
 }
 
-module.exports = { resolveCheckoutId };
+module.exports = { resolveCheckoutId, primaryEmailFromMail };

--- a/tests/manual-booking-assigned-user.test.js
+++ b/tests/manual-booking-assigned-user.test.js
@@ -1,0 +1,61 @@
+const assert = require("assert");
+const sinon = require("sinon");
+const {
+  primaryEmailFromMail,
+} = require("../src/commons/utilities/checkout-utils");
+const {
+  BundleCheckoutService,
+  ManualBundleCheckoutService,
+} = require("../src/commons/services/checkout/bundle-checkout-service");
+
+describe("primaryEmailFromMail", () => {
+  it("returns the first email in lowercase", () => {
+    assert.strictEqual(
+      primaryEmailFromMail("Nutzer@Example.com"),
+      "nutzer@example.com",
+    );
+  });
+
+  it("uses the first address from multi-email values", () => {
+    assert.strictEqual(
+      primaryEmailFromMail("first@example.com, second@example.com"),
+      "first@example.com",
+    );
+  });
+
+  it("returns an empty string when mail is missing", () => {
+    assert.strictEqual(primaryEmailFromMail(""), "");
+    assert.strictEqual(primaryEmailFromMail(null), "");
+  });
+});
+
+describe("ManualBundleCheckoutService assignedUserId", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("sets assignedUserId from the booking email instead of the admin user", async () => {
+    sinon.stub(BundleCheckoutService.prototype, "prepareBooking").resolves({
+      assignedUserId: "admin@example.com",
+      mail: "Nutzer@Example.com",
+    });
+
+    const service = new ManualBundleCheckoutService({
+      user: "admin@example.com",
+      tenant: "tenant-1",
+      timeBegin: Date.now(),
+      timeEnd: Date.now() + 3600000,
+      bookableItems: [],
+      email: "Nutzer@Example.com",
+      name: "Nutzer",
+      isCommit: true,
+      isPayed: true,
+      isRejected: false,
+    });
+
+    const booking = await service.prepareBooking();
+
+    assert.strictEqual(booking.assignedUserId, "nutzer@example.com");
+    assert.strictEqual(booking.mail, "Nutzer@Example.com");
+  });
+});


### PR DESCRIPTION
## Summary
- Manual admin bookings now set `assignedUserId` from the booking email instead of the admin user ID
- Adds `primaryEmailFromMail()` helper for consistent lowercase user ID resolution
- Ensures customers can see admin-created bookings in their personal booking list via `getAssignedBookings`

## Test plan
- [x] `npx mocha tests/manual-booking-assigned-user.test.js`
- [x] Create a manual booking in admin with a customer email and verify `assignedUserId` matches that email
- [x] Log in as the customer and confirm the booking appears in the personal booking list
- [x] Verify existing self-service bookings are unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Manual admin bookings are now assigned using the booking email, ensuring they appear in the correct personal booking list.
  - Email addresses are normalized by selecting the first valid address and converting it to lowercase.

- **Tests**
  - Added coverage for email normalization and manual booking assignment behavior.

- **Documentation**
  - Updated the unreleased changelog with the booking assignment fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->