### PR TITLE
Hide cancellation button in emails when user cancellation is disabled

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,12 +9,15 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 ### Fixed
 
+- Booking emails no longer show a cancel button when `cancellationPolicy.userCancellable` is `false`; an optional `contactHint` is shown instead when configured
 - `authenticateIfNeeded` now verifies Keycloak access tokens in addition to local JWTs, fixing `invalid algorithm` errors for SSO users on routes such as related bookings, protected files, and private catalogs
 - Token type detection (`classifyToken`) extracted into a shared utility used by auth middleware and `authenticateIfNeeded`
 - Manual admin bookings now set `assignedUserId` from the booking email so the assigned user can see the booking in their personal booking list
 
 
 ### Added
+- Optional `cancellationPolicy.contactHint` on bookables and bookings for cancellation contact instructions in emails when user self-cancellation is disabled; bundle bookings aggregate all relevant hints from non-cancellable items
+- Migration `13-07-2026-add-cancellation-contact-hint` to backfill `contactHint` on existing bookables and bookings
 - JSON catalog bookables expose aggregated `groupBookingAllowed` flag indicating whether the current user may create series bookings (combines `groupBooking.enabled` and `groupBooking.permittedRoles`)
 - Shared `GroupBookingPermissions` utility reused by JSON catalog and checkout controllers for consistent series-booking permission checks
 - Supervisor booking notifications: per-membership `bookingNotificationRecipients` (types `user`, `role`, `email`; max. 10 entries) resolved and mailed on booking creation for single and group bookings

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -262,7 +262,7 @@ Example:
   "permittedRoles": ["role1", "role2"],
   "freeBookingUsers": ["user3"],
   "freeBookingRoles": ["role3"],
-  "cancellationPolicy": { "userCancellable": true },
+  "cancellationPolicy": { "userCancellable": true, "contactHint": "" },
 
   "relatedBookableIds": ["bookable1", "bookable2"],
   "checkoutBookableIds": [{ "bookableId": "bookable2", "mandatory": false }],
@@ -335,7 +335,7 @@ Key fields of a bookable:
 | relatedBookableIds    | IDs of bookables related to this bookable.                                                                                                                 |
 | checkoutBookableIds   | Additional bookables for checkout: `{ bookableId, mandatory }`.                                                                                          |
 | requiresLogin         | If `true`, only authenticated users may book.                                                                                                              |
-| cancellationPolicy    | e.g. `{ userCancellable: true }` — whether users can cancel bookings themselves.                                                                           |
+| cancellationPolicy    | e.g. `{ userCancellable: true, contactHint: "" }` — whether users can cancel bookings themselves; `contactHint` is an optional message shown in emails when user cancellation is disabled.                                                                           |
 | permittedUsers        | List of user IDs that are allowed to book. If empty, every user including guests may book (depending on other rules).                                     |
 | permittedRoles        | List of role IDs that are allowed to book. If empty, every user including guests may book (depending on other rules).                                     |
 | freeBookingUsers      | Users who can book this bookable for free.                                                                                                                 |
@@ -388,7 +388,7 @@ Example:
   "vatIncludedEur": 19,
   "_couponUsed": {},
   "customFieldValues": [],
-  "cancellationPolicy": { "userCancellable": true },
+  "cancellationPolicy": { "userCancellable": true, "contactHint": "" },
   "hooks": []
 }
 ```

--- a/migrations/scripts/13-07-2026-add-cancellation-contact-hint.js
+++ b/migrations/scripts/13-07-2026-add-cancellation-contact-hint.js
@@ -1,0 +1,33 @@
+module.exports = {
+  name: "13-07-2026-add-cancellation-contact-hint",
+
+  up: async function (mongoose) {
+    const Bookable = mongoose.model("Bookable");
+    const Booking = mongoose.model("Booking");
+
+    await Bookable.updateMany(
+      { "cancellationPolicy.contactHint": { $exists: false } },
+      { $set: { "cancellationPolicy.contactHint": "" } },
+    );
+
+    await Booking.updateMany(
+      { "cancellationPolicy.contactHint": { $exists: false } },
+      { $set: { "cancellationPolicy.contactHint": "" } },
+    );
+  },
+
+  down: async function (mongoose) {
+    const Bookable = mongoose.model("Bookable");
+    const Booking = mongoose.model("Booking");
+
+    await Bookable.updateMany(
+      {},
+      { $unset: { "cancellationPolicy.contactHint": "" } },
+    );
+
+    await Booking.updateMany(
+      {},
+      { $unset: { "cancellationPolicy.contactHint": "" } },
+    );
+  },
+};

--- a/src/commons/mail-service/mail-data.service.js
+++ b/src/commons/mail-service/mail-data.service.js
@@ -5,6 +5,27 @@ const QRCode = require("qrcode");
 const { renderSnippet } = require("./templates/template-loader");
 
 class MailDataService {
+  static buildCancellationMailContext(booking, tenantId, addRejectionLink = false) {
+    if (!addRejectionLink || !booking) {
+      return { rejectionUrl: null, cancellationContactHint: null };
+    }
+
+    const userCancellable = booking.cancellationPolicy?.userCancellable === true;
+
+    if (userCancellable) {
+      return {
+        rejectionUrl: `${process.env.FRONTEND_URL}/booking/request-reject/${tenantId}?id=${booking.id}`,
+        cancellationContactHint: null,
+      };
+    }
+
+    const contactHint = booking.cancellationPolicy?.contactHint?.trim();
+    return {
+      rejectionUrl: null,
+      cancellationContactHint: contactHint || null,
+    };
+  }
+
   static async getPopulatedBookables(bookingId, tenant) {
     const booking = await BookingManager.getBooking(bookingId, tenant);
     const bookables = (await BookableManager.getBookables(tenant)).filter((b) =>
@@ -90,14 +111,14 @@ class MailDataService {
       return { amount: item.amount, bookableTitle: bookable.title };
     });
 
-    const rejectionUrl = addRejectionLink
-      ? `${process.env.FRONTEND_URL}/booking/request-reject/${tenantId}?id=${bookingId}`
-      : null;
+    const { rejectionUrl, cancellationContactHint } =
+      this.buildCancellationMailContext(booking, tenantId, addRejectionLink);
 
     return renderSnippet("short-booking-details", {
       booking,
       bookingItems,
       rejectionUrl,
+      cancellationContactHint,
     });
   }
 

--- a/src/commons/mail-service/mail-sender.service.js
+++ b/src/commons/mail-service/mail-sender.service.js
@@ -92,6 +92,10 @@ class MailSenderService {
   }) {
     const tenant = await TenantManager.getTenant(tenantId);
 
+    const booking = bookingId
+      ? await BookingManager.getBooking(bookingId, tenantId)
+      : null;
+
     // Booking details
     const bookingDetails = bookingId
       ? await MailDataService.generateBookingDetails(bookingId, tenantId)
@@ -108,10 +112,12 @@ class MailSenderService {
       attachments = [...attachments, qrResult.attachment];
     }
 
-    // Rejection link
-    const rejectionUrl = addRejectionLink
-      ? `${process.env.FRONTEND_URL}/booking/request-reject/${tenantId}?id=${bookingId}`
-      : null;
+    const { rejectionUrl, cancellationContactHint } =
+      MailDataService.buildCancellationMailContext(
+        booking,
+        tenantId,
+        addRejectionLink,
+      );
 
     const snippetHtml = renderSnippet("single-booking-wrapper", {
       message,
@@ -120,6 +126,7 @@ class MailSenderService {
       rejectionReason,
       bookingDetails,
       rejectionUrl,
+      cancellationContactHint,
       qrContent,
       showFooter: true,
       supportEmail: tenant.mail,

--- a/src/commons/mail-service/templates/snippets/short-booking-details.hbs
+++ b/src/commons/mail-service/templates/snippets/short-booking-details.hbs
@@ -32,3 +32,10 @@
     Buchung stornieren
   </a>
 {{/if}}
+
+{{#if cancellationContactHint}}
+  <p>
+    <strong>Hinweis zur Stornierung:</strong>
+    {{sanitizeString cancellationContactHint}}
+  </p>
+{{/if}}

--- a/src/commons/mail-service/templates/snippets/single-booking-wrapper.hbs
+++ b/src/commons/mail-service/templates/snippets/single-booking-wrapper.hbs
@@ -52,6 +52,14 @@
   </a>
 {{/if}}
 
+{{#if cancellationContactHint}}
+  <br /><br />
+  <p>
+    <strong>Hinweis zur Stornierung:</strong>
+    {{sanitizeString cancellationContactHint}}
+  </p>
+{{/if}}
+
 {{#if qrContent}}
   <br />
   {{{qrContent}}}

--- a/src/commons/schemas/bookableSchema.js
+++ b/src/commons/schemas/bookableSchema.js
@@ -194,7 +194,7 @@ const bookableSchemaDefinition = {
   // Cancellation policy
   cancellationPolicy: {
     type: Object,
-    default: { userCancellable: true },
+    default: { userCancellable: true, contactHint: "" },
   },
 
   // Relationship properties

--- a/src/commons/schemas/bookingSchema.js
+++ b/src/commons/schemas/bookingSchema.js
@@ -100,7 +100,7 @@ const bookingSchemaDefinition = {
   },
   cancellationPolicy: {
     type: Object,
-    default: { userCancellable: true },
+    default: { userCancellable: true, contactHint: "" },
   },
 };
 

--- a/src/commons/services/checkout/bundle-checkout-service.js
+++ b/src/commons/services/checkout/bundle-checkout-service.js
@@ -232,14 +232,40 @@ class BundleCheckoutService {
    * Restrictive rule: every item must allow user cancellation, otherwise the
    * resulting booking is not user-cancellable.
    * @param {Array} bookableItems Bookable items with `_bookableUsed` populated.
-   * @returns {{userCancellable: boolean}} Aggregated policy.
+   * @returns {{userCancellable: boolean, contactHint?: string}} Aggregated policy.
    */
   aggregateCancellationPolicy(bookableItems) {
     const userCancellable = bookableItems.every(
       (item) =>
         item._bookableUsed?.cancellationPolicy?.userCancellable === true,
     );
-    return { userCancellable };
+
+    if (userCancellable) {
+      return { userCancellable };
+    }
+
+    const contactHints = [
+      ...new Set(
+        bookableItems
+          .filter(
+            (item) =>
+              item._bookableUsed?.cancellationPolicy?.userCancellable !== true,
+          )
+          .map((item) =>
+            item._bookableUsed?.cancellationPolicy?.contactHint?.trim(),
+          )
+          .filter(Boolean),
+      ),
+    ];
+
+    if (contactHints.length === 0) {
+      return { userCancellable };
+    }
+
+    return {
+      userCancellable,
+      contactHint: contactHints.join("\n\n"),
+    };
   }
 
   processAttachments(bookableItems, attachmentStatus) {


### PR DESCRIPTION
## Summary
- Respect `booking.cancellationPolicy.userCancellable` when rendering cancellation actions in booking emails
- Add optional `cancellationPolicy.contactHint` on bookables and bookings, aggregated for bundle checkouts
- Show a cancellation contact hint in emails only when user cancellation is disabled and a hint is configured; otherwise hide the cancel button without fallback text

## Context
Fixes DEV-787. The API already blocked self-service cancellations when `userCancellable` was `false`, but confirmation and invoice emails still showed a "Cancel booking" button.

## Test plan
- [x] Create a bookable with `cancellationPolicy.userCancellable: false` and no `contactHint`; complete a booking and verify the confirmation email has no cancel button and no hint text
- [x] Create a bookable with `userCancellable: false` and a `contactHint`; verify the email shows the hint and no cancel button
- [x] Create a booking with `userCancellable: true`; verify the cancel button is still shown
- [x] Create a bundle booking with multiple non-cancellable bookables that each have different hints; verify all relevant hints are shown
- [x] Run migration `13-07-2026-add-cancellation-contact-hint` on an existing database