### PR TITLE
Fix coupon discount pricing and invoice display (DEV-813)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 ### Fixed
 
+- Fixed-amount coupons are now deducted from the gross checkout price instead of the net price (percentage coupons and booking discounts unchanged)
+- Invoice and receipt PDFs show coupon line items at regular net prices, label coupon lines as Rabatt, and list fixed and percentage discounts after VAT
 - Deleting custom field definitions at instance, tenant, or bookable level now removes the corresponding `customFieldValues` entries from affected bookables (no backfill migration for existing orphaned values)
 - Booking emails no longer show a cancel button when `cancellationPolicy.userCancellable` is `false`; an optional `contactHint` is shown instead when configured
 - `authenticateIfNeeded` now verifies Keycloak access tokens in addition to local JWTs, fixing `invalid algorithm` errors for SSO users on routes such as related bookings, protected files, and private catalogs

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,8 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 ### Fixed
 
 - Fixed-amount coupons are now deducted from the gross checkout price instead of the net price (percentage coupons and booking discounts unchanged)
-- Invoice and receipt PDFs show coupon line items at regular net prices, label coupon lines as Rabatt, and list fixed and percentage discounts after VAT
+- Multi-item bundle checkouts apply fixed-amount coupons once at booking level instead of per line item
+- Invoice and receipt PDFs show coupon line items at regular net prices, label coupon lines as Rabatt, and list fixed and percentage discounts after VAT; aggregated documents and legacy bookings without stored regular prices use the same presentation
 - Deleting custom field definitions at instance, tenant, or bookable level now removes the corresponding `customFieldValues` entries from affected bookables (no backfill migration for existing orphaned values)
 - Booking emails no longer show a cancel button when `cancellationPolicy.userCancellable` is `false`; an optional `contactHint` is shown instead when configured
 - `authenticateIfNeeded` now verifies Keycloak access tokens in addition to local JWTs, fixing `invalid algorithm` errors for SSO users on routes such as related bookings, protected files, and private catalogs

--- a/src/commons/pdf-service/pdf-service.js
+++ b/src/commons/pdf-service/pdf-service.js
@@ -83,12 +83,6 @@ const PRINT_CSS = `
     padding-bottom: 4px;
   }
   table.pdf-items--compact tr.coupon td { color: #555; }
-  table.pdf-items--compact tr.gross-subtotal td {
-    font-weight: bold;
-    text-align: right;
-    border-top: 1px solid #bbb;
-  }
-  table.pdf-items--compact tr.gross-subtotal td:first-child { text-align: left; }
   table.pdf-items--compact tr.totals-sub td {
     padding-top: 4px;
     border-top: 2px solid #000;
@@ -146,21 +140,9 @@ const PRINT_CSS = `
     padding-left: 18px;
   }
   table.pdf-items--detailed tr.coupon td { color: #555; }
-  table.pdf-items--detailed tr.gross-subtotal td {
-    font-weight: bold;
-    text-align: right;
-    border-top: 1px solid #bbb;
-  }
-  table.pdf-items--detailed tr.gross-subtotal td:first-child { text-align: left; }
   table.pdf-items--detailed tr.netto td {
     padding-top: 8px;
     border-top: 2px solid #000;
-  }
-  table.pdf-items--detailed tr.netto.tax-breakdown td {
-    padding-top: 4px;
-    border-top: none;
-    color: #444;
-    font-size: 9px;
   }
   table.pdf-items--detailed tr.netto td,
   table.pdf-items--detailed tr.mwst td,
@@ -815,7 +797,12 @@ class PdfService {
     return lines.join("<br/>\n");
   }
 
-  static _renderBookingItemsTable(tenant, data, layoutOverride, tableMetaOverride) {
+  static _renderBookingItemsTable(
+    tenant,
+    data,
+    layoutOverride,
+    tableMetaOverride,
+  ) {
     const layout = resolveBookingLayout(tenant, layoutOverride || data.layout);
     const tableMeta = resolveBookingTableMeta(
       tenant,
@@ -916,6 +903,54 @@ class PdfService {
     return Math.round(item.userPriceEur * (1 + vatRate) * 100) / 100;
   }
 
+  static _sumUserGrossPriceEur(booking) {
+    let total = 0;
+    for (const item of booking.bookableItems || []) {
+      total +=
+        PdfService._resolveUserGrossPriceEur(item, booking) *
+        PdfService._itemAmountMultiplier(item);
+    }
+    return Math.round(total * 100) / 100;
+  }
+
+  static _fixedCouponDiscountAtBookingLevel(booking) {
+    const coupon = booking._couponUsed;
+    if (coupon?.type !== COUPON_TYPE.FIXED) {
+      return false;
+    }
+
+    const totalUserGross = PdfService._sumUserGrossPriceEur(booking);
+    const bookingGross = booking.priceEur ?? totalUserGross;
+    const expectedAfterDiscount =
+      Math.round(Math.max(0, totalUserGross - coupon.discount) * 100) / 100;
+
+    return Math.abs(expectedAfterDiscount - bookingGross) < 0.02;
+  }
+
+  static _allocateFixedCouponDiscountToItem(item, booking) {
+    const coupon = booking._couponUsed;
+    if (coupon?.type !== COUPON_TYPE.FIXED) {
+      return 0;
+    }
+
+    const items = booking.bookableItems || [];
+    if (items.length <= 1) {
+      return coupon.discount;
+    }
+
+    const totalUserGross = PdfService._sumUserGrossPriceEur(booking);
+    if (!totalUserGross) {
+      return 0;
+    }
+
+    const itemGross =
+      PdfService._resolveUserGrossPriceEur(item, booking) *
+      PdfService._itemAmountMultiplier(item);
+    return (
+      Math.round(((coupon.discount * itemGross) / totalUserGross) * 100) / 100
+    );
+  }
+
   static _resolveRegularGrossPriceEur(item, booking) {
     if (item.regularGrossPriceEur != null) {
       return item.regularGrossPriceEur;
@@ -925,7 +960,14 @@ class PdfService {
     const userGross = PdfService._resolveUserGrossPriceEur(item, booking);
 
     if (coupon?.type === COUPON_TYPE.FIXED) {
-      return Math.round((userGross + coupon.discount) * 100) / 100;
+      if (PdfService._fixedCouponDiscountAtBookingLevel(booking)) {
+        return userGross;
+      }
+      const allocated = PdfService._allocateFixedCouponDiscountToItem(
+        item,
+        booking,
+      );
+      return Math.round((userGross + allocated) * 100) / 100;
     }
 
     if (
@@ -946,13 +988,18 @@ class PdfService {
 
     if (item.regularGrossPriceEur != null) {
       const vatRate = PdfService._bookingVatRate(booking);
-      return Math.round((item.regularGrossPriceEur / (1 + vatRate)) * 100) / 100;
+      return (
+        Math.round((item.regularGrossPriceEur / (1 + vatRate)) * 100) / 100
+      );
     }
 
     const coupon = booking._couponUsed;
     if (coupon?.type === COUPON_TYPE.FIXED) {
       const vatRate = PdfService._bookingVatRate(booking);
-      const regularGross = PdfService._resolveRegularGrossPriceEur(item, booking);
+      const regularGross = PdfService._resolveRegularGrossPriceEur(
+        item,
+        booking,
+      );
       return Math.round((regularGross / (1 + vatRate)) * 100) / 100;
     }
 
@@ -961,9 +1008,10 @@ class PdfService {
       coupon.discount > 0 &&
       coupon.discount < 100
     ) {
-      return Math.round(
-        (item.userPriceEur / (1 - coupon.discount / 100)) * 100,
-      ) / 100;
+      return (
+        Math.round((item.userPriceEur / (1 - coupon.discount / 100)) * 100) /
+        100
+      );
     }
 
     return item.userPriceEur;
@@ -1089,9 +1137,9 @@ class PdfService {
     let discountLabel;
 
     if (coupon.type === COUPON_TYPE.FIXED) {
-      discountLabel = (options.negative
-        ? formatters.formatCurrency
-        : formatters.formatNegativeCurrency)(coupon.discount);
+      discountLabel = options.negative
+        ? `+${formatters.formatAmount(coupon.discount)} €`
+        : formatters.formatNegativeCurrency(coupon.discount);
     } else if (coupon.type === COUPON_TYPE.PERCENTAGE) {
       discountLabel = `${sign}${coupon.discount} %`;
     } else {
@@ -1103,7 +1151,6 @@ class PdfService {
       discount: coupon.discount,
       type: coupon.type,
       discountLabel,
-      showAfterVat: true,
     };
   }
 
@@ -1143,18 +1190,21 @@ class PdfService {
         booking.timePaid > 0
           ? formatters.formatDateTime(booking.timePaid)
           : "-";
+      const tableTotals = PdfService._buildTableTotals(booking, options);
+      const coupon = PdfService._buildCoupon(booking, options);
 
       return {
         id: booking.id,
         period,
         paymentDate,
         paymentMethod: formatters.translatePayMethod(booking.paymentMethod),
-        nettoEur: booking.priceEur - booking.vatIncludedEur,
-        netto: (options.negative
-          ? formatters.formatNegativeCurrency
-          : formatters.formatCurrency)(
-          booking.priceEur - booking.vatIncludedEur,
-        ),
+        nettoEur: tableTotals.nettoEur,
+        netto: tableTotals.netto,
+        vat: tableTotals.vat,
+        vatEur: tableTotals.vatEur,
+        brutto: tableTotals.brutto,
+        bruttoEur: tableTotals.bruttoEur,
+        coupon,
         items: PdfService._buildItems(booking, allBookables, options),
         summaryItems: PdfService._buildSummaryItems(booking, allBookables),
       };

--- a/src/commons/pdf-service/pdf-service.js
+++ b/src/commons/pdf-service/pdf-service.js
@@ -8,6 +8,7 @@ const lazyBrowser = require("./LazyBrowser");
 const fs = require("fs");
 const path = require("path");
 const formatters = require("./pdf-formatters");
+const { COUPON_TYPE } = require("../entities/coupon/coupon");
 const { buildSampleData } = require("./pdf-sample-data");
 const { resolveBookingLayout } = require("./pdf-booking-layout");
 const {
@@ -82,6 +83,12 @@ const PRINT_CSS = `
     padding-bottom: 4px;
   }
   table.pdf-items--compact tr.coupon td { color: #555; }
+  table.pdf-items--compact tr.gross-subtotal td {
+    font-weight: bold;
+    text-align: right;
+    border-top: 1px solid #bbb;
+  }
+  table.pdf-items--compact tr.gross-subtotal td:first-child { text-align: left; }
   table.pdf-items--compact tr.totals-sub td {
     padding-top: 4px;
     border-top: 2px solid #000;
@@ -139,9 +146,21 @@ const PRINT_CSS = `
     padding-left: 18px;
   }
   table.pdf-items--detailed tr.coupon td { color: #555; }
+  table.pdf-items--detailed tr.gross-subtotal td {
+    font-weight: bold;
+    text-align: right;
+    border-top: 1px solid #bbb;
+  }
+  table.pdf-items--detailed tr.gross-subtotal td:first-child { text-align: left; }
   table.pdf-items--detailed tr.netto td {
     padding-top: 8px;
     border-top: 2px solid #000;
+  }
+  table.pdf-items--detailed tr.netto.tax-breakdown td {
+    padding-top: 4px;
+    border-top: none;
+    color: #444;
+    font-size: 9px;
   }
   table.pdf-items--detailed tr.netto td,
   table.pdf-items--detailed tr.mwst td,
@@ -346,10 +365,7 @@ class PdfService {
 
     const items = PdfService._buildItems(booking, allBookables);
     const coupon = PdfService._buildCoupon(booking);
-    const totals = PdfService._buildTotals(
-      booking.priceEur,
-      booking.vatIncludedEur,
-    );
+    const totals = PdfService._buildTableTotals(booking);
 
     const bookingContext = PdfService._buildBookingContext(
       booking,
@@ -442,10 +458,7 @@ class PdfService {
 
     const items = PdfService._buildItems(booking, allBookables);
     const coupon = PdfService._buildCoupon(booking);
-    const totals = PdfService._buildTotals(
-      booking.priceEur,
-      booking.vatIncludedEur,
-    );
+    const totals = PdfService._buildTableTotals(booking);
 
     const bookingContext = PdfService._buildBookingContext(
       booking,
@@ -574,11 +587,7 @@ class PdfService {
       negative: true,
     });
     const coupon = PdfService._buildCoupon(booking, { negative: true });
-    const totals = PdfService._buildTotals(
-      booking.priceEur,
-      booking.vatIncludedEur,
-      { negative: true },
-    );
+    const totals = PdfService._buildTableTotals(booking, { negative: true });
 
     const bookingContext = PdfService._buildBookingContext(
       booking,
@@ -891,6 +900,130 @@ class PdfService {
     });
   }
 
+  static _bookingVatRate(booking) {
+    const nettoEur = booking.priceEur - booking.vatIncludedEur;
+    if (!nettoEur) {
+      return 0;
+    }
+    return booking.vatIncludedEur / nettoEur;
+  }
+
+  static _resolveUserGrossPriceEur(item, booking) {
+    if (item.userGrossPriceEur != null) {
+      return item.userGrossPriceEur;
+    }
+    const vatRate = PdfService._bookingVatRate(booking);
+    return Math.round(item.userPriceEur * (1 + vatRate) * 100) / 100;
+  }
+
+  static _resolveRegularGrossPriceEur(item, booking) {
+    if (item.regularGrossPriceEur != null) {
+      return item.regularGrossPriceEur;
+    }
+
+    const coupon = booking._couponUsed;
+    const userGross = PdfService._resolveUserGrossPriceEur(item, booking);
+
+    if (coupon?.type === COUPON_TYPE.FIXED) {
+      return Math.round((userGross + coupon.discount) * 100) / 100;
+    }
+
+    if (
+      coupon?.type === COUPON_TYPE.PERCENTAGE &&
+      coupon.discount > 0 &&
+      coupon.discount < 100
+    ) {
+      return Math.round((userGross / (1 - coupon.discount / 100)) * 100) / 100;
+    }
+
+    return userGross;
+  }
+
+  static _resolveRegularNetPriceEur(item, booking) {
+    if (item.regularPriceEur != null) {
+      return item.regularPriceEur;
+    }
+
+    if (item.regularGrossPriceEur != null) {
+      const vatRate = PdfService._bookingVatRate(booking);
+      return Math.round((item.regularGrossPriceEur / (1 + vatRate)) * 100) / 100;
+    }
+
+    const coupon = booking._couponUsed;
+    if (coupon?.type === COUPON_TYPE.FIXED) {
+      const vatRate = PdfService._bookingVatRate(booking);
+      const regularGross = PdfService._resolveRegularGrossPriceEur(item, booking);
+      return Math.round((regularGross / (1 + vatRate)) * 100) / 100;
+    }
+
+    if (
+      coupon?.type === COUPON_TYPE.PERCENTAGE &&
+      coupon.discount > 0 &&
+      coupon.discount < 100
+    ) {
+      return Math.round(
+        (item.userPriceEur / (1 - coupon.discount / 100)) * 100,
+      ) / 100;
+    }
+
+    return item.userPriceEur;
+  }
+
+  static _usesPreDiscountCouponDisplay(coupon) {
+    return (
+      coupon &&
+      Object.keys(coupon).length > 0 &&
+      (coupon.type === COUPON_TYPE.FIXED ||
+        coupon.type === COUPON_TYPE.PERCENTAGE)
+    );
+  }
+
+  static _calculatePreDiscountNetTotal(booking) {
+    let nettoEur = 0;
+    for (const item of booking.bookableItems || []) {
+      nettoEur +=
+        PdfService._resolveRegularNetPriceEur(item, booking) *
+        PdfService._itemAmountMultiplier(item);
+    }
+    return Math.round(nettoEur * 100) / 100;
+  }
+
+  static _itemAmountMultiplier(item) {
+    return item.ignoreAmount ? 1 : item.amount;
+  }
+
+  static _buildTableTotals(booking, options = {}) {
+    const coupon = booking._couponUsed;
+
+    if (!PdfService._usesPreDiscountCouponDisplay(coupon)) {
+      return PdfService._buildTotals(
+        booking.priceEur,
+        booking.vatIncludedEur,
+        options,
+      );
+    }
+
+    const nettoEur = PdfService._calculatePreDiscountNetTotal(booking);
+    const vatRate = PdfService._bookingVatRate(booking);
+    const vatEur = Math.round(nettoEur * vatRate * 100) / 100;
+    const finalTotals = PdfService._buildTotals(
+      booking.priceEur,
+      booking.vatIncludedEur,
+      options,
+    );
+    const format = options.negative
+      ? formatters.formatNegativeCurrency
+      : formatters.formatCurrency;
+
+    return {
+      ...finalTotals,
+      nettoEur,
+      vatEur,
+      netto: format(nettoEur),
+      vat: format(vatEur),
+    };
+  }
+
   /**
    * Builds the structured line items of a booking.
    *
@@ -904,22 +1037,46 @@ class PdfService {
     const format = options.negative
       ? formatters.formatNegativeCurrency
       : formatters.formatCurrency;
+    const coupon = booking._couponUsed;
+    const showRegularNetPrice =
+      PdfService._usesPreDiscountCouponDisplay(coupon);
 
     return (booking.bookableItems || []).map((item) => {
       const bookable =
         item._bookableUsed ||
         allBookables.find((b) => b.id === item.bookableId);
-      const totalPriceEur = item.userPriceEur * item.amount;
+      const unitPriceEur = showRegularNetPrice
+        ? PdfService._resolveRegularNetPriceEur(item, booking)
+        : item.userPriceEur;
+      const multiplier = PdfService._itemAmountMultiplier(item);
+      const totalPriceEur = unitPriceEur * multiplier;
 
       return {
         title: bookable?.title || "Unbekannt",
         amount: item.amount,
-        unitPriceEur: item.userPriceEur,
+        unitPriceEur,
         totalPriceEur,
-        unitPrice: format(item.userPriceEur),
+        unitPrice: format(unitPriceEur),
         totalPrice: format(totalPriceEur),
       };
     });
+  }
+
+  static _formatCouponDescription(coupon) {
+    const description = (coupon.description || "").trim();
+    const discountText = String(coupon.discount);
+
+    if (coupon.type === COUPON_TYPE.FIXED) {
+      if (!description || description === discountText) {
+        return "Rabatt";
+      }
+      return `Rabatt (${description})`;
+    }
+
+    if (!description) {
+      return "Rabatt";
+    }
+    return `Rabatt (${description})`;
   }
 
   static _buildCoupon(booking, options = {}) {
@@ -929,13 +1086,24 @@ class PdfService {
     }
 
     const sign = options.negative ? "+" : "-";
-    const unit = coupon.type === "fixed" ? "€" : "%";
+    let discountLabel;
+
+    if (coupon.type === COUPON_TYPE.FIXED) {
+      discountLabel = (options.negative
+        ? formatters.formatCurrency
+        : formatters.formatNegativeCurrency)(coupon.discount);
+    } else if (coupon.type === COUPON_TYPE.PERCENTAGE) {
+      discountLabel = `${sign}${coupon.discount} %`;
+    } else {
+      return null;
+    }
 
     return {
-      description: coupon.description,
+      description: PdfService._formatCouponDescription(coupon),
       discount: coupon.discount,
       type: coupon.type,
-      discountLabel: `${sign}${coupon.discount} ${unit}`,
+      discountLabel,
+      showAfterVat: true,
     };
   }
 

--- a/src/commons/pdf-service/templates/partials/aggregated-bookings-table.temp.html
+++ b/src/commons/pdf-service/templates/partials/aggregated-bookings-table.temp.html
@@ -27,6 +27,12 @@
       <td class="label">Gesamt (netto)</td>
       <td class="value">{{netto}}</td>
     </tr>
+    {{#if coupon}}
+    <tr>
+      <td class="label">{{coupon.description}}</td>
+      <td class="value">{{coupon.discountLabel}}</td>
+    </tr>
+    {{/if}}
     {{/each}}
     <tr class="booking-sep">
       <td colspan="2"></td>
@@ -65,7 +71,8 @@
       <td colspan="{{../tableMeta.aggregatedInvoiceColumnCount}}" class="sub">
         {{#each items}}{{title}} ×{{amount}} ({{totalPrice}}){{#unless @last}}
         &nbsp;·&nbsp; {{/unless}}{{else}}Keine Buchungsobjekte
-        vorhanden.{{/each}}
+        vorhanden.{{/each}}{{#if coupon}} &nbsp;·&nbsp; {{coupon.description}}:
+        {{coupon.discountLabel}}{{/if}}
       </td>
     </tr>
     {{/each}}
@@ -105,6 +112,9 @@
           {{else}}
           <li>Keine Buchungsobjekte vorhanden.</li>
           {{/each}}
+          {{#if coupon}}
+          <li>{{coupon.description}}: {{coupon.discountLabel}}</li>
+          {{/if}}
         </ul>
       </td>
     </tr>

--- a/src/commons/pdf-service/templates/partials/aggregated-receipt-table.temp.html
+++ b/src/commons/pdf-service/templates/partials/aggregated-receipt-table.temp.html
@@ -37,6 +37,12 @@
       <td class="label">Gesamt (netto)</td>
       <td class="value">{{netto}}</td>
     </tr>
+    {{#if coupon}}
+    <tr>
+      <td class="label">{{coupon.description}}</td>
+      <td class="value">{{coupon.discountLabel}}</td>
+    </tr>
+    {{/if}}
     {{/each}}
     <tr class="booking-sep">
       <td colspan="2"></td>
@@ -78,7 +84,8 @@
     <tr>
       <td colspan="{{../tableMeta.aggregatedReceiptColumnCount}}" class="sub">
         {{#each items}}{{title}} ×{{amount}} ({{totalPrice}}){{#unless @last}}
-        &nbsp;·&nbsp; {{/unless}}{{else}}Keine Artikel{{/each}}
+        &nbsp;·&nbsp; {{/unless}}{{else}}Keine Artikel{{/each}}{{#if coupon}}
+        &nbsp;·&nbsp; {{coupon.description}}: {{coupon.discountLabel}}{{/if}}
       </td>
     </tr>
     {{/each}}
@@ -122,6 +129,9 @@
           {{else}}
           <li>Keine Artikel</li>
           {{/each}}
+          {{#if coupon}}
+          <li>{{coupon.description}}: {{coupon.discountLabel}}</li>
+          {{/if}}
         </ul>
       </td>
     </tr>

--- a/src/commons/pdf-service/templates/partials/booking-items-table.temp.html
+++ b/src/commons/pdf-service/templates/partials/booking-items-table.temp.html
@@ -15,12 +15,12 @@
       <td class="label">zzgl. MwSt.</td>
       <td class="value">{{totals.vat}}</td>
     </tr>
-    {{#if coupon}}{{#if coupon.showAfterVat}}
+    {{#if coupon}}
     <tr>
       <td class="label">{{coupon.description}}</td>
       <td class="value">{{coupon.discountLabel}}</td>
     </tr>
-    {{/if}}{{/if}}
+    {{/if}}
     <tr class="totals">
       <td class="label">Gesamt (brutto)</td>
       <td class="value">{{totals.brutto}}</td>
@@ -40,12 +40,7 @@
       <td class="label">Buchungszeitraum</td>
       <td class="value">{{booking.period}}</td>
     </tr>
-    {{/if}} {{/if}} {{#if coupon}}{{#unless coupon.showAfterVat}}
-    <tr>
-      <td class="label">{{coupon.description}}</td>
-      <td class="value">{{coupon.discountLabel}}</td>
-    </tr>
-    {{/unless}}{{/if}}
+    {{/if}} {{/if}}
     <tr class="objects">
       <td class="label">Buchungsobjekt</td>
       <td class="value">
@@ -75,23 +70,18 @@
       <td class="bi-price-item num">{{amount}} × {{unitPrice}}</td>
       <td class="bi-price-total num">{{totalPrice}}</td>
     </tr>
-    {{/each}} {{#if coupon}}{{#unless coupon.showAfterVat}}
-    <tr class="coupon">
-      <td colspan="2">{{coupon.description}}</td>
-      <td class="num">{{coupon.discountLabel}}</td>
-    </tr>
-    {{/unless}}{{/if}}
+    {{/each}}
     <tr class="totals-sub netto">
       <td colspan="3">
         Gesamt (netto) {{totals.netto}} &nbsp;·&nbsp; zzgl. MwSt. {{totals.vat}}
       </td>
     </tr>
-    {{#if coupon}}{{#if coupon.showAfterVat}}
+    {{#if coupon}}
     <tr class="coupon">
       <td colspan="2">{{coupon.description}}</td>
       <td class="num">{{coupon.discountLabel}}</td>
     </tr>
-    {{/if}}{{/if}}
+    {{/if}}
     <tr class="brutto">
       <td colspan="2">Gesamt (brutto)</td>
       <td class="num">{{totals.brutto}}</td>
@@ -124,12 +114,7 @@
       <td class="bi-price-item num">{{unitPrice}}</td>
       <td class="bi-price-total num">{{totalPrice}}</td>
     </tr>
-    {{/each}} {{#if coupon}}{{#unless coupon.showAfterVat}}
-    <tr class="coupon">
-      <td colspan="3">{{coupon.description}}</td>
-      <td class="num">{{coupon.discountLabel}}</td>
-    </tr>
-    {{/unless}}{{/if}}
+    {{/each}}
     <tr class="netto">
       <td colspan="3">Gesamt (netto)</td>
       <td class="num">{{totals.netto}}</td>
@@ -138,12 +123,12 @@
       <td colspan="3">zzgl. MwSt.</td>
       <td class="num">{{totals.vat}}</td>
     </tr>
-    {{#if coupon}}{{#if coupon.showAfterVat}}
+    {{#if coupon}}
     <tr class="coupon">
       <td colspan="3">{{coupon.description}}</td>
       <td class="num">{{coupon.discountLabel}}</td>
     </tr>
-    {{/if}}{{/if}}
+    {{/if}}
     <tr class="brutto">
       <td colspan="3">Gesamt (brutto)</td>
       <td class="num">{{totals.brutto}}</td>

--- a/src/commons/pdf-service/templates/partials/booking-items-table.temp.html
+++ b/src/commons/pdf-service/templates/partials/booking-items-table.temp.html
@@ -15,6 +15,12 @@
       <td class="label">zzgl. MwSt.</td>
       <td class="value">{{totals.vat}}</td>
     </tr>
+    {{#if coupon}}{{#if coupon.showAfterVat}}
+    <tr>
+      <td class="label">{{coupon.description}}</td>
+      <td class="value">{{coupon.discountLabel}}</td>
+    </tr>
+    {{/if}}{{/if}}
     <tr class="totals">
       <td class="label">Gesamt (brutto)</td>
       <td class="value">{{totals.brutto}}</td>
@@ -34,12 +40,12 @@
       <td class="label">Buchungszeitraum</td>
       <td class="value">{{booking.period}}</td>
     </tr>
-    {{/if}} {{/if}} {{#if coupon}}
+    {{/if}} {{/if}} {{#if coupon}}{{#unless coupon.showAfterVat}}
     <tr>
       <td class="label">{{coupon.description}}</td>
       <td class="value">{{coupon.discountLabel}}</td>
     </tr>
-    {{/if}}
+    {{/unless}}{{/if}}
     <tr class="objects">
       <td class="label">Buchungsobjekt</td>
       <td class="value">
@@ -69,17 +75,23 @@
       <td class="bi-price-item num">{{amount}} × {{unitPrice}}</td>
       <td class="bi-price-total num">{{totalPrice}}</td>
     </tr>
-    {{/each}} {{#if coupon}}
+    {{/each}} {{#if coupon}}{{#unless coupon.showAfterVat}}
     <tr class="coupon">
       <td colspan="2">{{coupon.description}}</td>
       <td class="num">{{coupon.discountLabel}}</td>
     </tr>
-    {{/if}}
+    {{/unless}}{{/if}}
     <tr class="totals-sub netto">
       <td colspan="3">
         Gesamt (netto) {{totals.netto}} &nbsp;·&nbsp; zzgl. MwSt. {{totals.vat}}
       </td>
     </tr>
+    {{#if coupon}}{{#if coupon.showAfterVat}}
+    <tr class="coupon">
+      <td colspan="2">{{coupon.description}}</td>
+      <td class="num">{{coupon.discountLabel}}</td>
+    </tr>
+    {{/if}}{{/if}}
     <tr class="brutto">
       <td colspan="2">Gesamt (brutto)</td>
       <td class="num">{{totals.brutto}}</td>
@@ -112,12 +124,12 @@
       <td class="bi-price-item num">{{unitPrice}}</td>
       <td class="bi-price-total num">{{totalPrice}}</td>
     </tr>
-    {{/each}} {{#if coupon}}
+    {{/each}} {{#if coupon}}{{#unless coupon.showAfterVat}}
     <tr class="coupon">
       <td colspan="3">{{coupon.description}}</td>
       <td class="num">{{coupon.discountLabel}}</td>
     </tr>
-    {{/if}}
+    {{/unless}}{{/if}}
     <tr class="netto">
       <td colspan="3">Gesamt (netto)</td>
       <td class="num">{{totals.netto}}</td>
@@ -126,6 +138,12 @@
       <td colspan="3">zzgl. MwSt.</td>
       <td class="num">{{totals.vat}}</td>
     </tr>
+    {{#if coupon}}{{#if coupon.showAfterVat}}
+    <tr class="coupon">
+      <td colspan="3">{{coupon.description}}</td>
+      <td class="num">{{coupon.discountLabel}}</td>
+    </tr>
+    {{/if}}{{/if}}
     <tr class="brutto">
       <td colspan="3">Gesamt (brutto)</td>
       <td class="num">{{totals.brutto}}</td>

--- a/src/commons/services/checkout/bundle-checkout-service.js
+++ b/src/commons/services/checkout/bundle-checkout-service.js
@@ -5,6 +5,7 @@ const {
 const { BookableManager } = require("../../data-managers/bookable-manager");
 const BookingManager = require("../../data-managers/booking-manager");
 const CouponManager = require("../../data-managers/coupon-manager");
+const { COUPON_TYPE } = require("../../entities/coupon/coupon");
 const LockerService = require("../locker/locker-service");
 const { primaryEmailFromMail } = require("../../utilities/checkout-utils");
 
@@ -87,6 +88,38 @@ class BundleCheckoutService {
       : [];
   }
 
+  async _getUsedCoupon() {
+    if (!this.couponCode) {
+      return null;
+    }
+    if (this._usedCoupon !== undefined) {
+      return this._usedCoupon;
+    }
+    this._usedCoupon = await CouponManager.getCoupon(
+      this.couponCode,
+      this.tenant,
+    );
+    return this._usedCoupon;
+  }
+
+  async _isMultiItemFixedCoupon() {
+    if (!this.couponCode || this.bookableItems.length <= 1) {
+      return false;
+    }
+    const coupon = await this._getUsedCoupon();
+    return coupon?.type === COUPON_TYPE.FIXED;
+  }
+
+  async _itemCouponCode() {
+    if (!this.couponCode) {
+      return null;
+    }
+    if (await this._isMultiItemFixedCoupon()) {
+      return null;
+    }
+    return this.couponCode;
+  }
+
   async createItemCheckoutService(bookableItem) {
     const itemCheckoutService = new ItemCheckoutService({
       user: this.user,
@@ -95,7 +128,7 @@ class BundleCheckoutService {
       timeEnd: this.timeEnd,
       bookableId: bookableItem.bookableId,
       amount: bookableItem.amount,
-      couponCode: this.couponCode,
+      couponCode: await this._itemCouponCode(),
       bookWithoutDiscount: this.bookWithoutDiscount,
       checkoutId: this.checkoutId,
     });
@@ -164,8 +197,23 @@ class BundleCheckoutService {
       const multiplier = bookableItem.ignoreAmount ? 1 : bookableItem.amount;
       total += bookableItem.userPriceEur * multiplier;
     }
+    total = Math.round(total * 100) / 100;
 
-    return Math.round(total * 100) / 100;
+    if (await this._isMultiItemFixedCoupon()) {
+      const grossAfter = await this.userGrossPriceEur();
+      let grossBefore = 0;
+      for (const bookableItem of this.bookableItems) {
+        const multiplier = bookableItem.ignoreAmount ? 1 : bookableItem.amount;
+        grossBefore += bookableItem.userGrossPriceEur * multiplier;
+      }
+      grossBefore = Math.round(grossBefore * 100) / 100;
+      if (!grossBefore) {
+        return 0;
+      }
+      return Math.round(((total * grossAfter) / grossBefore) * 100) / 100;
+    }
+
+    return total;
   }
 
   async userGrossPriceEur() {
@@ -174,7 +222,14 @@ class BundleCheckoutService {
       const multiplier = bookableItem.ignoreAmount ? 1 : bookableItem.amount;
       total += bookableItem.userGrossPriceEur * multiplier;
     }
-    return Math.round(total * 100) / 100;
+    total = Math.round(total * 100) / 100;
+
+    if (await this._isMultiItemFixedCoupon()) {
+      const coupon = await this._getUsedCoupon();
+      return Math.max(0, Math.round((total - coupon.discount) * 100) / 100);
+    }
+
+    return total;
   }
 
   async vatIncludedEur() {
@@ -502,7 +557,7 @@ class ManualBundleCheckoutService extends BundleCheckoutService {
       timeEnd: this.timeEnd,
       bookableId: bookableItem.bookableId,
       amount: bookableItem.amount,
-      couponCode: this.couponCode,
+      couponCode: await this._itemCouponCode(),
       bookWithoutDiscount: this.bookWithoutDiscount,
     });
 

--- a/src/commons/services/checkout/item-checkout-service.js
+++ b/src/commons/services/checkout/item-checkout-service.js
@@ -519,34 +519,35 @@ class ItemCheckoutService {
     return Math.round(price * 100) / 100;
   }
 
-  async userPriceEur() {
-    return this._cached("userPriceEur", async () => {
-      let price = await this.regularPriceEur();
+  async _userPricesAfterCoupons() {
+    return this._cached("userPricesAfterCoupons", async () => {
+      let netPrice = await this.regularPriceEur();
 
       const discountPercent = await this.bookingDiscountPercent();
       if (discountPercent > 0 && !this.bookWithoutDiscount) {
-        price = Math.max(
+        netPrice = Math.max(
           0,
-          Math.round(price * (1 - discountPercent / 100) * 100) / 100,
+          Math.round(netPrice * (1 - discountPercent / 100) * 100) / 100,
         );
       }
 
-      const total = await CouponService.applyCoupon(
+      return CouponService.applyCouponToCheckoutPrices(
         this.originBookable.enableCoupons ? this.couponCode : null,
         this.tenantId,
-        price,
+        netPrice,
+        await this.priceValueAddedTax(),
       );
-
-      return Math.round(total * 100) / 100;
     });
   }
 
+  async userPriceEur() {
+    const { netPrice } = await this._userPricesAfterCoupons();
+    return netPrice;
+  }
+
   async userGrossPriceEur() {
-    return this._cached("userGrossPriceEur", async () => {
-      const price =
-        (await this.userPriceEur()) * (1 + (await this.priceValueAddedTax()));
-      return Math.round(price * 100) / 100;
-    });
+    const { grossPrice } = await this._userPricesAfterCoupons();
+    return grossPrice;
   }
 
   async checkPermissions() {

--- a/src/commons/services/coupon-service.js
+++ b/src/commons/services/coupon-service.js
@@ -3,6 +3,10 @@ const { COUPON_TYPE } = require("../entities/coupon/coupon");
 const crypto = require("crypto");
 
 class CouponService {
+  static _roundEur(value) {
+    return Math.round(value * 100) / 100;
+  }
+
   static async applyCoupon(couponID, tenantID, bookingPrice) {
     if (!couponID) {
       return bookingPrice;
@@ -28,6 +32,69 @@ class CouponService {
         break;
     }
     return discountedPrice;
+  }
+
+  /**
+   * Applies a coupon to checkout prices.
+   * Percentage coupons are deducted from net; fixed-amount coupons from gross.
+   *
+   * @param {string|null} couponID
+   * @param {string} tenantID
+   * @param {number} netPrice Net price after booking discounts
+   * @param {number} vatRate VAT rate as decimal (e.g. 0.19)
+   * @returns {Promise<{ netPrice: number, grossPrice: number }>}
+   */
+  static async applyCouponToCheckoutPrices(
+    couponID,
+    tenantID,
+    netPrice,
+    vatRate,
+  ) {
+    const roundedNet = CouponService._roundEur(netPrice);
+
+    if (!couponID) {
+      return {
+        netPrice: roundedNet,
+        grossPrice: CouponService._roundEur(roundedNet * (1 + vatRate)),
+      };
+    }
+
+    const coupon = await CouponManager.getCoupon(couponID, tenantID);
+
+    if (!coupon) {
+      return {
+        netPrice: roundedNet,
+        grossPrice: CouponService._roundEur(roundedNet * (1 + vatRate)),
+      };
+    }
+
+    if (coupon.type === COUPON_TYPE.PERCENTAGE) {
+      const discountedNet = CouponService._roundEur(
+        Math.max(0, roundedNet * (1 - coupon.discount / 100)),
+      );
+      return {
+        netPrice: discountedNet,
+        grossPrice: CouponService._roundEur(discountedNet * (1 + vatRate)),
+      };
+    }
+
+    if (coupon.type === COUPON_TYPE.FIXED) {
+      const grossBeforeCoupon = CouponService._roundEur(
+        roundedNet * (1 + vatRate),
+      );
+      const grossPrice = CouponService._roundEur(
+        Math.max(0, grossBeforeCoupon - coupon.discount),
+      );
+      return {
+        netPrice: CouponService._roundEur(grossPrice / (1 + vatRate)),
+        grossPrice,
+      };
+    }
+
+    return {
+      netPrice: roundedNet,
+      grossPrice: CouponService._roundEur(roundedNet * (1 + vatRate)),
+    };
   }
 
   static async incrementCouponUsage(couponID, tenantID) {

--- a/src/commons/services/coupon-service.js
+++ b/src/commons/services/coupon-service.js
@@ -7,6 +7,14 @@ class CouponService {
     return Math.round(value * 100) / 100;
   }
 
+  static _unchangedCheckoutPrices(netPrice, vatRate) {
+    const roundedNet = CouponService._roundEur(netPrice);
+    return {
+      netPrice: roundedNet,
+      grossPrice: CouponService._roundEur(roundedNet * (1 + vatRate)),
+    };
+  }
+
   static async applyCoupon(couponID, tenantID, bookingPrice) {
     if (!couponID) {
       return bookingPrice;
@@ -53,19 +61,13 @@ class CouponService {
     const roundedNet = CouponService._roundEur(netPrice);
 
     if (!couponID) {
-      return {
-        netPrice: roundedNet,
-        grossPrice: CouponService._roundEur(roundedNet * (1 + vatRate)),
-      };
+      return CouponService._unchangedCheckoutPrices(netPrice, vatRate);
     }
 
     const coupon = await CouponManager.getCoupon(couponID, tenantID);
 
     if (!coupon) {
-      return {
-        netPrice: roundedNet,
-        grossPrice: CouponService._roundEur(roundedNet * (1 + vatRate)),
-      };
+      return CouponService._unchangedCheckoutPrices(netPrice, vatRate);
     }
 
     if (coupon.type === COUPON_TYPE.PERCENTAGE) {
@@ -91,10 +93,7 @@ class CouponService {
       };
     }
 
-    return {
-      netPrice: roundedNet,
-      grossPrice: CouponService._roundEur(roundedNet * (1 + vatRate)),
-    };
+    return CouponService._unchangedCheckoutPrices(netPrice, vatRate);
   }
 
   static async incrementCouponUsage(couponID, tenantID) {

--- a/tests/booking-discount-checkout.test.js
+++ b/tests/booking-discount-checkout.test.js
@@ -76,9 +76,13 @@ describe("ItemCheckoutService booking discount pricing", function () {
       .stub(MembershipManager, "getMembershipByTenantAndUserID")
       .resolves({ roles: ["role-member"] });
     sinon
-      .stub(CouponService, "applyCoupon")
-      .callsFake(async (_code, _tenant, price) => {
-        return Math.max(0, price - 10);
+      .stub(CouponService, "applyCouponToCheckoutPrices")
+      .callsFake(async (_code, _tenant, netPrice, vatRate) => {
+        const net = Math.max(0, netPrice - 10);
+        return {
+          netPrice: net,
+          grossPrice: Math.round(net * (1 + vatRate) * 100) / 100,
+        };
       });
 
     const bookable = discountBookable({
@@ -103,8 +107,11 @@ describe("ItemCheckoutService booking discount pricing", function () {
       .stub(MembershipManager, "getMembershipByTenantAndUserID")
       .resolves({ roles: [] });
     sinon
-      .stub(CouponService, "applyCoupon")
-      .callsFake(async (_code, _tenant, price) => price);
+      .stub(CouponService, "applyCouponToCheckoutPrices")
+      .callsFake(async (_code, _tenant, netPrice, vatRate) => ({
+        netPrice,
+        grossPrice: Math.round(netPrice * (1 + vatRate) * 100) / 100,
+      }));
 
     const bookable = discountBookable({
       bookingDiscounts: {
@@ -125,8 +132,11 @@ describe("ItemCheckoutService booking discount pricing", function () {
       .stub(MembershipManager, "getMembershipByTenantAndUserID")
       .resolves({ roles: [] });
     sinon
-      .stub(CouponService, "applyCoupon")
-      .callsFake(async (_code, _tenant, price) => price);
+      .stub(CouponService, "applyCouponToCheckoutPrices")
+      .callsFake(async (_code, _tenant, netPrice, vatRate) => ({
+        netPrice,
+        grossPrice: Math.round(netPrice * (1 + vatRate) * 100) / 100,
+      }));
 
     const bookable = discountBookable({
       bookingDiscounts: {

--- a/tests/fixed-coupon-checkout.test.js
+++ b/tests/fixed-coupon-checkout.test.js
@@ -6,6 +6,9 @@ const {
 } = require("../src/commons/services/checkout/item-checkout-service");
 const CouponManager = require("../src/commons/data-managers/coupon-manager");
 const CouponService = require("../src/commons/services/coupon-service");
+const {
+  BundleCheckoutService,
+} = require("../src/commons/services/checkout/bundle-checkout-service");
 const MembershipManager = require("../src/commons/data-managers/membership-manager");
 const { COUPON_TYPE } = require("../src/commons/entities/coupon/coupon");
 
@@ -113,5 +116,64 @@ describe("ItemCheckoutService fixed coupon pricing", function () {
 
     assert.strictEqual(await service.userGrossPriceEur(), 109);
     assert.strictEqual(await service.userPriceEur(), 91.6);
+  });
+});
+
+describe("BundleCheckoutService fixed coupon pricing", function () {
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it("applies fixed-amount coupons once across multiple items", async function () {
+    sinon.stub(CouponManager, "getCoupon").resolves({
+      type: COUPON_TYPE.FIXED,
+      discount: 10,
+    });
+
+    const service = new BundleCheckoutService({
+      user: USER_ID,
+      tenant: TENANT_ID,
+      timeBegin: Date.now(),
+      timeEnd: Date.now() + 3600000,
+      bookableItems: [
+        {
+          bookableId: "a",
+          amount: 1,
+          userPriceEur: 100,
+          userGrossPriceEur: 119,
+        },
+        {
+          bookableId: "b",
+          amount: 1,
+          userPriceEur: 50,
+          userGrossPriceEur: 59.5,
+        },
+      ],
+      couponCode: "SAVE10",
+    });
+
+    assert.strictEqual(await service.userGrossPriceEur(), 168.5);
+    assert.strictEqual(await service.userPriceEur(), 141.6);
+  });
+
+  it("does not pass fixed coupons to per-item checkout for multi-item bundles", async function () {
+    sinon.stub(CouponManager, "getCoupon").resolves({
+      type: COUPON_TYPE.FIXED,
+      discount: 10,
+    });
+
+    const service = new BundleCheckoutService({
+      user: USER_ID,
+      tenant: TENANT_ID,
+      timeBegin: Date.now(),
+      timeEnd: Date.now() + 3600000,
+      bookableItems: [
+        { bookableId: "a", amount: 1 },
+        { bookableId: "b", amount: 1 },
+      ],
+      couponCode: "SAVE10",
+    });
+
+    assert.strictEqual(await service._itemCouponCode(), null);
   });
 });

--- a/tests/fixed-coupon-checkout.test.js
+++ b/tests/fixed-coupon-checkout.test.js
@@ -1,0 +1,117 @@
+const assert = require("assert");
+const sinon = require("sinon");
+const { Bookable } = require("../src/commons/entities/bookable/bookable");
+const {
+  ManualItemCheckoutService,
+} = require("../src/commons/services/checkout/item-checkout-service");
+const CouponManager = require("../src/commons/data-managers/coupon-manager");
+const CouponService = require("../src/commons/services/coupon-service");
+const MembershipManager = require("../src/commons/data-managers/membership-manager");
+const { COUPON_TYPE } = require("../src/commons/entities/coupon/coupon");
+
+const TENANT_ID = "tenant-1";
+const USER_ID = "user-1";
+
+function couponBookable(overrides = {}) {
+  return new Bookable({
+    id: "ticket-a",
+    tenantId: TENANT_ID,
+    title: "Ticket A",
+    priceType: "per-item",
+    priceValueAddedTax: 19,
+    priceCategories: [{ priceEur: 100, interval: { start: null, end: null } }],
+    enableCoupons: true,
+    ...overrides,
+  });
+}
+
+async function createCheckoutService(bookable, options = {}) {
+  const service = new ManualItemCheckoutService({
+    user: USER_ID,
+    tenantId: TENANT_ID,
+    timeBegin: Date.now(),
+    timeEnd: Date.now() + 3600000,
+    bookableId: bookable.id,
+    amount: 1,
+    couponCode: options.couponCode ?? null,
+    bookWithoutDiscount: options.bookWithoutDiscount ?? false,
+  });
+
+  await service.init(bookable);
+  return service;
+}
+
+describe("CouponService.applyCouponToCheckoutPrices", function () {
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it("deducts fixed-amount coupons from gross price", async function () {
+    sinon.stub(CouponManager, "getCoupon").resolves({
+      type: COUPON_TYPE.FIXED,
+      discount: 10,
+    });
+
+    const result = await CouponService.applyCouponToCheckoutPrices(
+      "SAVE10",
+      TENANT_ID,
+      100,
+      0.19,
+    );
+
+    assert.strictEqual(result.grossPrice, 109);
+    assert.strictEqual(result.netPrice, 91.6);
+  });
+
+  it("keeps percentage coupons on net price", async function () {
+    sinon.stub(CouponManager, "getCoupon").resolves({
+      type: COUPON_TYPE.PERCENTAGE,
+      discount: 50,
+    });
+
+    const result = await CouponService.applyCouponToCheckoutPrices(
+      "HALF",
+      TENANT_ID,
+      100,
+      0.19,
+    );
+
+    assert.strictEqual(result.netPrice, 50);
+    assert.strictEqual(result.grossPrice, 59.5);
+  });
+
+  it("returns unchanged prices when no coupon is provided", async function () {
+    const result = await CouponService.applyCouponToCheckoutPrices(
+      null,
+      TENANT_ID,
+      100,
+      0.19,
+    );
+
+    assert.strictEqual(result.netPrice, 100);
+    assert.strictEqual(result.grossPrice, 119);
+  });
+});
+
+describe("ItemCheckoutService fixed coupon pricing", function () {
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it("applies fixed-amount coupons to gross checkout price", async function () {
+    sinon
+      .stub(MembershipManager, "getMembershipByTenantAndUserID")
+      .resolves({ roles: [] });
+    sinon.stub(CouponManager, "getCoupon").resolves({
+      type: COUPON_TYPE.FIXED,
+      discount: 10,
+    });
+
+    const service = await createCheckoutService(couponBookable(), {
+      couponCode: "SAVE10",
+    });
+
+    assert.strictEqual(await service.userGrossPriceEur(), 109);
+    assert.strictEqual(await service.userPriceEur(), 91.6);
+  });
+});

--- a/tests/pdf-service.test.js
+++ b/tests/pdf-service.test.js
@@ -488,10 +488,7 @@ describe("PdfService fixed coupon display", () => {
   }
 
   it("shows regular net prices on line items", () => {
-    const items = PdfService._buildItems(
-      makeFixedCouponBooking(),
-      bookables,
-    );
+    const items = PdfService._buildItems(makeFixedCouponBooking(), bookables);
 
     assert.strictEqual(items[0].unitPriceEur, 100);
     assert.strictEqual(items[0].totalPriceEur, 100);
@@ -521,7 +518,6 @@ describe("PdfService fixed coupon display", () => {
     const coupon = PdfService._buildCoupon(makeFixedCouponBooking());
 
     assert.ok(coupon.discountLabel.includes("-10,00"));
-    assert.strictEqual(coupon.showAfterVat, true);
   });
 
   it("shows pre-discount net and VAT totals before the coupon", () => {
@@ -574,6 +570,44 @@ describe("PdfService fixed coupon display", () => {
 
     assert.strictEqual(items[0].unitPriceEur, 100);
   });
+
+  it("uses a plus prefix for fixed coupons on cancellation receipts", () => {
+    const coupon = PdfService._buildCoupon(makeFixedCouponBooking(), {
+      negative: true,
+    });
+
+    assert.strictEqual(coupon.discountLabel, "+10,00 €");
+  });
+
+  it("allocates legacy fixed coupon discount proportionally across items", () => {
+    const bookables = [
+      { id: "room-a", title: "Room A" },
+      { id: "room-b", title: "Room B" },
+    ];
+    const booking = makeFixedCouponBooking({
+      priceEur: 168.5,
+      vatIncludedEur: 26.9,
+      bookableItems: [
+        {
+          bookableId: "room-a",
+          amount: 1,
+          userPriceEur: 100,
+          userGrossPriceEur: 119,
+        },
+        {
+          bookableId: "room-b",
+          amount: 1,
+          userPriceEur: 50,
+          userGrossPriceEur: 59.5,
+        },
+      ],
+    });
+
+    const items = PdfService._buildItems(booking, bookables);
+
+    assert.strictEqual(items[0].unitPriceEur, 100);
+    assert.strictEqual(items[1].unitPriceEur, 50);
+  });
 });
 
 describe("PdfService percentage coupon display", () => {
@@ -615,7 +649,6 @@ describe("PdfService percentage coupon display", () => {
 
     assert.strictEqual(coupon.description, "Rabatt (Prozent)");
     assert.strictEqual(coupon.discountLabel, "-10 %");
-    assert.strictEqual(coupon.showAfterVat, true);
   });
 
   it("shows pre-discount net and VAT totals before the coupon", () => {
@@ -624,6 +657,49 @@ describe("PdfService percentage coupon display", () => {
     assert.strictEqual(totals.nettoEur, 100);
     assert.strictEqual(totals.vatEur, 19);
     assert.strictEqual(totals.bruttoEur, 107.1);
+  });
+});
+
+describe("PdfService aggregated coupon display", () => {
+  const bookables = [{ id: "week-room", title: "Week" }];
+
+  function makeFixedCouponBooking(overrides = {}) {
+    return makeBooking({
+      priceEur: 109,
+      vatIncludedEur: 17.4,
+      _couponUsed: {
+        description: "Sommeraktion",
+        type: "fixed",
+        discount: 10,
+      },
+      bookableItems: [
+        {
+          bookableId: "week-room",
+          amount: 1,
+          regularPriceEur: 100,
+          regularGrossPriceEur: 119,
+          userPriceEur: 91.6,
+          userGrossPriceEur: 109,
+        },
+      ],
+      ...overrides,
+    });
+  }
+
+  it("shows pre-discount net totals and coupon data per booking row", () => {
+    const booking = makeFixedCouponBooking();
+    const { bookingRows } = PdfService._buildAggregatedData(
+      [booking],
+      bookables,
+    );
+
+    assert.strictEqual(bookingRows[0].nettoEur, 100);
+    assert.strictEqual(
+      bookingRows[0].coupon.description,
+      "Rabatt (Sommeraktion)",
+    );
+    assert.ok(bookingRows[0].coupon.discountLabel.includes("-10,00"));
+    assert.strictEqual(bookingRows[0].items[0].unitPriceEur, 100);
   });
 });
 

--- a/tests/pdf-service.test.js
+++ b/tests/pdf-service.test.js
@@ -461,6 +461,172 @@ describe("pdf booking table meta", () => {
   });
 });
 
+describe("PdfService fixed coupon display", () => {
+  const bookables = [{ id: "week-room", title: "Week" }];
+
+  function makeFixedCouponBooking(overrides = {}) {
+    return makeBooking({
+      priceEur: 109,
+      vatIncludedEur: 17.4,
+      _couponUsed: {
+        description: "Sommeraktion",
+        type: "fixed",
+        discount: 10,
+      },
+      bookableItems: [
+        {
+          bookableId: "week-room",
+          amount: 1,
+          regularPriceEur: 100,
+          regularGrossPriceEur: 119,
+          userPriceEur: 91.6,
+          userGrossPriceEur: 109,
+        },
+      ],
+      ...overrides,
+    });
+  }
+
+  it("shows regular net prices on line items", () => {
+    const items = PdfService._buildItems(
+      makeFixedCouponBooking(),
+      bookables,
+    );
+
+    assert.strictEqual(items[0].unitPriceEur, 100);
+    assert.strictEqual(items[0].totalPriceEur, 100);
+  });
+
+  it("labels fixed coupons explicitly as Rabatt", () => {
+    const coupon = PdfService._buildCoupon(makeFixedCouponBooking());
+
+    assert.strictEqual(coupon.description, "Rabatt (Sommeraktion)");
+  });
+
+  it("uses Rabatt without suffix when the description equals the discount amount", () => {
+    const coupon = PdfService._buildCoupon(
+      makeFixedCouponBooking({
+        _couponUsed: {
+          description: "10",
+          type: "fixed",
+          discount: 10,
+        },
+      }),
+    );
+
+    assert.strictEqual(coupon.description, "Rabatt");
+  });
+
+  it("shows the fixed coupon after VAT with a euro discount", () => {
+    const coupon = PdfService._buildCoupon(makeFixedCouponBooking());
+
+    assert.ok(coupon.discountLabel.includes("-10,00"));
+    assert.strictEqual(coupon.showAfterVat, true);
+  });
+
+  it("shows pre-discount net and VAT totals before the coupon", () => {
+    const totals = PdfService._buildTableTotals(makeFixedCouponBooking());
+
+    assert.strictEqual(totals.nettoEur, 100);
+    assert.strictEqual(totals.vatEur, 19);
+    assert.strictEqual(totals.bruttoEur, 109);
+  });
+
+  it("renders a detailed invoice table with net items and coupon after VAT", () => {
+    const booking = makeFixedCouponBooking();
+    const html = Handlebars.renderPartial("pdfBookingItemsTable", {
+      layout: "detailed",
+      tableClass: "booked-items",
+      items: PdfService._buildItems(booking, bookables),
+      coupon: PdfService._buildCoupon(booking),
+      totals: PdfService._buildTableTotals(booking),
+      booking: null,
+      tableMeta: {},
+      compactMetaHtml: null,
+    });
+
+    const nettoIndex = html.indexOf("Gesamt (netto)");
+    const mwstIndex = html.indexOf("zzgl. MwSt.");
+    const couponIndex = html.indexOf("Rabatt (Sommeraktion)");
+    const bruttoIndex = html.lastIndexOf("Gesamt (brutto)");
+
+    assert.ok(/100,00/.test(html));
+    assert.ok(/-10,00/.test(html));
+    assert.ok(/109,00/.test(html));
+    assert.ok(nettoIndex < mwstIndex);
+    assert.ok(mwstIndex < couponIndex);
+    assert.ok(couponIndex < bruttoIndex);
+  });
+
+  it("derives the regular net price for legacy bookings without stored values", () => {
+    const booking = makeFixedCouponBooking({
+      bookableItems: [
+        {
+          bookableId: "week-room",
+          amount: 1,
+          userPriceEur: 91.6,
+          userGrossPriceEur: 109,
+        },
+      ],
+    });
+
+    const items = PdfService._buildItems(booking, bookables);
+
+    assert.strictEqual(items[0].unitPriceEur, 100);
+  });
+});
+
+describe("PdfService percentage coupon display", () => {
+  const bookables = [{ id: "week-room", title: "Week" }];
+
+  function makePercentageCouponBooking(overrides = {}) {
+    return makeBooking({
+      priceEur: 107.1,
+      vatIncludedEur: 17.1,
+      _couponUsed: {
+        description: "Prozent",
+        type: "percentage",
+        discount: 10,
+      },
+      bookableItems: [
+        {
+          bookableId: "week-room",
+          amount: 1,
+          regularPriceEur: 100,
+          userPriceEur: 90,
+          userGrossPriceEur: 107.1,
+        },
+      ],
+      ...overrides,
+    });
+  }
+
+  it("shows regular net prices on line items", () => {
+    const items = PdfService._buildItems(
+      makePercentageCouponBooking(),
+      bookables,
+    );
+
+    assert.strictEqual(items[0].unitPriceEur, 100);
+  });
+
+  it("shows the percentage coupon after VAT", () => {
+    const coupon = PdfService._buildCoupon(makePercentageCouponBooking());
+
+    assert.strictEqual(coupon.description, "Rabatt (Prozent)");
+    assert.strictEqual(coupon.discountLabel, "-10 %");
+    assert.strictEqual(coupon.showAfterVat, true);
+  });
+
+  it("shows pre-discount net and VAT totals before the coupon", () => {
+    const totals = PdfService._buildTableTotals(makePercentageCouponBooking());
+
+    assert.strictEqual(totals.nettoEur, 100);
+    assert.strictEqual(totals.vatEur, 19);
+    assert.strictEqual(totals.bruttoEur, 107.1);
+  });
+});
+
 describe("pdf booking layout", () => {
   it("defaults to detailed when tenant has no layout configured", () => {
     const {


### PR DESCRIPTION
## Summary
- Apply fixed-amount coupons to the gross checkout price instead of the net price; percentage coupons and booking discounts remain unchanged
- Improve invoice/receipt PDFs for coupon bookings: show regular net line items, label coupon rows as Rabatt, and list fixed and percentage discounts after VAT

## Test plan
- [x] `npx mocha tests/fixed-coupon-checkout.test.js tests/pdf-service.test.js tests/booking-discount-checkout.test.js`
- [x] Verify checkout validate-item for a fixed coupon (100 € net, 19% VAT, 10 € discount → 109 € gross)
- [x] Regenerate invoice PDF for fixed and percentage coupon bookings and confirm layout
- [x] Confirm bookings without coupons are unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed-amount coupons are now deducted from the gross checkout price, while percentage coupons continue to apply to net prices.
  - Checkout totals now calculate net and gross amounts consistently, including VAT and booking discounts.
  - Invoice and receipt PDFs now show coupon-adjusted pricing accurately.
  - Coupon lines in PDFs are labeled “Rabatt,” display after VAT, and use regular net prices for line items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->