### PR TITLE
feat(DEV-781): Add percentage booking discounts per user/role

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,10 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 
 ### Added
+- Per-user and per-role percentage booking discounts on bookables via `bookingDiscounts` (replaces `freeBookingUsers` / `freeBookingRoles`); highest matching discount applies, then coupons
+- Checkout validate-item responses now include `bookingDiscountPercent`; `freeBookingAllowed` remains `true` when discount is 100%
+- Checkout request flag renamed from `bookWithPrice` to `bookWithoutDiscount` (inverted semantics; default `false`)
+- Migration `14-07-2026-migrate-booking-discounts` to convert existing free-booking lists to 100% discounts
 - Optional `cancellationPolicy.contactHint` on bookables and bookings for cancellation contact instructions in emails when user self-cancellation is disabled; bundle bookings aggregate all relevant hints from non-cancellable items
 - Migration `13-07-2026-add-cancellation-contact-hint` to backfill `contactHint` on existing bookables and bookings
 - JSON catalog bookables expose aggregated `groupBookingAllowed` flag indicating whether the current user may create series bookings (combines `groupBooking.enabled` and `groupBooking.permittedRoles`)

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -260,8 +260,10 @@ Example:
   "requiresLogin": false,
   "permittedUsers": ["user1", "user2"],
   "permittedRoles": ["role1", "role2"],
-  "freeBookingUsers": ["user3"],
-  "freeBookingRoles": ["role3"],
+  "bookingDiscounts": {
+    "users": [{ "userId": "user3", "discountPercent": 100 }],
+    "roles": [{ "roleId": "role3", "discountPercent": 50 }]
+  },
   "cancellationPolicy": { "userCancellable": true, "contactHint": "" },
 
   "relatedBookableIds": ["bookable1", "bookable2"],
@@ -338,8 +340,7 @@ Key fields of a bookable:
 | cancellationPolicy    | e.g. `{ userCancellable: true, contactHint: "" }` — whether users can cancel bookings themselves; `contactHint` is an optional message shown in emails when user cancellation is disabled.                                                                           |
 | permittedUsers        | List of user IDs that are allowed to book. If empty, every user including guests may book (depending on other rules).                                     |
 | permittedRoles        | List of role IDs that are allowed to book. If empty, every user including guests may book (depending on other rules).                                     |
-| freeBookingUsers      | Users who can book this bookable for free.                                                                                                                 |
-| freeBookingRoles      | Roles that can book this bookable for free.                                                                                                                |
+| bookingDiscounts      | Per-user and per-role booking discounts (`users[].userId`, `users[].discountPercent`, `roles[].roleId`, `roles[].discountPercent`; integer 0–100). Highest matching discount applies. |
 | attachments           | Attachments: `id`, `title`, `caption`, `type`, `url`, `show`, `required`, `mailAttach`.                                                                     |
 | lockerDetails         | Configuration for locker integrations (e.g. units).                                                                                                       |
 | requiredFields        | Checkout fields required from the user (default: `address`, `zipCode`, `city`).                                                                            |

--- a/migrations/scripts/14-07-2026-migrate-booking-discounts.js
+++ b/migrations/scripts/14-07-2026-migrate-booking-discounts.js
@@ -1,0 +1,76 @@
+module.exports = {
+  name: "14-07-2026-migrate-booking-discounts",
+
+  up: async function (mongoose) {
+    const Bookable = mongoose.model("Bookable");
+
+    const cursor = Bookable.find({
+      $or: [
+        { freeBookingUsers: { $exists: true, $not: { $size: 0 } } },
+        { freeBookingRoles: { $exists: true, $not: { $size: 0 } } },
+      ],
+    }).cursor();
+
+    for await (const bookable of cursor) {
+      const users = (bookable.freeBookingUsers || []).map((userId) => ({
+        userId,
+        discountPercent: 100,
+      }));
+      const roles = (bookable.freeBookingRoles || []).map((roleId) => ({
+        roleId,
+        discountPercent: 100,
+      }));
+
+      await Bookable.updateOne(
+        { _id: bookable._id },
+        {
+          $set: { bookingDiscounts: { users, roles } },
+          $unset: { freeBookingUsers: "", freeBookingRoles: "" },
+        },
+      );
+    }
+
+    await Bookable.updateMany(
+      { bookingDiscounts: { $exists: false } },
+      { $set: { bookingDiscounts: { users: [], roles: [] } } },
+    );
+
+    await Bookable.updateMany(
+      {},
+      { $unset: { freeBookingUsers: "", freeBookingRoles: "" } },
+    );
+  },
+
+  down: async function (mongoose) {
+    const Bookable = mongoose.model("Bookable");
+
+    const cursor = Bookable.find({
+      $or: [
+        { "bookingDiscounts.users": { $exists: true, $not: { $size: 0 } } },
+        { "bookingDiscounts.roles": { $exists: true, $not: { $size: 0 } } },
+      ],
+    }).cursor();
+
+    for await (const bookable of cursor) {
+      const freeBookingUsers = (bookable.bookingDiscounts?.users || [])
+        .filter((entry) => entry.discountPercent >= 100)
+        .map((entry) => entry.userId);
+      const freeBookingRoles = (bookable.bookingDiscounts?.roles || [])
+        .filter((entry) => entry.discountPercent >= 100)
+        .map((entry) => entry.roleId);
+
+      await Bookable.updateOne(
+        { _id: bookable._id },
+        {
+          $set: { freeBookingUsers, freeBookingRoles },
+          $unset: { bookingDiscounts: "" },
+        },
+      );
+    }
+
+    await Bookable.updateMany(
+      { bookingDiscounts: { $exists: true } },
+      { $unset: { bookingDiscounts: "" } },
+    );
+  },
+};

--- a/migrations/scripts/14-07-2026-migrate-booking-discounts.js
+++ b/migrations/scripts/14-07-2026-migrate-booking-discounts.js
@@ -9,7 +9,9 @@ module.exports = {
         { freeBookingUsers: { $exists: true, $not: { $size: 0 } } },
         { freeBookingRoles: { $exists: true, $not: { $size: 0 } } },
       ],
-    }).cursor();
+    })
+      .lean()
+      .cursor();
 
     for await (const bookable of cursor) {
       const users = (bookable.freeBookingUsers || []).map((userId) => ({

--- a/src/commons/entities/bookable/bookable.js
+++ b/src/commons/entities/bookable/bookable.js
@@ -149,16 +149,28 @@ class Bookable {
   }
 
   /**
-   * Check if user gets free booking
+   * Get the highest applicable booking discount for a user.
    * @param {string} userId User ID
-   * @param {string[]} userRoles User roles
-   * @returns {boolean} True if user gets free booking
+   * @param {string[]} userRoles User role IDs
+   * @returns {number} Discount percent (0–100)
    */
-  isFreeForUser(userId, userRoles = []) {
-    if (this.freeBookingUsers.includes(userId)) {
-      return true;
+  getUserDiscountPercent(userId, userRoles = []) {
+    const discounts = this.bookingDiscounts || { users: [], roles: [] };
+    let maxDiscount = 0;
+
+    for (const entry of discounts.users || []) {
+      if (entry.userId === userId) {
+        maxDiscount = Math.max(maxDiscount, entry.discountPercent || 0);
+      }
     }
-    return userRoles.some((role) => this.freeBookingRoles.includes(role));
+
+    for (const entry of discounts.roles || []) {
+      if (userRoles.includes(entry.roleId)) {
+        maxDiscount = Math.max(maxDiscount, entry.discountPercent || 0);
+      }
+    }
+
+    return maxDiscount;
   }
 
   /**

--- a/src/commons/schemas/bookableSchema.js
+++ b/src/commons/schemas/bookableSchema.js
@@ -188,8 +188,56 @@ const bookableSchemaDefinition = {
   requiresLogin: { type: Boolean, default: false },
   permittedUsers: { type: [String], default: [] },
   permittedRoles: { type: [String], default: [] },
-  freeBookingUsers: { type: [String], default: [] },
-  freeBookingRoles: { type: [String], default: [] },
+  bookingDiscounts: {
+    type: new Schema(
+      {
+        users: {
+          type: [
+            new Schema(
+              {
+                userId: { type: String, required: true },
+                discountPercent: {
+                  type: Number,
+                  default: 0,
+                  min: 0,
+                  max: 100,
+                  validate: {
+                    validator: Number.isInteger,
+                    message: "discountPercent must be an integer",
+                  },
+                },
+              },
+              { _id: false },
+            ),
+          ],
+          default: [],
+        },
+        roles: {
+          type: [
+            new Schema(
+              {
+                roleId: { type: String, required: true },
+                discountPercent: {
+                  type: Number,
+                  default: 0,
+                  min: 0,
+                  max: 100,
+                  validate: {
+                    validator: Number.isInteger,
+                    message: "discountPercent must be an integer",
+                  },
+                },
+              },
+              { _id: false },
+            ),
+          ],
+          default: [],
+        },
+      },
+      { _id: false },
+    ),
+    default: { users: [], roles: [] },
+  },
 
   // Cancellation policy
   cancellationPolicy: {

--- a/src/commons/services/bookable-service.js
+++ b/src/commons/services/bookable-service.js
@@ -46,7 +46,7 @@ class BookableService {
         timeEnd,
         bookableId,
         amount: 1,
-        bookWithPrice: false,
+        bookWithoutDiscount: false,
       });
 
       await checkoutService.init(bookable);

--- a/src/commons/services/checkout/booking-service.js
+++ b/src/commons/services/checkout/booking-service.js
@@ -174,7 +174,7 @@ class BookingService {
       isCommitted,
       isPayed,
       isRejected,
-      bookWithPrice,
+      bookWithoutDiscount,
       customFieldValues: rawCustomFieldValues,
       cancellationPolicy,
     } = bookingAttempt;
@@ -280,7 +280,7 @@ class BookingService {
         isRejected: Boolean(isRejected),
         attachmentStatus,
         paymentProvider,
-        bookWithPrice,
+        bookWithoutDiscount,
         checkoutId: providedCheckoutId,
         customFieldValues,
         cancellationPolicy,
@@ -306,7 +306,7 @@ class BookingService {
         comment,
         attachmentStatus,
         paymentProvider,
-        bookWithPrice,
+        bookWithoutDiscount,
         checkoutId: providedCheckoutId,
         customFieldValues,
       });

--- a/src/commons/services/checkout/bundle-checkout-service.js
+++ b/src/commons/services/checkout/bundle-checkout-service.js
@@ -33,7 +33,7 @@ class BundleCheckoutService {
    * @param {Array} attachmentStatus - The attachments of the user.
    * @param {string} paymentProvider - The payment method.
    * @param {Array} attachments - The attachments.
-   * @param {boolean} bookWithPrice - Whether to book with price.
+   * @param {boolean} bookWithoutDiscount - When true, booking discounts are ignored.
    * @param {string} checkoutId - The checkout ID.
    * @param {Array} customFieldValues - Checkout custom field values.
    */
@@ -57,7 +57,7 @@ class BundleCheckoutService {
     attachmentStatus,
     paymentProvider,
     attachments,
-    bookWithPrice,
+    bookWithoutDiscount,
     checkoutId,
     customFieldValues,
   }) {
@@ -80,7 +80,7 @@ class BundleCheckoutService {
     this.attachmentStatus = attachmentStatus;
     this.paymentProvider = paymentProvider;
     this.attachments = attachments || [];
-    this.bookWithPrice = bookWithPrice;
+    this.bookWithoutDiscount = bookWithoutDiscount;
     this.checkoutId = checkoutId;
     this.customFieldValues = Array.isArray(customFieldValues)
       ? customFieldValues
@@ -96,7 +96,7 @@ class BundleCheckoutService {
       bookableId: bookableItem.bookableId,
       amount: bookableItem.amount,
       couponCode: this.couponCode,
-      bookWithPrice: this.bookWithPrice,
+      bookWithoutDiscount: this.bookWithoutDiscount,
       checkoutId: this.checkoutId,
     });
     await itemCheckoutService.init();
@@ -418,7 +418,7 @@ class ManualBundleCheckoutService extends BundleCheckoutService {
    * @param {string} paymentMethod - The payment method.
    * @param {Array} hooks - The hooks.
    * @param {Array} attachments - The attachments.
-   * @param {boolean} bookWithPrice - Whether to book with price.
+   * @param {boolean} bookWithoutDiscount - When true, booking discounts are ignored.
    * @param {string} checkoutId - The checkout ID.
    * @param {Array} lockerInfo - The locker info.
    * @param {Array} customFieldValues - Checkout custom field values.
@@ -453,7 +453,7 @@ class ManualBundleCheckoutService extends BundleCheckoutService {
     paymentMethod,
     hooks,
     attachments,
-    bookWithPrice,
+    bookWithoutDiscount,
     checkoutId,
     lockerInfo,
     customFieldValues,
@@ -479,7 +479,7 @@ class ManualBundleCheckoutService extends BundleCheckoutService {
       attachmentStatus,
       paymentProvider,
       attachments,
-      bookWithPrice,
+      bookWithoutDiscount,
       checkoutId,
       customFieldValues,
     });
@@ -503,7 +503,7 @@ class ManualBundleCheckoutService extends BundleCheckoutService {
       bookableId: bookableItem.bookableId,
       amount: bookableItem.amount,
       couponCode: this.couponCode,
-      bookWithPrice: this.bookWithPrice,
+      bookWithoutDiscount: this.bookWithoutDiscount,
     });
 
     await itemCheckoutService.init(bookableItem._bookableUsed);

--- a/src/commons/services/checkout/item-checkout-service.js
+++ b/src/commons/services/checkout/item-checkout-service.js
@@ -51,10 +51,10 @@ class ItemCheckoutService {
    * @param {string} bookableId The ID of the bookable
    * @param {number} amount The amount of the booking
    * @param {string || null} couponCode The coupon code
-   * @param {boolean} bookWithPrice Determines whether the booking process should include pricing calculations.
+   * @param {boolean} bookWithoutDiscount When true, booking discounts are ignored and the full price applies.
    * @param {string} checkoutId The ID of the checkout process, used for correlating logs and operations. Optional.
    * @param {Map} externalCache An optional Map instance for caching data across multiple service instances, particularly useful for external provider data. If not provided, a new Map will be created for each instance.
-   *                                Set to `true` to enable pricing considerations, or `false` to skip them. Defaults to `true`.
+   *                                Defaults to `false` (discounts are applied when configured).
    */
   constructor({
     user,
@@ -64,7 +64,7 @@ class ItemCheckoutService {
     bookableId,
     amount,
     couponCode,
-    bookWithPrice,
+    bookWithoutDiscount,
     checkoutId,
     externalCache,
   }) {
@@ -76,7 +76,7 @@ class ItemCheckoutService {
     this.amount = Number(amount);
     this.couponCode = couponCode;
     this.originBookable = null;
-    this.bookWithPrice = bookWithPrice ?? true;
+    this.bookWithoutDiscount = bookWithoutDiscount ?? false;
     this.checkoutId = checkoutId;
     this.externalCache = externalCache || new Map();
     this._cache = new Map();
@@ -162,7 +162,7 @@ class ItemCheckoutService {
     this.amount = null;
     this.couponCode = null;
     this.originBookable = null;
-    this.bookWithPrice = null;
+    this.bookWithoutDiscount = null;
     this._availabilityProvider = null;
     this._cache.clear();
   }
@@ -235,24 +235,24 @@ class ItemCheckoutService {
     return this.originBookable.hasExternalBookingDuration;
   }
 
-  async freeBookingAllowed() {
-    return this._cached("freeBookingAllowed", async () => {
-      const freeBookingUsers = [
-        ...(this.originBookable.freeBookingUsers || []),
-        ...(
-          await MembershipManager.getMembershipsByTenantAndRoles(
-            this.tenantId,
-            this.originBookable.freeBookingRoles || [],
-          )
-        ).map((u) => u.userId),
-      ];
+  async bookingDiscountPercent() {
+    return this._cached("bookingDiscountPercent", async () => {
+      if (!this.user || this.originBookable.tenantId !== this.tenantId) {
+        return 0;
+      }
 
-      return (
-        !!this.user &&
-        freeBookingUsers.includes(this.user) &&
-        this.originBookable.tenantId === this.tenantId
+      const membership = await MembershipManager.getMembershipByTenantAndUserID(
+        this.tenantId,
+        this.user,
       );
+      const userRoles = membership?.roles || [];
+
+      return this.originBookable.getUserDiscountPercent(this.user, userRoles);
     });
+  }
+
+  async freeBookingAllowed() {
+    return (await this.bookingDiscountPercent()) >= 100;
   }
 
   async calculateAmountBooked(bookable) {
@@ -521,16 +521,20 @@ class ItemCheckoutService {
 
   async userPriceEur() {
     return this._cached("userPriceEur", async () => {
-      if (await this.freeBookingAllowed()) {
-        if (!this.bookWithPrice) {
-          return 0;
-        }
+      let price = await this.regularPriceEur();
+
+      const discountPercent = await this.bookingDiscountPercent();
+      if (discountPercent > 0 && !this.bookWithoutDiscount) {
+        price = Math.max(
+          0,
+          Math.round(price * (1 - discountPercent / 100) * 100) / 100,
+        );
       }
 
       const total = await CouponService.applyCoupon(
         this.originBookable.enableCoupons ? this.couponCode : null,
         this.tenantId,
-        await this.regularPriceEur(),
+        price,
       );
 
       return Math.round(total * 100) / 100;
@@ -816,6 +820,7 @@ class ManualItemCheckoutService extends ItemCheckoutService {
     bookableId,
     amount,
     couponCode,
+    bookWithoutDiscount,
   }) {
     super({
       user,
@@ -825,6 +830,7 @@ class ManualItemCheckoutService extends ItemCheckoutService {
       bookableId,
       amount,
       couponCode,
+      bookWithoutDiscount,
     });
   }
 

--- a/src/platform/api/controllers/checkout-controller.js
+++ b/src/platform/api/controllers/checkout-controller.js
@@ -30,7 +30,7 @@ class CheckoutController {
       timeEnd,
       amount,
       couponCode,
-      bookWithPrice,
+      bookWithoutDiscount,
     } = request.body;
 
     if (!bookableId || !amount) {
@@ -59,7 +59,7 @@ class CheckoutController {
         bookableId,
         amount: parseInt(amount),
         couponCode,
-        bookWithPrice,
+        bookWithoutDiscount,
         checkoutId,
       });
 
@@ -89,6 +89,8 @@ class CheckoutController {
         userGrossPriceEur:
           (await itemCheckoutService.userGrossPriceEur()) * multiplier,
         freeBookingAllowed: await itemCheckoutService.freeBookingAllowed(),
+        bookingDiscountPercent:
+          await itemCheckoutService.bookingDiscountPercent(),
       };
 
       return response.status(200).json(payload);

--- a/src/platform/api/v2/controllers/checkout.controller.js
+++ b/src/platform/api/v2/controllers/checkout.controller.js
@@ -50,7 +50,7 @@ class CheckoutControllerV2 {
       end,
       amount,
       couponCode,
-      bookWithPrice,
+      bookWithoutDiscount,
     } = req.body;
 
     const { checkoutId, generated } = await resolveCheckoutId(
@@ -88,7 +88,7 @@ class CheckoutControllerV2 {
       bookableId,
       amount: parseInt(amount),
       couponCode,
-      bookWithPrice,
+      bookWithoutDiscount,
       checkoutId,
     });
 
@@ -135,6 +135,7 @@ class CheckoutControllerV2 {
           (await service.regularGrossPriceEur()) * multiplier,
         userGrossPriceEur: (await service.userGrossPriceEur()) * multiplier,
         freeBookingAllowed: await service.freeBookingAllowed(),
+        bookingDiscountPercent: await service.bookingDiscountPercent(),
       };
 
       logger.info(
@@ -237,7 +238,7 @@ class CheckoutControllerV2 {
       const {
         bookableItems: rawBookableItems,
         bookingAttempts: rawBookingAttempts,
-        bookWithPrice,
+        bookWithoutDiscount,
         paymentProvider,
         customFieldValues,
         couponCode,
@@ -319,7 +320,7 @@ class CheckoutControllerV2 {
         timeBegin: attempt?.timeBegin,
         timeEnd: attempt?.timeEnd,
         bookableItems,
-        bookWithPrice,
+        bookWithoutDiscount,
         customFieldValues,
         couponCode,
       }));

--- a/tests/booking-discount-checkout.test.js
+++ b/tests/booking-discount-checkout.test.js
@@ -1,0 +1,146 @@
+const assert = require("assert");
+const sinon = require("sinon");
+const { Bookable } = require("../src/commons/entities/bookable/bookable");
+const {
+  ManualItemCheckoutService,
+} = require("../src/commons/services/checkout/item-checkout-service");
+const MembershipManager = require("../src/commons/data-managers/membership-manager");
+const CouponService = require("../src/commons/services/coupon-service");
+
+const TENANT_ID = "tenant-1";
+const USER_ID = "user-1";
+
+function discountBookable(overrides = {}) {
+  return new Bookable({
+    id: "room-a",
+    tenantId: TENANT_ID,
+    title: "Room A",
+    priceType: "per-item",
+    priceCategories: [{ priceEur: 100, interval: { start: null, end: null } }],
+    bookingDiscounts: {
+      users: [],
+      roles: [],
+    },
+    ...overrides,
+  });
+}
+
+async function createCheckoutService(bookable, options = {}) {
+  const service = new ManualItemCheckoutService({
+    user: USER_ID,
+    tenantId: TENANT_ID,
+    timeBegin: Date.now(),
+    timeEnd: Date.now() + 3600000,
+    bookableId: bookable.id,
+    amount: 1,
+    couponCode: options.couponCode ?? null,
+    bookWithoutDiscount: options.bookWithoutDiscount ?? false,
+  });
+
+  await service.init(bookable);
+  return service;
+}
+
+describe("Bookable booking discounts", function () {
+  it("returns the highest discount when user and role both match", function () {
+    const bookable = discountBookable({
+      bookingDiscounts: {
+        users: [{ userId: USER_ID, discountPercent: 30 }],
+        roles: [{ roleId: "role-member", discountPercent: 50 }],
+      },
+    });
+
+    assert.strictEqual(
+      bookable.getUserDiscountPercent(USER_ID, ["role-member"]),
+      50,
+    );
+  });
+
+  it("returns 0 when no discount is configured", function () {
+    const bookable = discountBookable();
+
+    assert.strictEqual(
+      bookable.getUserDiscountPercent(USER_ID, ["role-member"]),
+      0,
+    );
+  });
+});
+
+describe("ItemCheckoutService booking discount pricing", function () {
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it("applies a role-based percentage discount before coupons", async function () {
+    sinon
+      .stub(MembershipManager, "getMembershipByTenantAndUserID")
+      .resolves({ roles: ["role-member"] });
+    sinon
+      .stub(CouponService, "applyCoupon")
+      .callsFake(async (_code, _tenant, price) => {
+        return Math.max(0, price - 10);
+      });
+
+    const bookable = discountBookable({
+      enableCoupons: true,
+      bookingDiscounts: {
+        users: [],
+        roles: [{ roleId: "role-member", discountPercent: 50 }],
+      },
+    });
+
+    const service = await createCheckoutService(bookable, {
+      couponCode: "SAVE10",
+    });
+
+    assert.strictEqual(await service.bookingDiscountPercent(), 50);
+    assert.strictEqual(await service.freeBookingAllowed(), false);
+    assert.strictEqual(await service.userPriceEur(), 40);
+  });
+
+  it("treats 100 percent discount as free booking", async function () {
+    sinon
+      .stub(MembershipManager, "getMembershipByTenantAndUserID")
+      .resolves({ roles: [] });
+    sinon
+      .stub(CouponService, "applyCoupon")
+      .callsFake(async (_code, _tenant, price) => price);
+
+    const bookable = discountBookable({
+      bookingDiscounts: {
+        users: [{ userId: USER_ID, discountPercent: 100 }],
+        roles: [],
+      },
+    });
+
+    const service = await createCheckoutService(bookable);
+
+    assert.strictEqual(await service.bookingDiscountPercent(), 100);
+    assert.strictEqual(await service.freeBookingAllowed(), true);
+    assert.strictEqual(await service.userPriceEur(), 0);
+  });
+
+  it("ignores discounts when bookWithoutDiscount is true", async function () {
+    sinon
+      .stub(MembershipManager, "getMembershipByTenantAndUserID")
+      .resolves({ roles: [] });
+    sinon
+      .stub(CouponService, "applyCoupon")
+      .callsFake(async (_code, _tenant, price) => price);
+
+    const bookable = discountBookable({
+      bookingDiscounts: {
+        users: [{ userId: USER_ID, discountPercent: 100 }],
+        roles: [],
+      },
+    });
+
+    const service = await createCheckoutService(bookable, {
+      bookWithoutDiscount: true,
+    });
+
+    assert.strictEqual(await service.bookingDiscountPercent(), 100);
+    assert.strictEqual(await service.freeBookingAllowed(), true);
+    assert.strictEqual(await service.userPriceEur(), 100);
+  });
+});


### PR DESCRIPTION
## Summary

- Replace `freeBookingUsers` / `freeBookingRoles` with `bookingDiscounts` on bookables (integer `discountPercent` 0–100 per user/role)
- Apply the highest matching discount on net price before coupons in checkout; `freeBookingAllowed` remains `true` when discount is 100%
- Rename checkout flag `bookWithPrice` → `bookWithoutDiscount` (inverted semantics, default `false`)
- Add migration `14-07-2026-migrate-booking-discounts` to convert existing free-booking entries to 100% discounts

## Test plan

- [x] `npx mocha tests/booking-discount-checkout.test.js` (5 tests passing)
- [x] Run migration on staging DB before deploy
- [x] Update Admin UI to configure `bookingDiscounts` (separate repo)
- [x] Update Storefront to send `bookWithoutDiscount` and display `bookingDiscountPercent` (separate repo)
- [x] Verify checkout validate-item returns `bookingDiscountPercent` and correct `userPriceEur` for partial discounts
- [x] Verify 100% discount still skips payment (`userPriceEur === 0`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added percentage-based booking discounts for individual users and roles.
  * Checkout responses now show the applicable discount percentage.
  * Discounts are applied before coupons, with 100% discounts enabling free booking.
  * Added an option to book without applying configured discounts.
* **Documentation**
  * Updated booking discount and checkout documentation.
* **Chores**
  * Added migration support for existing free-booking configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->