### PR TITLE
feat(DEV-792): expose groupBookingAllowed in JSON catalog

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,8 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 
 ### Added
+- JSON catalog bookables expose aggregated `groupBookingAllowed` flag indicating whether the current user may create series bookings (combines `groupBooking.enabled` and `groupBooking.permittedRoles`)
+- Shared `GroupBookingPermissions` utility reused by JSON catalog and checkout controllers for consistent series-booking permission checks
 - Supervisor booking notifications: per-membership `bookingNotificationRecipients` (types `user`, `role`, `email`; max. 10 entries) resolved and mailed on booking creation for single and group bookings
 - Tenant feature flag `notifySupervisorsOnBooking` (default `false`) to enable supervisor notifications per tenant
 - Admin endpoint `POST /tenants/:id/update-user-booking-notification-recipients` (requires `manageUsers.updateAny`) to manage recipients on memberships

--- a/src/commons/utilities/group-booking-permissions.js
+++ b/src/commons/utilities/group-booking-permissions.js
@@ -1,0 +1,25 @@
+class GroupBookingPermissions {
+  /**
+   * Whether the current user may create a group booking for this bookable.
+   * Aggregates groupBooking.enabled and groupBooking.permittedRoles.
+   */
+  static isAllowed(bookable, identity, userRoles) {
+    const gb = bookable?.groupBooking;
+    if (!gb?.enabled) {
+      return false;
+    }
+
+    const permitted = Array.isArray(gb.permittedRoles) ? gb.permittedRoles : [];
+    if (permitted.length === 0) {
+      return true;
+    }
+
+    if (!identity) {
+      return false;
+    }
+
+    return userRoles?.some((role) => permitted.includes(role)) ?? false;
+  }
+}
+
+module.exports = { GroupBookingPermissions };

--- a/src/platform/api/controllers/checkout-controller.js
+++ b/src/platform/api/controllers/checkout-controller.js
@@ -9,6 +9,9 @@ const {
 } = require("../../../commons/data-managers/bookable-manager");
 const MembershipManager = require("../../../commons/data-managers/membership-manager");
 const {
+  GroupBookingPermissions,
+} = require("../../../commons/utilities/group-booking-permissions");
+const {
   resolveCheckoutId,
 } = require("../../../commons/utilities/checkout-utils");
 const logger = bunyan.createLogger({
@@ -170,16 +173,13 @@ class CheckoutController {
         .send("Group booking not enabled for this bookable");
     }
 
-    let allowed = false;
     const permitted = Array.isArray(gb.permittedRoles) ? gb.permittedRoles : [];
+    if (permitted.length > 0 && !user) {
+      return res.status(401).send("Unauthorized");
+    }
 
-    if (permitted.length === 0) {
-      allowed = true;
-    } else {
-      if (!user) {
-        return res.status(401).send("Unauthorized");
-      }
-      let userRoles;
+    let userRoles = [];
+    if (user) {
       try {
         const membership =
           await MembershipManager.getMembershipByTenantAndUserID(
@@ -194,10 +194,9 @@ class CheckoutController {
         );
         return res.status(500).send("Error while loading user roles");
       }
-      allowed = userRoles.some((r) => permitted.includes(r));
     }
 
-    if (!allowed) {
+    if (!GroupBookingPermissions.isAllowed(bookable, user, userRoles)) {
       logger.error(
         `User ${user?.id} not allowed to create group booking for bookable ${bookableItem.id}`,
       );

--- a/src/platform/api/v2/controllers/checkout.controller.js
+++ b/src/platform/api/v2/controllers/checkout.controller.js
@@ -8,6 +8,9 @@ const {
 } = require("../../../../commons/data-managers/bookable-manager");
 const MembershipManager = require("../../../../commons/data-managers/membership-manager");
 const {
+  GroupBookingPermissions,
+} = require("../../../../commons/utilities/group-booking-permissions");
+const {
   resolveCheckoutId,
 } = require("../../../../commons/utilities/checkout-utils");
 const {
@@ -287,29 +290,29 @@ class CheckoutControllerV2 {
       const permitted = Array.isArray(gb.permittedRoles)
         ? gb.permittedRoles
         : [];
-      if (permitted.length > 0) {
-        if (!user) {
-          throw new CheckoutError({
-            reason: CHECKOUT_REASONS.UNAUTHORIZED,
-            statusCode: 401,
-          });
-        }
+      if (permitted.length > 0 && !user) {
+        throw new CheckoutError({
+          reason: CHECKOUT_REASONS.UNAUTHORIZED,
+          statusCode: 401,
+        });
+      }
 
+      let userRoles = [];
+      if (user) {
         const membership =
           await MembershipManager.getMembershipByTenantAndUserID(
             tenantId,
             user.id,
           );
-        const userRoles = membership?.roles || [];
-        const allowed = userRoles.some((r) => permitted.includes(r));
+        userRoles = membership?.roles || [];
+      }
 
-        if (!allowed) {
-          throw new CheckoutError({
-            reason: CHECKOUT_REASONS.GROUP_BOOKING_ROLE_REQUIRED,
-            statusCode: 403,
-            params: { requiredRoles: permitted },
-          });
-        }
+      if (!GroupBookingPermissions.isAllowed(bookable, user, userRoles)) {
+        throw new CheckoutError({
+          reason: CHECKOUT_REASONS.GROUP_BOOKING_ROLE_REQUIRED,
+          statusCode: 403,
+          params: { requiredRoles: permitted },
+        });
       }
 
       const bookingAttempts = rawAttempts.map((attempt) => ({

--- a/src/platform/json-engine/controllers/json-controller.js
+++ b/src/platform/json-engine/controllers/json-controller.js
@@ -8,6 +8,9 @@ const ExternalPriceService = require("../../../commons/services/external-price-s
 const {
   enforceTenantCatalogAccess,
 } = require("../../../commons/utilities/catalog-participation-utils");
+const {
+  GroupBookingPermissions,
+} = require("../../../commons/utilities/group-booking-permissions");
 
 class JSONController {
   static _sendCatalogAccessError(res, error) {
@@ -41,12 +44,22 @@ class JSONController {
     return `${process.env.FRONTEND_URL}/checkout/?id=${bookableId}&tenant=${tenantId}`;
   }
 
-  static async _exportPublicBookable(bookable, tenantId, instance) {
+  static async _exportPublicBookable(
+    bookable,
+    tenantId,
+    instance,
+    { identity, userRoles } = {},
+  ) {
     const pub = bookable.exportPublic();
     pub.checkoutUrl = await JSONController._checkoutUrl(
       bookable.id,
       tenantId,
       instance,
+    );
+    pub.groupBookingAllowed = GroupBookingPermissions.isAllowed(
+      bookable,
+      identity,
+      userRoles,
     );
     return pub;
   }
@@ -104,6 +117,7 @@ class JSONController {
           bookable,
           tenantId,
           checkoutInstance,
+          { identity, userRoles },
         );
 
         const extPrices = await ExternalPriceService.resolve(
@@ -126,7 +140,10 @@ class JSONController {
           );
         pub.relatedBookables = await Promise.all(
           pub.relatedBookables.map((b) =>
-            JSONController._exportPublicBookable(b, tenantId, checkoutInstance),
+            JSONController._exportPublicBookable(b, tenantId, checkoutInstance, {
+              identity,
+              userRoles,
+            }),
           ),
         );
         return pub;
@@ -171,6 +188,7 @@ class JSONController {
           bookable,
           tenantId,
           checkoutInstance,
+          { identity, userRoles },
         );
 
         const extPrices = await ExternalPriceService.resolve(
@@ -196,7 +214,10 @@ class JSONController {
           );
         pub.relatedBookables = await Promise.all(
           pub.relatedBookables.map((b) =>
-            JSONController._exportPublicBookable(b, tenantId, checkoutInstance),
+            JSONController._exportPublicBookable(b, tenantId, checkoutInstance, {
+              identity,
+              userRoles,
+            }),
           ),
         );
 
@@ -225,6 +246,8 @@ class JSONController {
     }
 
     try {
+      const identity = req.user;
+      const userRoles = await JSONController.getUserRoles(tenantId, identity);
       let events = await EventManager.getEvents(tenantId);
       const checkoutInstance = await InstanceManager.getInstance();
 
@@ -266,6 +289,7 @@ class JSONController {
                 ticket,
                 tenantId,
                 checkoutInstance,
+                { identity, userRoles },
               ),
             ),
         );
@@ -286,6 +310,8 @@ class JSONController {
     }
 
     try {
+      const identity = req.user;
+      const userRoles = await JSONController.getUserRoles(tenantId, identity);
       const event = await EventManager.getEvent(id, tenantId);
       const checkoutInstance = await InstanceManager.getInstance();
 
@@ -304,6 +330,7 @@ class JSONController {
                 ticket,
                 tenantId,
                 checkoutInstance,
+                { identity, userRoles },
               ),
             ),
         );

--- a/tests/group-booking-permissions.test.js
+++ b/tests/group-booking-permissions.test.js
@@ -1,0 +1,95 @@
+const { expect } = require("chai");
+const {
+  GroupBookingPermissions,
+} = require("../src/commons/utilities/group-booking-permissions");
+
+describe("group-booking-permissions", () => {
+  const identity = { id: "user-1" };
+
+  function bookable(overrides = {}) {
+    return {
+      groupBooking: { enabled: false, permittedRoles: [] },
+      ...overrides,
+    };
+  }
+
+  describe("isAllowed", () => {
+    it("returns false when group booking is disabled", () => {
+      expect(
+        GroupBookingPermissions.isAllowed(
+          bookable({
+            groupBooking: { enabled: false, permittedRoles: [] },
+          }),
+          identity,
+          ["admin"],
+        ),
+      ).to.equal(false);
+    });
+
+    it("returns true when enabled without role restrictions for guests", () => {
+      expect(
+        GroupBookingPermissions.isAllowed(
+          bookable({
+            groupBooking: { enabled: true, permittedRoles: [] },
+          }),
+          null,
+          null,
+        ),
+      ).to.equal(true);
+    });
+
+    it("returns true when enabled without role restrictions for logged-in users", () => {
+      expect(
+        GroupBookingPermissions.isAllowed(
+          bookable({
+            groupBooking: { enabled: true, permittedRoles: [] },
+          }),
+          identity,
+          ["member"],
+        ),
+      ).to.equal(true);
+    });
+
+    it("returns false when roles are required but user is not logged in", () => {
+      expect(
+        GroupBookingPermissions.isAllowed(
+          bookable({
+            groupBooking: { enabled: true, permittedRoles: ["staff"] },
+          }),
+          null,
+          null,
+        ),
+      ).to.equal(false);
+    });
+
+    it("returns true when user has a permitted role", () => {
+      expect(
+        GroupBookingPermissions.isAllowed(
+          bookable({
+            groupBooking: { enabled: true, permittedRoles: ["staff", "admin"] },
+          }),
+          identity,
+          ["staff"],
+        ),
+      ).to.equal(true);
+    });
+
+    it("returns false when user lacks a permitted role", () => {
+      expect(
+        GroupBookingPermissions.isAllowed(
+          bookable({
+            groupBooking: { enabled: true, permittedRoles: ["staff"] },
+          }),
+          identity,
+          ["member"],
+        ),
+      ).to.equal(false);
+    });
+
+    it("returns false when groupBooking is missing", () => {
+      expect(GroupBookingPermissions.isAllowed({}, identity, ["staff"])).to.equal(
+        false,
+      );
+    });
+  });
+});

--- a/tests/json-group-booking.test.js
+++ b/tests/json-group-booking.test.js
@@ -1,0 +1,156 @@
+const assert = require("assert");
+const sinon = require("sinon");
+const JSONController = require("../src/platform/json-engine/controllers/json-controller");
+const {
+  BookableManager,
+} = require("../src/commons/data-managers/bookable-manager");
+const MembershipManager = require("../src/commons/data-managers/membership-manager");
+const InstanceManager = require("../src/commons/data-managers/instance-manager");
+const ExternalPriceService = require("../src/commons/services/external-price-service");
+const TenantManager = require("../src/commons/data-managers/tenant-manager");
+const { Bookable } = require("../src/commons/entities/bookable/bookable");
+
+function createMockResponse() {
+  const res = {
+    statusCode: null,
+    body: null,
+    headers: {},
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+    send(payload) {
+      this.body = payload;
+      return this;
+    },
+    setHeader(key, value) {
+      this.headers[key] = value;
+      return this;
+    },
+  };
+  return res;
+}
+
+function createBookable(overrides = {}) {
+  return new Bookable({
+    id: "bookable-1",
+    tenantId: "tenant-1",
+    title: "Test Bookable",
+    type: "resource",
+    isPublic: true,
+    isBookable: true,
+    groupBooking: { enabled: false, permittedRoles: [] },
+    ...overrides,
+  });
+}
+
+describe("json-controller groupBookingAllowed", () => {
+  let getBookableStub;
+  let getInstanceStub;
+  let externalPriceStub;
+  let getMembershipStub;
+  let getTenantStub;
+
+  beforeEach(() => {
+    getTenantStub = sinon.stub(TenantManager, "getTenant").resolves({
+      id: "tenant-1",
+      catalogParticipation: { restricted: false },
+    });
+    getInstanceStub = sinon.stub(InstanceManager, "getInstance").resolves(null);
+    externalPriceStub = sinon
+      .stub(ExternalPriceService, "resolve")
+      .resolves(null);
+    getMembershipStub = sinon.stub(
+      MembershipManager,
+      "getMembershipByTenantAndUserID",
+    );
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("getBookable", () => {
+    it("sets groupBookingAllowed to true when enabled without role restrictions", async () => {
+      const bookable = createBookable({
+        groupBooking: { enabled: true, permittedRoles: [] },
+      });
+      getBookableStub = sinon
+        .stub(BookableManager, "getBookable")
+        .resolves(bookable);
+
+      const req = { params: { tenant: "tenant-1", id: "bookable-1" }, user: null };
+      const res = createMockResponse();
+
+      await JSONController.getBookable(req, res);
+
+      assert.strictEqual(res.statusCode, 200);
+      assert.strictEqual(res.body.groupBookingAllowed, true);
+      assert.ok(getBookableStub.calledOnce);
+      assert.ok(getTenantStub.calledOnce);
+    });
+
+    it("sets groupBookingAllowed to false when roles are required but user is not logged in", async () => {
+      const bookable = createBookable({
+        groupBooking: { enabled: true, permittedRoles: ["staff"] },
+      });
+      getBookableStub = sinon
+        .stub(BookableManager, "getBookable")
+        .resolves(bookable);
+
+      const req = { params: { tenant: "tenant-1", id: "bookable-1" }, user: null };
+      const res = createMockResponse();
+
+      await JSONController.getBookable(req, res);
+
+      assert.strictEqual(res.statusCode, 200);
+      assert.strictEqual(res.body.groupBookingAllowed, false);
+    });
+
+    it("sets groupBookingAllowed to true when user has a permitted role", async () => {
+      const bookable = createBookable({
+        groupBooking: { enabled: true, permittedRoles: ["staff"] },
+      });
+      getBookableStub = sinon
+        .stub(BookableManager, "getBookable")
+        .resolves(bookable);
+      getMembershipStub.resolves({ roles: ["staff"] });
+
+      const req = {
+        params: { tenant: "tenant-1", id: "bookable-1" },
+        user: { id: "user-1" },
+      };
+      const res = createMockResponse();
+
+      await JSONController.getBookable(req, res);
+
+      assert.strictEqual(res.statusCode, 200);
+      assert.strictEqual(res.body.groupBookingAllowed, true);
+      assert.ok(getMembershipStub.calledOnce);
+    });
+
+    it("sets groupBookingAllowed to false when group booking is disabled", async () => {
+      const bookable = createBookable({
+        groupBooking: { enabled: false, permittedRoles: [] },
+      });
+      getBookableStub = sinon
+        .stub(BookableManager, "getBookable")
+        .resolves(bookable);
+
+      const req = {
+        params: { tenant: "tenant-1", id: "bookable-1" },
+        user: { id: "user-1" },
+      };
+      const res = createMockResponse();
+
+      await JSONController.getBookable(req, res);
+
+      assert.strictEqual(res.statusCode, 200);
+      assert.strictEqual(res.body.groupBookingAllowed, false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add aggregated `groupBookingAllowed` field to JSON catalog bookable responses (bookables, related bookables, event tickets)
- Introduce shared `GroupBookingPermissions.isAllowed()` utility that combines `groupBooking.enabled` and `groupBooking.permittedRoles` checks for the current user
- Reuse the same permission logic in checkout controllers v1 and v2 to keep catalog and checkout behavior aligned

## Test plan
- [x] `npx mocha tests/group-booking-permissions.test.js tests/json-group-booking.test.js`
- [x] Verify `GET /json/:tenant/bookables` returns `groupBookingAllowed: true` for enabled bookables without role restrictions
- [x] Verify `groupBookingAllowed: false` for guests when `permittedRoles` are configured
- [x] Verify `groupBookingAllowed: true` for logged-in users with matching roles
- [x] Verify event ticket exports include the same field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added role-based access control for group bookings.
  - Group booking availability now reflects the viewer’s login status and permitted roles.
  - Public bookable and event details now include accurate group booking availability.

- **Bug Fixes**
  - Guests and users without required roles are correctly prevented from restricted group bookings.
  - Group bookings without role restrictions remain available as configured.

- **Tests**
  - Added coverage for authorization and publicly displayed group booking availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->