### PR TITLE
Clean up bookable custom field values when definitions are deleted (DEV-668)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 ### Fixed
 
+- Deleting custom field definitions at instance, tenant, or bookable level now removes the corresponding `customFieldValues` entries from affected bookables (no backfill migration for existing orphaned values)
 - Booking emails no longer show a cancel button when `cancellationPolicy.userCancellable` is `false`; an optional `contactHint` is shown instead when configured
 - `authenticateIfNeeded` now verifies Keycloak access tokens in addition to local JWTs, fixing `invalid algorithm` errors for SSO users on routes such as related bookings, protected files, and private catalogs
 - Token type detection (`classifyToken`) extracted into a shared utility used by auth middleware and `authenticateIfNeeded`

--- a/src/commons/data-managers/bookable-manager.js
+++ b/src/commons/data-managers/bookable-manager.js
@@ -46,6 +46,30 @@ class BookableManager {
   }
 
   /**
+   * Remove stored custom field values for the given field IDs.
+   * @param {string[]} fieldIds Custom field IDs to remove from bookables
+   * @param {{ tenantId?: string, bookableId?: string }} [scope] Optional scope
+   * @returns {Promise<void>}
+   */
+  static async removeCustomFieldValues(fieldIds, scope = {}) {
+    if (!Array.isArray(fieldIds) || fieldIds.length === 0) {
+      return;
+    }
+
+    const filter = {};
+    if (scope.tenantId) {
+      filter.tenantId = scope.tenantId;
+    }
+    if (scope.bookableId) {
+      filter.id = scope.bookableId;
+    }
+
+    await BookableModel.updateMany(filter, {
+      $pull: { customFieldValues: { fieldId: { $in: fieldIds } } },
+    });
+  }
+
+  /**
    * Get all bookables for a tenant
    * @param {string} tenantId Tenant ID
    * @returns {Promise<Bookable[]>} List of bookables
@@ -341,6 +365,11 @@ class BookableManager {
     const bookableEntity =
       bookable instanceof Bookable ? bookable : new Bookable(bookable);
 
+    const existingBookable = await BookableModel.findOne(
+      { id: bookableEntity.id, tenantId: bookableEntity.tenantId },
+      { customFieldDefinitions: 1 },
+    ).lean();
+
     CustomFieldService.normalizeDefinitions(
       bookableEntity.customFieldDefinitions || [],
     );
@@ -352,6 +381,17 @@ class BookableManager {
       bookableEntity,
       { upsert: upsert },
     );
+
+    const removedFieldIds = CustomFieldService.getRemovedFieldIds(
+      existingBookable?.customFieldDefinitions || [],
+      bookableEntity.customFieldDefinitions || [],
+    );
+    if (removedFieldIds.length > 0) {
+      await BookableManager.removeCustomFieldValues(removedFieldIds, {
+        tenantId: bookableEntity.tenantId,
+        bookableId: bookableEntity.id,
+      });
+    }
 
     return bookableEntity;
   }

--- a/src/commons/data-managers/instance-manager.js
+++ b/src/commons/data-managers/instance-manager.js
@@ -7,6 +7,7 @@ const {
   CustomFieldService,
 } = require("../services/custom-field/custom-field-service");
 const { InstanceCache } = require("../services/instance/instance-cache");
+const { BookableManager } = require("./bookable-manager");
 
 const DEFAULT_BRANDING = Object.freeze({
   active: false,
@@ -48,11 +49,22 @@ class InstanceManager {
     if (!rawInstance) {
       return null;
     }
+
+    const previousCustomFields = rawInstance.bookableCustomFields || [];
+
     const updated = await InstanceModel.findOneAndUpdate(
       {},
       { $set: instanceEntity },
       { new: true },
     );
+
+    const removedFieldIds = CustomFieldService.getRemovedFieldIds(
+      previousCustomFields,
+      instanceEntity.bookableCustomFields || [],
+    );
+    if (removedFieldIds.length > 0) {
+      await BookableManager.removeCustomFieldValues(removedFieldIds);
+    }
 
     CustomFieldCache.invalidateInstance();
     InstanceCache.invalidate();

--- a/src/commons/data-managers/tenant-manager.js
+++ b/src/commons/data-managers/tenant-manager.js
@@ -1,10 +1,12 @@
 const Tenant = require("../entities/tenant/tenant");
 const TenantModel = require("./models/tenantModel");
-const { CustomFieldCache } = require("../services/custom-field/custom-field-cache");
+const {
+  CustomFieldCache,
+} = require("../services/custom-field/custom-field-cache");
 const {
   CustomFieldService,
 } = require("../services/custom-field/custom-field-service");
-const rawTenant = require("../schemas/tenantSchema");
+const { BookableManager } = require("./bookable-manager");
 
 /**
  * Data Manager for Tenant objects.
@@ -45,6 +47,12 @@ class TenantManager {
    */
   static async storeTenant(tenant, upsert = true) {
     const tenantEntity = tenant instanceof Tenant ? tenant : new Tenant(tenant);
+
+    const existingTenant = await TenantModel.findOne(
+      { id: tenantEntity.id },
+      { bookableCustomFields: 1 },
+    ).lean();
+
     CustomFieldService.normalizeDefinitions(
       tenantEntity.bookableCustomFields || [],
     );
@@ -53,6 +61,16 @@ class TenantManager {
       upsert: upsert,
       setDefaultsOnInsert: true,
     });
+
+    const removedFieldIds = CustomFieldService.getRemovedFieldIds(
+      existingTenant?.bookableCustomFields || [],
+      tenantEntity.bookableCustomFields || [],
+    );
+    if (removedFieldIds.length > 0) {
+      await BookableManager.removeCustomFieldValues(removedFieldIds, {
+        tenantId: tenantEntity.id,
+      });
+    }
 
     CustomFieldCache.invalidateTenant(tenantEntity.id);
 

--- a/src/commons/services/custom-field/custom-field-service.js
+++ b/src/commons/services/custom-field/custom-field-service.js
@@ -44,6 +44,26 @@ class CustomFieldService {
     return definitions.map((def) => this.normalizeUsageOptions(def));
   }
 
+  /**
+   * Returns field IDs that exist in previousDefinitions but not in nextDefinitions.
+   * @param {Array} previousDefinitions
+   * @param {Array} nextDefinitions
+   * @returns {string[]}
+   */
+  static getRemovedFieldIds(previousDefinitions = [], nextDefinitions = []) {
+    const nextIds = new Set(
+      nextDefinitions.map((definition) => definition?.id).filter(Boolean),
+    );
+
+    return [
+      ...new Set(
+        previousDefinitions
+          .map((definition) => definition?.id)
+          .filter((id) => id && !nextIds.has(id)),
+      ),
+    ];
+  }
+
   static mergeDefinitions({
     instanceFields = [],
     tenantFields = [],

--- a/tests/custom-field-cleanup.test.js
+++ b/tests/custom-field-cleanup.test.js
@@ -1,0 +1,166 @@
+const assert = require("assert");
+const sinon = require("sinon");
+const {
+  CustomFieldService,
+} = require("../src/commons/services/custom-field/custom-field-service");
+const {
+  BookableManager,
+} = require("../src/commons/data-managers/bookable-manager");
+const BookableModel = require("../src/commons/data-managers/models/bookableModel");
+const TenantModel = require("../src/commons/data-managers/models/tenantModel");
+const InstanceModel = require("../src/commons/data-managers/models/instanceModel");
+const TenantManager = require("../src/commons/data-managers/tenant-manager");
+const InstanceManager = require("../src/commons/data-managers/instance-manager");
+
+describe("CustomFieldService.getRemovedFieldIds", () => {
+  it("returns IDs removed between definition updates", () => {
+    const previous = [{ id: "field-a" }, { id: "field-b" }];
+    const next = [{ id: "field-b" }, { id: "field-c" }];
+
+    assert.deepStrictEqual(
+      CustomFieldService.getRemovedFieldIds(previous, next),
+      ["field-a"],
+    );
+  });
+
+  it("returns an empty array when nothing was removed", () => {
+    const definitions = [{ id: "field-a" }];
+
+    assert.deepStrictEqual(
+      CustomFieldService.getRemovedFieldIds(definitions, definitions),
+      [],
+    );
+  });
+});
+
+describe("BookableManager.removeCustomFieldValues", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("does nothing when fieldIds is empty", async () => {
+    const updateManyStub = sinon.stub(BookableModel, "updateMany");
+
+    await BookableManager.removeCustomFieldValues([]);
+
+    assert.strictEqual(updateManyStub.called, false);
+  });
+
+  it("removes values from all bookables when no scope is provided", async () => {
+    const updateManyStub = sinon.stub(BookableModel, "updateMany").resolves();
+
+    await BookableManager.removeCustomFieldValues(["field-a", "field-b"]);
+
+    assert.strictEqual(updateManyStub.calledOnce, true);
+    assert.deepStrictEqual(updateManyStub.firstCall.args[0], {});
+    assert.deepStrictEqual(updateManyStub.firstCall.args[1], {
+      $pull: {
+        customFieldValues: { fieldId: { $in: ["field-a", "field-b"] } },
+      },
+    });
+  });
+
+  it("scopes cleanup to a tenant", async () => {
+    const updateManyStub = sinon.stub(BookableModel, "updateMany").resolves();
+
+    await BookableManager.removeCustomFieldValues(["field-a"], {
+      tenantId: "tenant-1",
+    });
+
+    assert.deepStrictEqual(updateManyStub.firstCall.args[0], {
+      tenantId: "tenant-1",
+    });
+  });
+
+  it("scopes cleanup to a single bookable", async () => {
+    const updateManyStub = sinon.stub(BookableModel, "updateMany").resolves();
+
+    await BookableManager.removeCustomFieldValues(["field-a"], {
+      tenantId: "tenant-1",
+      bookableId: "bookable-1",
+    });
+
+    assert.deepStrictEqual(updateManyStub.firstCall.args[0], {
+      tenantId: "tenant-1",
+      id: "bookable-1",
+    });
+  });
+});
+
+describe("custom field value cleanup on definition delete", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("cleans up bookable values when tenant custom fields are removed", async () => {
+    sinon.stub(TenantModel, "findOne").returns({
+      lean: async () => ({
+        bookableCustomFields: [{ id: "field-a" }, { id: "field-b" }],
+      }),
+    });
+    sinon.stub(TenantModel, "updateOne").resolves();
+    const cleanupStub = sinon
+      .stub(BookableManager, "removeCustomFieldValues")
+      .resolves();
+
+    await TenantManager.storeTenant({
+      id: "tenant-1",
+      name: "Tenant 1",
+      bookableCustomFields: [{ id: "field-b" }],
+    });
+
+    assert.strictEqual(cleanupStub.calledOnce, true);
+    assert.deepStrictEqual(cleanupStub.firstCall.args[0], ["field-a"]);
+    assert.deepStrictEqual(cleanupStub.firstCall.args[1], {
+      tenantId: "tenant-1",
+    });
+  });
+
+  it("cleans up bookable values when instance custom fields are removed", async () => {
+    const rawInstance = {
+      bookableCustomFields: [{ id: "field-a" }],
+      toEntity: () => ({ bookableCustomFields: [{ id: "field-a" }] }),
+    };
+
+    sinon.stub(InstanceModel, "findOne").resolves(rawInstance);
+    sinon.stub(InstanceModel, "findOneAndUpdate").resolves(rawInstance);
+    const cleanupStub = sinon
+      .stub(BookableManager, "removeCustomFieldValues")
+      .resolves();
+
+    await InstanceManager.updateInstance({
+      bookableCustomFields: [],
+    });
+
+    assert.strictEqual(cleanupStub.calledOnce, true);
+    assert.deepStrictEqual(cleanupStub.firstCall.args[0], ["field-a"]);
+    assert.deepStrictEqual(cleanupStub.firstCall.args[1], undefined);
+  });
+
+  it("cleans up values on the same bookable when definitions are removed", async () => {
+    sinon.stub(BookableModel, "findOne").returns({
+      lean: async () => ({
+        customFieldDefinitions: [{ id: "field-a" }],
+      }),
+    });
+    sinon.stub(BookableModel, "updateOne").resolves();
+    const cleanupStub = sinon
+      .stub(BookableManager, "removeCustomFieldValues")
+      .resolves();
+
+    await BookableManager.storeBookable({
+      id: "bookable-1",
+      tenantId: "tenant-1",
+      type: "room",
+      title: "Room 1",
+      customFieldDefinitions: [],
+    });
+
+    assert.strictEqual(cleanupStub.calledOnce, true);
+    assert.deepStrictEqual(cleanupStub.firstCall.args[0], ["field-a"]);
+    assert.deepStrictEqual(cleanupStub.firstCall.args[1], {
+      tenantId: "tenant-1",
+      bookableId: "bookable-1",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Remove orphaned `customFieldValues` from bookables when custom field definitions are deleted at instance, tenant, or bookable level
- Add `CustomFieldService.getRemovedFieldIds()` and `BookableManager.removeCustomFieldValues()` for scoped cleanup via MongoDB `$pull`
- Document the fix in `docs/CHANGELOG.md`

## Scope
- **Instance level:** deleted fields are removed from all bookables across all tenants
- **Tenant level:** deleted fields are removed from bookables of that tenant only
- **Bookable level:** deleted fields are removed from the affected bookable only
- **Out of scope:** no migration for existing orphaned values; booking `customFieldValues` are left unchanged

## Test plan
- [x] `npx mocha tests/custom-field-cleanup.test.js` (9 tests passing)
- [x] Delete a custom field on instance/tenant/bookable level in admin UI and verify `customFieldValues` are removed from affected bookables
- [x] Confirm existing bookings still retain their stored custom field values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Deleting custom field definitions at the tenant, instance, or bookable level now removes their associated saved values from affected bookables.
  - Prevents orphaned custom field values from remaining after fields are removed.
  - Existing orphaned values are not automatically cleaned up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->