### PR TITLE
Add configurable cancellation refund tiers (DEV-786)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 ### Added
 
 - Tenant-wide cancellation refund tiers with calendar-day calculation, administrator previews and overrides, per-cancellation audit data, and partial single/group cancellation documents
+- Booking field `cancellationRefund` persists applied refund audit data on rejection, including when cancellation documents are skipped
 - Per-user and per-role percentage booking discounts on bookables via `bookingDiscounts` (replaces `freeBookingUsers` / `freeBookingRoles`); highest matching discount applies, then coupons
 - Checkout validate-item responses now include `bookingDiscountPercent`; `freeBookingAllowed` remains `true` when discount is 100%
 - Checkout request flag renamed from `bookWithPrice` to `bookWithoutDiscount` (inverted semantics; default `false`)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,8 +20,9 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 - Token type detection (`classifyToken`) extracted into a shared utility used by auth middleware and `authenticateIfNeeded`
 - Manual admin bookings now set `assignedUserId` from the booking email so the assigned user can see the booking in their personal booking list
 
-
 ### Added
+
+- Tenant-wide cancellation refund tiers with calendar-day calculation, administrator previews and overrides, per-cancellation audit data, and partial single/group cancellation documents
 - Per-user and per-role percentage booking discounts on bookables via `bookingDiscounts` (replaces `freeBookingUsers` / `freeBookingRoles`); highest matching discount applies, then coupons
 - Checkout validate-item responses now include `bookingDiscountPercent`; `freeBookingAllowed` remains `true` when discount is 100%
 - Checkout request flag renamed from `bookWithPrice` to `bookWithoutDiscount` (inverted semantics; default `false`)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 ### Fixed
 
+- Aggregated PDF item tables keep article detail rows visually connected to booking rows and render valid single-column totals when booking metadata columns are hidden; single-booking total amounts stay right-aligned in detailed tables
+- Cancellation numbers no longer default to a `Storno` prefix; an optional `cancellationNumberPrefix` is included in the cancellation number and PDF filename only when configured on the tenant (same pattern as invoice numbers)
 - Rule-engine aggregate email action tests mock `TenantManager.getTenant` and validate tenant existence before reading `tenant.name`, fixing timeouts in `rule-actions.test.js`
 - `npm test` no longer hangs after all tests pass; Keycloak cache prune interval uses `unref()` so it does not keep the Node process alive
 - Fixed-amount coupons are now deducted from the gross checkout price instead of the net price (percentage coupons and booking discounts unchanged)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 ### Added
 
+- Group booking cancellations accept optional `bankDetails` for the aggregated cancellation PDF (same fields as single-booking reject)
 - Public and hook-scoped cancellation refund preview endpoints for customer self-cancellation, plus refund amounts in verify-rejection and booking-cancel mails
 - Tenant-wide cancellation refund tiers with calendar-day calculation, administrator previews and overrides, per-cancellation audit data, and partial single/group cancellation documents
 - Booking field `cancellationRefund` persists applied refund audit data on rejection, including when cancellation documents are skipped

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 ### Added
 
+- Public and hook-scoped cancellation refund preview endpoints for customer self-cancellation, plus refund amounts in verify-rejection and booking-cancel mails
 - Tenant-wide cancellation refund tiers with calendar-day calculation, administrator previews and overrides, per-cancellation audit data, and partial single/group cancellation documents
 - Booking field `cancellationRefund` persists applied refund audit data on rejection, including when cancellation documents are skipped
 - Per-user and per-role percentage booking discounts on bookables via `bookingDiscounts` (replaces `freeBookingUsers` / `freeBookingRoles`); highest matching discount applies, then coupons

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 ### Fixed
 
+- Cancellation PDFs label policy-driven administrator refunds as automatic tenant-rule calculations; “Manuell durch Administration” only appears when an admin override was applied
+- Unrejecting a booking clears persisted `cancellationRefund` via `$unset` so the audit field is removed from MongoDB
 - Aggregated PDF item tables keep article detail rows visually connected to booking rows and render valid single-column totals when booking metadata columns are hidden; single-booking total amounts stay right-aligned in detailed tables
 - Cancellation numbers no longer default to a `Storno` prefix; an optional `cancellationNumberPrefix` is included in the cancellation number and PDF filename only when configured on the tenant (same pattern as invoice numbers)
 - Rule-engine aggregate email action tests mock `TenantManager.getTenant` and validate tenant existence before reading `tenant.name`, fixing timeouts in `rule-actions.test.js`

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -128,7 +128,7 @@ _Response body:_ `{ title, availability: [{ timeBegin, timeEnd, available }], _m
 
 Alias for the primary `/availability` endpoint (same V2 engine). Optional auth.
 
-### GET /api/:tenant/bookables/:id/availability/v1 *(deprecated)*
+### GET /api/:tenant/bookables/:id/availability/v1 _(deprecated)_
 
 Legacy iterative checkout-based availability. Prefer `/availability`. Optional auth.
 
@@ -171,6 +171,28 @@ _Response:_
 - **totalCapacity** — Total capacity of the bookable
 - **booked** — Number of booked units
 - **remaining** — Number of remaining units
+
+## Cancellation refunds
+
+Tenant owners configure `cancellationRefundTiers` through the existing tenant create/update API. An empty array means a full refund.
+
+### GET /api/:tenant/bookings/:id/cancellation-refund-preview
+
+Returns the current policy proposal for an administrator. **Requires JWT and booking update permission.**
+
+### POST /api/:tenant/bookings/:id/reject
+
+Cancels or rejects a booking. Administrators may send an integer `refundPercentage` from 0 through 100. If omitted, the current policy proposal is used.
+
+### GET /api/:tenant/group-bookings/:id/cancellation-refund-preview
+
+Returns per-booking calculations and aggregate amounts for a group booking. **Requires JWT and booking update permission.**
+
+### POST /api/:tenant/group-bookings/:id/reject
+
+Cancels or rejects a group booking. Without an override, each booking uses its policy proposal; an optional `refundPercentage` applies to all bookings in the group.
+
+Customer self-cancellations always use the current tenant policy when the verification link is released. Rule-engine and workflow cancellations retain a full refund. Refunds are documented for manual processing; payment providers are not called automatically.
 
 ## Other categories
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -180,6 +180,14 @@ Tenant owners configure `cancellationRefundTiers` through the existing tenant cr
 
 Returns the current policy proposal for an administrator. **Requires JWT and booking update permission.**
 
+### GET /api/:tenant/bookings/:id/cancellation-refund-preview/public?name=
+
+Returns a customer-safe refund preview for self-cancellation. **Requires matching booking owner name. No JWT.**
+
+### GET /api/:tenant/bookings/:id/hooks/:hookId/cancellation-refund-preview
+
+Returns a customer-safe refund preview for a pending REJECT verification hook. **No JWT.**
+
 ### POST /api/:tenant/bookings/:id/reject
 
 Cancels or rejects a booking. Administrators may send an integer `refundPercentage` from 0 through 100. If omitted, the current policy proposal is used.
@@ -192,7 +200,7 @@ Returns per-booking calculations and aggregate amounts for a group booking. **Re
 
 Cancels or rejects a group booking. Without an override, each booking uses its policy proposal; an optional `refundPercentage` applies to all bookings in the group.
 
-Customer self-cancellations always use the current tenant policy when the verification link is released. Rule-engine and workflow cancellations retain a full refund. Refunds are documented for manual processing; payment providers are not called automatically.
+Customer self-cancellations always use the current tenant policy when the verification link is released. Expected refund amounts are exposed via the public/hook preview endpoints and included in verify-rejection and booking-cancel mails. Rule-engine and workflow cancellations retain a full refund. Refunds are documented for manual processing; payment providers are not called automatically.
 
 ## Other categories
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -198,7 +198,7 @@ Returns per-booking calculations and aggregate amounts for a group booking. **Re
 
 ### POST /api/:tenant/group-bookings/:id/reject
 
-Cancels or rejects a group booking. Without an override, each booking uses its policy proposal; an optional `refundPercentage` applies to all bookings in the group.
+Cancels or rejects a group booking. Without an override, each booking uses its policy proposal; an optional `refundPercentage` applies to all bookings in the group. Optional `bankDetails` are rendered on the aggregated cancellation PDF when a refund document is generated.
 
 Customer self-cancellations always use the current tenant policy when the verification link is released. Expected refund amounts are exposed via the public/hook preview endpoints and included in verify-rejection and booking-cancel mails. Rule-engine and workflow cancellations retain a full refund. Refunds are documented for manual processing; payment providers are not called automatically.
 

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -43,6 +43,10 @@ Example:
   "invoiceTemplate": "<html>...</html>",
   "invoiceNumberPrefix": "exmp",
   "invoiceCount": { "2024": 1 },
+  "cancellationRefundTiers": [
+    { "daysBeforeStart": 20, "refundPercentage": 100 },
+    { "daysBeforeStart": 0, "refundPercentage": 50 }
+  ],
   "paymentPurposeSuffix": "Example 123 4 56",
   "applications": [],
   "maxBookingAdvanceInMonths": 12,
@@ -57,6 +61,8 @@ Example:
 ```
 
 > **Note:** Sensitive information (e.g. `noreplyPassword`, payment-related secrets) is stored encrypted in the database.
+
+`cancellationRefundTiers` defines the tenant-wide refund proposal at cancellation time. Thresholds use calendar days in `Europe/Berlin`. An empty array preserves the default full refund. Below the lowest configured threshold, that tier continues to apply.
 
 ### Roles
 
@@ -299,58 +305,58 @@ Example:
 
 Key fields of a bookable:
 
-| Field                 | Description                                                                                                                                                 |
-|-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| id                    | Unique identifier of the bookable.                                                                                                                          |
-| tenantId              | Tenant to which the bookable belongs.                                                                                                                       |
-| type                  | Type of the bookable (e.g. `room`, `location`, `resource`, `ticket`).                                                                                       |
-| title                 | Human readable title/name.                                                                                                                                  |
-| description           | Description of the bookable.                                                                                                                                |
-| location              | Geo object with `coordinates`, `display_address`, `address`, and `meta` (same shape as Event location). |
-| isPublic              | If `false`, the bookable is hidden from public listings.                                                                                                    |
-| isBookable            | If `false`, the bookable cannot be checked out.                                                                                                             |
-| amount                | Available capacity/amount. `null` means unlimited.                                                                                                         |
-| minBookingDuration    | Minimum booking duration in minutes (if schedule-related).                                                                                                  |
-| maxBookingDuration    | Maximum booking duration in minutes (if schedule-related).                                                                                                  |
-| autoCommitBooking     | If `true`, bookings are automatically committed / forwarded to payment.                                                                                    |
-| isScheduleRelated     | If `true`, the user is asked to choose a booking time during checkout.                                                                                    |
-| isTimePeriodRelated   | If `true`, the user selects one of the predefined `timePeriods`.                                                                                           |
-| timePeriods           | Weekly repeating time windows when the bookable can be used.                                                                                               |
-| isOpeningHoursRelated | If `true`, availability is derived from `openingHours`.                                                                                                     |
-| openingHours          | Regular opening hours per weekday.                                                                                                                          |
-| preparationLeadTimeMinutes | Minimum preparation time in minutes before booking start. Lead-time enforcement is active when `isScheduleRelated`, `isTimePeriodRelated`, or `isBlockPeriodRelated` is `true`, `preparationLeadTimeMinutes` is greater than `0`, and `serviceHours` is non-empty. |
-| serviceHours          | Service windows when preparation can take place (same structure as `openingHours`, independent of opening hours). Only evaluated together with `preparationLeadTimeMinutes` on schedule-, time-period-, and block-period-related bookables. |
-| bufferTimeBeforeMinutes | Optional capacity buffer before each booking (minutes). Active only when `isScheduleRelated` is `true` and value is greater than `0`. Blocks back-to-back bookings in calendar and checkout capacity checks. |
-| bufferTimeAfterMinutes | Optional capacity buffer after each booking (minutes). Active only when `isScheduleRelated` is `true` and value is greater than `0`. |
-| isSpecialOpeningHoursRelated | If `true`, `specialOpeningHours` override the regular opening hours for specific dates.                                                              |
-| specialOpeningHours   | Special opening hours for specific dates.                                                                                                                   |
-| isLongRange           | If `true`, long-range bookings (e.g. weeks/months) are enabled.                                                                                            |
-| longRangeOptions      | Configuration for long-range bookings (e.g. type = `week` or `month`).                                                                                    |
-| isBlockPeriodRelated  | If `true`, availability uses `blockPeriods` (recurring weekday/time windows).                                                                              |
-| blockPeriods          | Block periods with `id`, `label`, `startWeekday`, `startTime`, `endWeekday`, `endTime`.                                                                    |
-| priceCategories       | List of price categories including price, interval, affected weekdays and holidays.                                                                       |
-| priceType             | Price type (e.g. `per-hour`, `per-day`, `per-item`, `per-square-meter`).                                                                                   |
-| priceValueAddedTax    | VAT rate (in percent) applied to this bookable.                                                                                                            |
-| enableCoupons         | If `true`, coupons can be applied to this bookable.                                                                                                       |
-| tags                  | Tags used for internal grouping and filtering.                                                                                                             |
-| flags                 | Feature flags highlighted to users (e.g. "barrier-free").                                                                                                |
-| relatedBookableIds    | IDs of bookables related to this bookable.                                                                                                                 |
-| checkoutBookableIds   | Additional bookables for checkout: `{ bookableId, mandatory }`.                                                                                          |
-| requiresLogin         | If `true`, only authenticated users may book.                                                                                                              |
-| cancellationPolicy    | e.g. `{ userCancellable: true, contactHint: "" }` — whether users can cancel bookings themselves; `contactHint` is an optional message shown in emails when user cancellation is disabled.                                                                           |
-| permittedUsers        | List of user IDs that are allowed to book. If empty, every user including guests may book (depending on other rules).                                     |
-| permittedRoles        | List of role IDs that are allowed to book. If empty, every user including guests may book (depending on other rules).                                     |
-| bookingDiscounts      | Per-user and per-role booking discounts (`users[].userId`, `users[].discountPercent`, `roles[].roleId`, `roles[].discountPercent`; integer 0–100). Highest matching discount applies. |
-| attachments           | Attachments: `id`, `title`, `caption`, `type`, `url`, `show`, `required`, `mailAttach`.                                                                     |
-| lockerDetails         | Configuration for locker integrations (e.g. units).                                                                                                       |
-| requiredFields        | Checkout fields required from the user (default: `address`, `zipCode`, `city`).                                                                            |
-| externalProviders     | External pricing/availability providers: `active`, `provider`, `handles`, `config`.                                                                         |
-| customFieldDefinitions| Tenant/bookable-level custom field definitions.                                                                                                            |
-| customFieldValues     | Stored values for custom fields on this bookable.                                                                                                          |
-| eventId               | ID of the related event (for `ticket` bookables).                                                                                                         |
-| ownerUserId           | ID of the user that owns/manages this bookable.                                                                                                           |
-| timeCreated           | Timestamp when the bookable was created.                                                                                                                   |
-| timeUpdated           | Timestamp when the bookable was last updated.                                                                                                              |
+| Field                        | Description                                                                                                                                                                                                                                                        |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| id                           | Unique identifier of the bookable.                                                                                                                                                                                                                                 |
+| tenantId                     | Tenant to which the bookable belongs.                                                                                                                                                                                                                              |
+| type                         | Type of the bookable (e.g. `room`, `location`, `resource`, `ticket`).                                                                                                                                                                                              |
+| title                        | Human readable title/name.                                                                                                                                                                                                                                         |
+| description                  | Description of the bookable.                                                                                                                                                                                                                                       |
+| location                     | Geo object with `coordinates`, `display_address`, `address`, and `meta` (same shape as Event location).                                                                                                                                                            |
+| isPublic                     | If `false`, the bookable is hidden from public listings.                                                                                                                                                                                                           |
+| isBookable                   | If `false`, the bookable cannot be checked out.                                                                                                                                                                                                                    |
+| amount                       | Available capacity/amount. `null` means unlimited.                                                                                                                                                                                                                 |
+| minBookingDuration           | Minimum booking duration in minutes (if schedule-related).                                                                                                                                                                                                         |
+| maxBookingDuration           | Maximum booking duration in minutes (if schedule-related).                                                                                                                                                                                                         |
+| autoCommitBooking            | If `true`, bookings are automatically committed / forwarded to payment.                                                                                                                                                                                            |
+| isScheduleRelated            | If `true`, the user is asked to choose a booking time during checkout.                                                                                                                                                                                             |
+| isTimePeriodRelated          | If `true`, the user selects one of the predefined `timePeriods`.                                                                                                                                                                                                   |
+| timePeriods                  | Weekly repeating time windows when the bookable can be used.                                                                                                                                                                                                       |
+| isOpeningHoursRelated        | If `true`, availability is derived from `openingHours`.                                                                                                                                                                                                            |
+| openingHours                 | Regular opening hours per weekday.                                                                                                                                                                                                                                 |
+| preparationLeadTimeMinutes   | Minimum preparation time in minutes before booking start. Lead-time enforcement is active when `isScheduleRelated`, `isTimePeriodRelated`, or `isBlockPeriodRelated` is `true`, `preparationLeadTimeMinutes` is greater than `0`, and `serviceHours` is non-empty. |
+| serviceHours                 | Service windows when preparation can take place (same structure as `openingHours`, independent of opening hours). Only evaluated together with `preparationLeadTimeMinutes` on schedule-, time-period-, and block-period-related bookables.                        |
+| bufferTimeBeforeMinutes      | Optional capacity buffer before each booking (minutes). Active only when `isScheduleRelated` is `true` and value is greater than `0`. Blocks back-to-back bookings in calendar and checkout capacity checks.                                                       |
+| bufferTimeAfterMinutes       | Optional capacity buffer after each booking (minutes). Active only when `isScheduleRelated` is `true` and value is greater than `0`.                                                                                                                               |
+| isSpecialOpeningHoursRelated | If `true`, `specialOpeningHours` override the regular opening hours for specific dates.                                                                                                                                                                            |
+| specialOpeningHours          | Special opening hours for specific dates.                                                                                                                                                                                                                          |
+| isLongRange                  | If `true`, long-range bookings (e.g. weeks/months) are enabled.                                                                                                                                                                                                    |
+| longRangeOptions             | Configuration for long-range bookings (e.g. type = `week` or `month`).                                                                                                                                                                                             |
+| isBlockPeriodRelated         | If `true`, availability uses `blockPeriods` (recurring weekday/time windows).                                                                                                                                                                                      |
+| blockPeriods                 | Block periods with `id`, `label`, `startWeekday`, `startTime`, `endWeekday`, `endTime`.                                                                                                                                                                            |
+| priceCategories              | List of price categories including price, interval, affected weekdays and holidays.                                                                                                                                                                                |
+| priceType                    | Price type (e.g. `per-hour`, `per-day`, `per-item`, `per-square-meter`).                                                                                                                                                                                           |
+| priceValueAddedTax           | VAT rate (in percent) applied to this bookable.                                                                                                                                                                                                                    |
+| enableCoupons                | If `true`, coupons can be applied to this bookable.                                                                                                                                                                                                                |
+| tags                         | Tags used for internal grouping and filtering.                                                                                                                                                                                                                     |
+| flags                        | Feature flags highlighted to users (e.g. "barrier-free").                                                                                                                                                                                                          |
+| relatedBookableIds           | IDs of bookables related to this bookable.                                                                                                                                                                                                                         |
+| checkoutBookableIds          | Additional bookables for checkout: `{ bookableId, mandatory }`.                                                                                                                                                                                                    |
+| requiresLogin                | If `true`, only authenticated users may book.                                                                                                                                                                                                                      |
+| cancellationPolicy           | e.g. `{ userCancellable: true, contactHint: "" }` — whether users can cancel bookings themselves; `contactHint` is an optional message shown in emails when user cancellation is disabled.                                                                         |
+| permittedUsers               | List of user IDs that are allowed to book. If empty, every user including guests may book (depending on other rules).                                                                                                                                              |
+| permittedRoles               | List of role IDs that are allowed to book. If empty, every user including guests may book (depending on other rules).                                                                                                                                              |
+| bookingDiscounts             | Per-user and per-role booking discounts (`users[].userId`, `users[].discountPercent`, `roles[].roleId`, `roles[].discountPercent`; integer 0–100). Highest matching discount applies.                                                                              |
+| attachments                  | Attachments: `id`, `title`, `caption`, `type`, `url`, `show`, `required`, `mailAttach`.                                                                                                                                                                            |
+| lockerDetails                | Configuration for locker integrations (e.g. units).                                                                                                                                                                                                                |
+| requiredFields               | Checkout fields required from the user (default: `address`, `zipCode`, `city`).                                                                                                                                                                                    |
+| externalProviders            | External pricing/availability providers: `active`, `provider`, `handles`, `config`.                                                                                                                                                                                |
+| customFieldDefinitions       | Tenant/bookable-level custom field definitions.                                                                                                                                                                                                                    |
+| customFieldValues            | Stored values for custom fields on this bookable.                                                                                                                                                                                                                  |
+| eventId                      | ID of the related event (for `ticket` bookables).                                                                                                                                                                                                                  |
+| ownerUserId                  | ID of the user that owns/manages this bookable.                                                                                                                                                                                                                    |
+| timeCreated                  | Timestamp when the bookable was created.                                                                                                                                                                                                                           |
+| timeUpdated                  | Timestamp when the bookable was last updated.                                                                                                                                                                                                                      |
 
 ### Booking
 
@@ -396,38 +402,50 @@ Example:
 
 Key fields of a booking:
 
-| Field           | Description                                                                                                                           |
-|-----------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| id              | Unique identifier of the booking.                                                                                                     |
-| tenantId        | Tenant to which the booking belongs.                                                                                                  |
-| assignedUserId  | ID of the user who made the booking (may be empty for guest bookings).                                                                |
-| timeBegin       | Start timestamp of the booking (epoch millis).                                                                                        |
-| timeEnd         | End timestamp of the booking (epoch millis).                                                                                          |
-| timeCreated     | Timestamp when the booking was created.                                                                                               |
-| timePaid        | Timestamp when the booking was paid (if applicable).                                                                                  |
-| bookableItems   | Array of booked items (bookable id, tenant, amount, and snapshot of the used bookable configuration).                                |
-| couponCode      | Coupon code applied to the booking (if any).                                                                                          |
-| _couponUsed     | Snapshot of the used coupon (id, tenant, discount and validity).                                                                      |
-| priceEur        | Total price in Euro (without additional taxes).                                                                                       |
-| vatIncludedEur  | VAT amount included in `priceEur`.                                                                                                     |
-| isCommitted     | Whether the booking is committed (confirmed) from the system’s perspective.                                                           |
-| isPayed         | Whether the booking has been paid.                                                                                                    |
-| isRejected      | Whether the booking has been rejected.                                                                                                |
-| name            | Name of the person who made the booking.                                                                                              |
-| company         | Company of the person who made the booking.                                                                                           |
-| street          | Street address of the person who made the booking.                                                                                    |
-| zipCode         | Zip code of the person who made the booking.                                                                                          |
-| location        | City or location of the person who made the booking.                                                                                  |
-| mail            | Email address of the person who made the booking.                                                                                     |
-| phone           | Phone number of the person who made the booking.                                                                                      |
-| comment         | Comment or special requests from the customer.                                                                                        |
-| internalComments| Internal comments visible only to administrators.                                                                                     |
-| rejectionReason | Reason why a booking has been rejected (if applicable).                                                                              |
-| attachments     | Attachments related to the booking.                                                                                                   |
-| lockerInfo      | Information about locker assignments associated with this booking.                                                                    |
-| paymentProvider | Identifier of the payment provider used (if any).                                                                                     |
-| paymentMethod   | Human readable payment method (e.g. credit card, invoice).                                                                           |
-| hooks           | Technical hooks triggered for this booking (e.g. webhooks).                                                                          |
+| Field            | Description                                                                                                         |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------- |
+| id               | Unique identifier of the booking.                                                                                   |
+| tenantId         | Tenant to which the booking belongs.                                                                                |
+| assignedUserId   | ID of the user who made the booking (may be empty for guest bookings).                                              |
+| timeBegin        | Start timestamp of the booking (epoch millis).                                                                      |
+| timeEnd          | End timestamp of the booking (epoch millis).                                                                        |
+| timeCreated      | Timestamp when the booking was created.                                                                             |
+| timePaid         | Timestamp when the booking was paid (if applicable).                                                                |
+| bookableItems    | Array of booked items (bookable id, tenant, amount, and snapshot of the used bookable configuration).               |
+| couponCode       | Coupon code applied to the booking (if any).                                                                        |
+| \_couponUsed     | Snapshot of the used coupon (id, tenant, discount and validity).                                                    |
+| priceEur         | Total price in Euro (without additional taxes).                                                                     |
+| vatIncludedEur   | VAT amount included in `priceEur`.                                                                                  |
+| isCommitted      | Whether the booking is committed (confirmed) from the system’s perspective.                                         |
+| isPayed          | Whether the booking has been paid.                                                                                  |
+| isRejected       | Whether the booking has been rejected.                                                                              |
+| name             | Name of the person who made the booking.                                                                            |
+| company          | Company of the person who made the booking.                                                                         |
+| street           | Street address of the person who made the booking.                                                                  |
+| zipCode          | Zip code of the person who made the booking.                                                                        |
+| location         | City or location of the person who made the booking.                                                                |
+| mail             | Email address of the person who made the booking.                                                                   |
+| phone            | Phone number of the person who made the booking.                                                                    |
+| comment          | Comment or special requests from the customer.                                                                      |
+| internalComments | Internal comments visible only to administrators.                                                                   |
+| rejectionReason  | Reason why a booking has been rejected (if applicable).                                                             |
+| attachments      | Attachments related to the booking. Cancellation attachments include the applied refund audit data described below. |
+| lockerInfo       | Information about locker assignments associated with this booking.                                                  |
+| paymentProvider  | Identifier of the payment provider used (if any).                                                                   |
+| paymentMethod    | Human readable payment method (e.g. credit card, invoice).                                                          |
+| hooks            | Technical hooks triggered for this booking (e.g. webhooks).                                                         |
+
+Cancellation attachments may contain a `cancellation` object with:
+
+- `cancelledAt` and `daysBeforeStart`
+- original, refunded and retained Euro amounts
+- proposed and applied refund percentages
+- the applied tier threshold
+- origin (`user`, `admin`, or `system`) and administrator override status
+- the acting administrator ID, when applicable
+- a reference to the original invoice or receipt
+
+The current tenant tiers are evaluated when the cancellation is finalized; the complete policy is not copied to the booking. Payment-provider refunds are not executed automatically.
 
 ### Coupon
 

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -429,6 +429,7 @@ Key fields of a booking:
 | comment          | Comment or special requests from the customer.                                                                      |
 | internalComments | Internal comments visible only to administrators.                                                                   |
 | rejectionReason  | Reason why a booking has been rejected (if applicable).                                                             |
+| cancellationRefund | Persisted refund audit for the latest cancellation while the booking is rejected. Cleared when the cancellation is reverted. |
 | attachments      | Attachments related to the booking. Cancellation attachments include the applied refund audit data described below. |
 | lockerInfo       | Information about locker assignments associated with this booking.                                                  |
 | paymentProvider  | Identifier of the payment provider used (if any).                                                                   |

--- a/docs/pdf-templates.md
+++ b/docs/pdf-templates.md
@@ -1,0 +1,16 @@
+# PDF Templates
+
+Tenant PDF templates use Handlebars. Cancellation templates receive the existing booking, item, total, address, and document-number values plus the following refund fields:
+
+- `cancellationDate` — exact cancellation date and time
+- `daysBeforeStart` / `daysBeforeStartLabel` — calendar days before the booking starts
+- `suggestedRefundPercentage` — tenant-policy proposal
+- `refundPercentage` — applied percentage
+- `refundAmount` — formatted refund amount
+- `cancellationFee` — formatted retained amount
+- `calculationMode` — policy/admin/system explanation
+- `adminOverride` — whether an administrator changed the proposal
+- `isFullRefund` / `hasCancellationFee` — template conditions
+- `refundCalculations` — per-booking values for group cancellations
+
+Custom cancellation templates are not rewritten automatically. Tenants using a custom `cancellationTemplate` must update wording that promises a full refund or complete invoice reversal before enabling partial refunds.

--- a/src/commons/data-managers/booking-manager.js
+++ b/src/commons/data-managers/booking-manager.js
@@ -179,18 +179,34 @@ class BookingManager {
    * Store a booking (create or update)
    * @param {Booking|Object} booking Booking to store
    * @param {boolean} upsert Whether to create if not exists
+   * @param {{ unset?: string[] }} [options] Optional fields to remove via $unset
    * @returns {Promise<Booking>} The stored booking
    */
-  static async storeBooking(booking, upsert = true) {
+  static async storeBooking(booking, upsert = true, options = {}) {
     const bookingEntity =
       booking instanceof Booking ? booking : new Booking(booking);
 
     bookingEntity.validate();
 
+    const unsetFields = Array.isArray(options.unset) ? options.unset : [];
+    const filter = { id: bookingEntity.id, tenantId: bookingEntity.tenantId };
+
+    if (unsetFields.length === 0) {
+      await BookingModel.updateOne(filter, bookingEntity, { upsert });
+      return bookingEntity;
+    }
+
+    for (const field of unsetFields) {
+      delete bookingEntity[field];
+    }
+
     await BookingModel.updateOne(
-      { id: bookingEntity.id, tenantId: bookingEntity.tenantId },
-      bookingEntity,
-      { upsert: upsert },
+      filter,
+      {
+        $set: bookingEntity,
+        $unset: Object.fromEntries(unsetFields.map((field) => [field, ""])),
+      },
+      { upsert },
     );
 
     return bookingEntity;

--- a/src/commons/data-managers/tenant-manager.js
+++ b/src/commons/data-managers/tenant-manager.js
@@ -7,6 +7,9 @@ const {
   CustomFieldService,
 } = require("../services/custom-field/custom-field-service");
 const { BookableManager } = require("./bookable-manager");
+const {
+  normalizeCancellationRefundTiers,
+} = require("../utilities/cancellation-refund-tiers");
 
 /**
  * Data Manager for Tenant objects.
@@ -55,6 +58,9 @@ class TenantManager {
 
     CustomFieldService.normalizeDefinitions(
       tenantEntity.bookableCustomFields || [],
+    );
+    tenantEntity.cancellationRefundTiers = normalizeCancellationRefundTiers(
+      tenantEntity.cancellationRefundTiers || [],
     );
     tenantEntity.validate();
     await TenantModel.updateOne({ id: tenantEntity.id }, tenantEntity, {

--- a/src/commons/mail-service/mail-controller.js
+++ b/src/commons/mail-service/mail-controller.js
@@ -7,6 +7,9 @@ const UserManager = require("../data-managers/user-manager");
 const { MailType } = require("./mail-types");
 const { renderSnippet } = require("./templates/template-loader");
 const ICalService = require("../services/ical-service");
+const {
+  CancellationRefundService,
+} = require("../services/payment/cancellation-refund-service");
 
 class MailController {
   static async _attachICalFiles(bookingIds, tenantId, attachments = []) {
@@ -113,12 +116,25 @@ class MailController {
     attachments,
     aggregated = false,
   ) {
+    const ids = Array.isArray(bookingIds) ? bookingIds : [bookingIds];
+    const primaryBookingId = ids[0];
+    let refundTemplateData = {};
+    if (primaryBookingId) {
+      const booking = await BookingManager.getBooking(
+        primaryBookingId,
+        tenantId,
+      );
+      refundTemplateData = CancellationRefundService.toMailTemplateData(
+        booking?.cancellationRefund,
+      );
+    }
+
     await MailSenderService.dispatch({
       mailType: MailType.BOOKING_CANCEL,
       address,
       bookingIds,
       tenantId,
-      templateData: { cancelReason: reason },
+      templateData: { cancelReason: reason, ...refundTemplateData },
       attachments,
       aggregated,
     });
@@ -272,15 +288,22 @@ class MailController {
     hookId,
     reason,
     attachments,
+    refundPreview = null,
   ) {
     const verifyRejectionUrl = `${process.env.FRONTEND_URL}/booking/verify-reject/${tenantId}?id=${bookingId}&hookId=${hookId}`;
+    const refundTemplateData =
+      CancellationRefundService.toMailTemplateData(refundPreview);
 
     await MailSenderService.dispatch({
       mailType: MailType.VERIFY_BOOKING_REJECTION,
       address,
       bookingIds: [bookingId],
       tenantId,
-      templateData: { cancelReason: reason, verifyRejectionUrl },
+      templateData: {
+        cancelReason: reason,
+        verifyRejectionUrl,
+        ...refundTemplateData,
+      },
       attachments,
     });
   }

--- a/src/commons/mail-service/mail-sender.service.js
+++ b/src/commons/mail-service/mail-sender.service.js
@@ -227,14 +227,43 @@ class MailSenderService {
     const sendBCC = this.resolve(mailType.sendBCC, ctx);
     const addRejectionLink = this.resolve(mailType.addRejectionLink, ctx);
     const overrideSource = getSnippetOverride(tenant, mailType.templateName);
-    const { paymentUrl, cancelReason, rejectionReason, verifyRejectionUrl } =
-      templateData;
+    const {
+      paymentUrl,
+      cancelReason,
+      rejectionReason,
+      verifyRejectionUrl,
+      hasRefundPreview,
+      originalAmountEur,
+      refundAmountEur,
+      cancellationFeeEur,
+      refundPercentage,
+      daysBeforeStart,
+      hasCancellationFee,
+    } = templateData;
 
     const renderForBooking = (booking) => {
+      const refundVars =
+        typeof hasRefundPreview === "boolean"
+          ? {
+              hasRefundPreview,
+              originalAmountEur,
+              refundAmountEur,
+              cancellationFeeEur,
+              refundPercentage,
+              daysBeforeStart,
+              hasCancellationFee,
+            }
+          : {};
+
       const variables = buildOverrideTemplateVariables({
         tenant,
         booking,
-        extra: { verifyRejectionUrl },
+        extra: {
+          verifyRejectionUrl,
+          cancelReason,
+          rejectionReason,
+          ...refundVars,
+        },
       });
 
       const message = renderSnippet(mailType.templateName, variables, {

--- a/src/commons/mail-service/templates/mail-snippet-overrides.js
+++ b/src/commons/mail-service/templates/mail-snippet-overrides.js
@@ -40,6 +40,36 @@ const OVERRIDE_TEMPLATE_VARIABLES = Object.freeze([
     name: "currentDate",
     description: "Aktuelles Versanddatum im Format TT.MM.JJJJ",
   },
+  {
+    name: "hasRefundPreview",
+    description:
+      "Wahr, wenn die Buchung einen Erstattungsbetrag größer 0 € hat",
+  },
+  {
+    name: "refundAmountEur",
+    description:
+      "Erstattungsbetrag als Zahl (mit Helper priceFormatted nutzbar)",
+  },
+  {
+    name: "cancellationFeeEur",
+    description: "Einbehaltener Betrag als Zahl",
+  },
+  {
+    name: "originalAmountEur",
+    description: "Ursprungsbetrag der Buchung als Zahl",
+  },
+  {
+    name: "refundPercentage",
+    description: "Angewandter Erstattungsprozentsatz (0–100)",
+  },
+  {
+    name: "hasCancellationFee",
+    description: "Wahr, wenn ein Einbehalt größer 0 € anfällt",
+  },
+  {
+    name: "daysBeforeStart",
+    description: "Kalendertage bis zum Buchungsbeginn zum Berechnungszeitpunkt",
+  },
 ]);
 
 const overridableSnippetSet = new Set(OVERRIDABLE_SNIPPETS);

--- a/src/commons/mail-service/templates/snippets/booking-cancel.hbs
+++ b/src/commons/mail-service/templates/snippets/booking-cancel.hbs
@@ -1,1 +1,13 @@
 <p>Die nachfolgende Buchung wurde storniert:</p>
+
+{{#if hasRefundPreview}}
+  <p>
+    <strong>Erstattung</strong>:
+    {{priceFormatted refundAmountEur}}
+    ({{refundPercentage}}&nbsp;%)
+    {{#if hasCancellationFee}}
+      <br />
+      Einbehalt (Stornogebühr): {{priceFormatted cancellationFeeEur}}
+    {{/if}}
+  </p>
+{{/if}}

--- a/src/commons/mail-service/templates/snippets/verify-rejection.hbs
+++ b/src/commons/mail-service/templates/snippets/verify-rejection.hbs
@@ -15,6 +15,22 @@
   </p>
 {{/if}}
 
+{{#if hasRefundPreview}}
+  <p>
+    <strong>Erwartete Erstattung</strong> nach aktueller Regelung:
+    {{priceFormatted refundAmountEur}}
+    ({{refundPercentage}}&nbsp;%)
+    {{#if hasCancellationFee}}
+      <br />
+      Einbehalt (Stornogebühr): {{priceFormatted cancellationFeeEur}}
+    {{/if}}
+  </p>
+  <p>
+    Der endgültige Erstattungsbetrag wird zum Zeitpunkt Ihrer Bestätigung
+    berechnet.
+  </p>
+{{/if}}
+
 <p>
   <a
     href="{{verifyRejectionUrl}}"

--- a/src/commons/pdf-service/pdf-booking-table-meta.js
+++ b/src/commons/pdf-service/pdf-booking-table-meta.js
@@ -74,6 +74,8 @@ function enrichBookingTableMeta(tableMeta) {
       aggregatedInvoiceColumnCount - 1,
       0,
     ),
+    useSplitAggregatedReceiptTotals: aggregatedReceiptColumnCount > 1,
+    useSplitAggregatedInvoiceTotals: aggregatedInvoiceColumnCount > 1,
     showAggregatedPaymentColumn: showPaymentInTable,
   };
 }

--- a/src/commons/pdf-service/pdf-sample-data.js
+++ b/src/commons/pdf-service/pdf-sample-data.js
@@ -216,7 +216,15 @@ function buildCancellationSampleData(
     cancellationDate: formatters.formatDate(new Date()),
     cancellationReason: "Veranstaltung wurde abgesagt",
     alreadyPaid: true,
+    daysBeforeStartLabel: "20",
+    suggestedRefundPercentage: 100,
+    refundPercentage: 100,
+    calculationMode: "Automatisch nach Mandantenregel",
+    adminOverride: false,
+    isFullRefund: true,
+    hasCancellationFee: false,
     refundAmount: formatters.formatCurrency(bruttoEur),
+    cancellationFee: formatters.formatCurrency(0),
     customerBankDetails:
       '<div class="information customer-bank-details">' +
       "<strong>Bankverbindung für die Rückerstattung:</strong><br />" +

--- a/src/commons/pdf-service/pdf-service.js
+++ b/src/commons/pdf-service/pdf-service.js
@@ -75,12 +75,15 @@ const PRINT_CSS = `
     font-weight: bold;
   }
   table.pdf-items--compact tbody tr.item:nth-child(even) td { background: #f5f5f5; }
+  table.pdf-items--compact tbody tr.item td { border-bottom: 1px solid #eee; }
   table.pdf-items--compact .num { text-align: right; white-space: nowrap; }
   table.pdf-items--compact td.sub {
     color: #555;
     font-size: 8px;
     padding-top: 0;
     padding-bottom: 4px;
+    border-bottom: 1px solid #ddd;
+    background: #fafafa;
   }
   table.pdf-items--compact tr.coupon td { color: #555; }
   table.pdf-items--compact tr.totals-sub td {
@@ -122,6 +125,7 @@ const PRINT_CSS = `
     font-weight: bold;
   }
   table.pdf-items--detailed tbody tr.item:nth-child(even) td { background: #f5f5f5; }
+  table.pdf-items--detailed tbody tr.item td { border-bottom: 1px solid #eee; }
   table.pdf-items--detailed .num { text-align: right; white-space: nowrap; }
   .pdf-booking-meta {
     font-size: 10px;
@@ -134,6 +138,8 @@ const PRINT_CSS = `
     font-size: 9px;
     padding-top: 0;
     padding-bottom: 6px;
+    border-bottom: 1px solid #ddd;
+    background: #fafafa;
   }
   table.pdf-items--detailed ul.item-list {
     margin: 4px 0 0;
@@ -144,12 +150,18 @@ const PRINT_CSS = `
     padding-top: 8px;
     border-top: 2px solid #000;
   }
-  table.pdf-items--detailed tr.netto td,
-  table.pdf-items--detailed tr.mwst td,
-  table.pdf-items--detailed tr.brutto td { text-align: right; }
-  table.pdf-items--detailed tr.netto td:first-child,
-  table.pdf-items--detailed tr.mwst td:first-child,
-  table.pdf-items--detailed tr.brutto td:first-child { text-align: left; }
+  table.pdf-items--detailed tr.netto td:not(.num),
+  table.pdf-items--detailed tr.mwst td:not(.num),
+  table.pdf-items--detailed tr.brutto td:not(.num) { text-align: left; }
+  table.pdf-items--detailed tr.netto td.num,
+  table.pdf-items--detailed tr.mwst td.num,
+  table.pdf-items--detailed tr.brutto td.num,
+  table.pdf-items--detailed tr.coupon td.num { text-align: right; }
+  table.pdf-items--detailed tr.netto td:not(.num) .num,
+  table.pdf-items--detailed tr.mwst td:not(.num) .num,
+  table.pdf-items--detailed tr.brutto td:not(.num) .num {
+    float: right;
+  }
   table.pdf-items--detailed tr.brutto td {
     font-weight: bold;
     border-bottom: 2px solid #000;
@@ -645,7 +657,10 @@ class PdfService {
     );
 
     const renderedHtml = template(data);
-    const filename = `Stornorechnung-${cancellationNumber}.pdf`;
+    const filename = PdfService._buildCancellationFilename(
+      "single",
+      cancellationNumber,
+    );
 
     return await PdfService.convertToPdf(renderedHtml, filename);
   }
@@ -747,7 +762,10 @@ class PdfService {
       DEFAULT_TEMPLATES.cancellation,
     );
     const renderedHtml = template(data);
-    const filename = `Sammel-Stornorechnung-${cancellationNumber}.pdf`;
+    const filename = PdfService._buildCancellationFilename(
+      "aggregated",
+      cancellationNumber,
+    );
 
     return await PdfService.convertToPdf(renderedHtml, filename);
   }
@@ -1286,6 +1304,17 @@ class PdfService {
   }
 
   /**
+   * Builds cancellation PDF filenames from the cancellation number. The number
+   * already includes an optional tenant prefix when configured.
+   */
+  static _buildCancellationFilename(documentType, cancellationNumber) {
+    if (documentType === "aggregated") {
+      return `Sammel-Stornorechnung-${cancellationNumber}.pdf`;
+    }
+    return `Stornorechnung-${cancellationNumber}.pdf`;
+  }
+
+  /**
    * Builds the structured rows and totals for aggregated documents
    * (Sammelbeleg, Sammelrechnung, Sammel-Stornorechnung).
    */
@@ -1355,12 +1384,8 @@ class PdfService {
     let calculationMode = "Automatisch durch das System";
     if (calculation.origin === "user") {
       calculationMode = "Automatisch nach Mandantenregel";
-    } else if (calculation.origin === "admin" && calculation.adminOverride) {
-      calculationMode =
-        "Manuell durch Administration (Regelvorschlag überschrieben)";
     } else if (calculation.origin === "admin") {
-      calculationMode =
-        "Manuell durch Administration (Regelvorschlag übernommen)";
+      calculationMode = "Manuell durch Administration";
     }
 
     return {

--- a/src/commons/pdf-service/pdf-service.js
+++ b/src/commons/pdf-service/pdf-service.js
@@ -557,6 +557,7 @@ class PdfService {
       alreadyPaid = false,
       originalInvoiceDate,
       bankDetails,
+      refundCalculation,
     } = options;
 
     const [tenant, booking, allBookables] = await Promise.all([
@@ -565,11 +566,34 @@ class PdfService {
       BookableManager.getBookables(tenantId),
     ]);
 
-    const items = PdfService._buildItems(booking, allBookables, {
+    const calculation = refundCalculation || {
+      cancelledAt: Date.now(),
+      daysBeforeStart: null,
+      originalAmountEur: booking.priceEur,
+      suggestedRefundPercentage: 100,
+      appliedRefundPercentage: 100,
+      refundAmountEur: booking.priceEur,
+      cancellationFeeEur: 0,
+      appliedTierDays: null,
+      origin: "system",
+      adminOverride: false,
+    };
+    const scale = calculation.appliedRefundPercentage / 100;
+    const documentOptions = {
       negative: true,
-    });
-    const coupon = PdfService._buildCoupon(booking, { negative: true });
-    const totals = PdfService._buildTableTotals(booking, { negative: true });
+      scale,
+      targetBruttoEur: calculation.refundAmountEur,
+      targetVatEur: PdfService._scaleCurrency(booking.vatIncludedEur, scale),
+    };
+    const items = PdfService._buildItems(
+      booking,
+      allBookables,
+      documentOptions,
+    );
+    const coupon = PdfService._buildCoupon(booking, documentOptions);
+    const totals = PdfService._buildTableTotals(booking, documentOptions);
+    const calculationData =
+      PdfService._buildCancellationCalculationData(calculation);
 
     const bookingContext = PdfService._buildBookingContext(
       booking,
@@ -594,15 +618,21 @@ class PdfService {
       originalInvoiceDate: originalInvoiceDate
         ? formatters.formatDate(originalInvoiceDate)
         : formatters.formatDate(new Date(booking.timeCreated)),
-      cancellationDate: formatters.formatDate(new Date()),
+      cancellationDate: formatters.formatDateTime(calculation.cancelledAt),
       cancellationReason,
       alreadyPaid,
-      refundAmount: formatters.formatCurrency(booking.priceEur),
+      refundAmount: formatters.formatCurrency(calculation.refundAmountEur),
+      cancellationFee: formatters.formatCurrency(
+        calculation.cancellationFeeEur,
+      ),
+      ...calculationData,
       customerBankDetails: PdfService._buildCustomerBankDetails(bankDetails),
       invoiceAddress: PdfService._buildAddressHtml(booking),
       mainContent,
       location: tenant.location,
-      totalAmount: formatters.formatNegativeCurrency(booking.priceEur),
+      totalAmount: formatters.formatNegativeCurrency(
+        calculation.refundAmountEur,
+      ),
       bookingId: booking.id,
       items,
       coupon,
@@ -633,6 +663,7 @@ class PdfService {
       originalInvoiceDate,
       bankDetails,
       groupBookingId,
+      refundCalculations,
     } = options;
 
     const [tenant, bookings, allBookables] = await Promise.all([
@@ -641,10 +672,42 @@ class PdfService {
       BookableManager.getBookables(tenantId),
     ]);
 
+    const calculations =
+      refundCalculations ||
+      bookings.map((booking) => ({
+        bookingId: booking.id,
+        cancelledAt: Date.now(),
+        daysBeforeStart: null,
+        originalAmountEur: booking.priceEur,
+        suggestedRefundPercentage: 100,
+        appliedRefundPercentage: 100,
+        refundAmountEur: booking.priceEur,
+        cancellationFeeEur: 0,
+        appliedTierDays: null,
+        origin: "system",
+        adminOverride: false,
+      }));
     const { bookingRows, totals } = PdfService._buildAggregatedData(
       bookings,
       allBookables,
-      { negative: true },
+      { negative: true, refundCalculations: calculations },
+    );
+    const formattedCalculations = calculations.map((calculation) => ({
+      bookingId: calculation.bookingId,
+      ...PdfService._buildCancellationCalculationData(calculation),
+      refundAmount: formatters.formatCurrency(calculation.refundAmountEur),
+      cancellationFee: formatters.formatCurrency(
+        calculation.cancellationFeeEur,
+      ),
+    }));
+    const cancellationFeeEur =
+      calculations.reduce(
+        (total, calculation) =>
+          total + Math.round(calculation.cancellationFeeEur * 100),
+        0,
+      ) / 100;
+    const isFullRefund = calculations.every(
+      (calculation) => calculation.appliedRefundPercentage === 100,
     );
 
     const mainContent = PdfService._renderAggregatedBookingsTable(tenant, {
@@ -659,10 +722,16 @@ class PdfService {
       originalInvoiceDate: originalInvoiceDate
         ? formatters.formatDate(originalInvoiceDate)
         : formatters.formatDate(new Date(bookings[0].timeCreated)),
-      cancellationDate: formatters.formatDate(new Date()),
+      cancellationDate: formatters.formatDateTime(
+        calculations[0]?.cancelledAt ?? Date.now(),
+      ),
       cancellationReason,
       alreadyPaid,
       refundAmount: formatters.formatCurrency(totals.bruttoEur),
+      cancellationFee: formatters.formatCurrency(cancellationFeeEur),
+      refundCalculations: formattedCalculations,
+      isFullRefund,
+      hasCancellationFee: cancellationFeeEur > 0,
       customerBankDetails: PdfService._buildCustomerBankDetails(bankDetails),
       invoiceAddress: PdfService._buildAddressHtml(bookings[0]),
       mainContent,
@@ -1042,21 +1111,27 @@ class PdfService {
 
   static _buildTableTotals(booking, options = {}) {
     const coupon = booking._couponUsed;
+    const scale = options.scale ?? 1;
+    const bruttoEur =
+      options.targetBruttoEur ??
+      PdfService._scaleCurrency(booking.priceEur, scale);
+    const finalVatEur =
+      options.targetVatEur ??
+      PdfService._scaleCurrency(booking.vatIncludedEur, scale);
 
     if (!PdfService._usesPreDiscountCouponDisplay(coupon)) {
-      return PdfService._buildTotals(
-        booking.priceEur,
-        booking.vatIncludedEur,
-        options,
-      );
+      return PdfService._buildTotals(bruttoEur, finalVatEur, options);
     }
 
-    const nettoEur = PdfService._calculatePreDiscountNetTotal(booking);
+    const nettoEur = PdfService._scaleCurrency(
+      PdfService._calculatePreDiscountNetTotal(booking),
+      scale,
+    );
     const vatRate = PdfService._bookingVatRate(booking);
     const vatEur = Math.round(nettoEur * vatRate * 100) / 100;
     const finalTotals = PdfService._buildTotals(
-      booking.priceEur,
-      booking.vatIncludedEur,
+      bruttoEur,
+      finalVatEur,
       options,
     );
     const format = options.negative
@@ -1086,18 +1161,26 @@ class PdfService {
       ? formatters.formatNegativeCurrency
       : formatters.formatCurrency;
     const coupon = booking._couponUsed;
+    const scale = options.scale ?? 1;
     const showRegularNetPrice =
       PdfService._usesPreDiscountCouponDisplay(coupon);
 
-    return (booking.bookableItems || []).map((item) => {
+    const items = (booking.bookableItems || []).map((item) => {
       const bookable =
         item._bookableUsed ||
         allBookables.find((b) => b.id === item.bookableId);
-      const unitPriceEur = showRegularNetPrice
+      const originalUnitPriceEur = showRegularNetPrice
         ? PdfService._resolveRegularNetPriceEur(item, booking)
         : item.userPriceEur;
       const multiplier = PdfService._itemAmountMultiplier(item);
-      const totalPriceEur = unitPriceEur * multiplier;
+      const unitPriceEur = PdfService._scaleCurrency(
+        originalUnitPriceEur,
+        scale,
+      );
+      const totalPriceEur = PdfService._scaleCurrency(
+        originalUnitPriceEur * multiplier,
+        scale,
+      );
 
       return {
         title: bookable?.title || "Unbekannt",
@@ -1108,6 +1191,32 @@ class PdfService {
         totalPrice: format(totalPriceEur),
       };
     });
+
+    if (items.length > 0 && scale !== 1) {
+      const originalTotal = (booking.bookableItems || []).reduce(
+        (total, item) => {
+          const unitPriceEur = showRegularNetPrice
+            ? PdfService._resolveRegularNetPriceEur(item, booking)
+            : item.userPriceEur;
+          return total + unitPriceEur * PdfService._itemAmountMultiplier(item);
+        },
+        0,
+      );
+      const targetTotal = PdfService._scaleCurrency(originalTotal, scale);
+      const currentTotal = items.reduce(
+        (total, item) => total + item.totalPriceEur,
+        0,
+      );
+      const remainder = Math.round((targetTotal - currentTotal) * 100) / 100;
+      if (remainder !== 0) {
+        const lastItem = items[items.length - 1];
+        lastItem.totalPriceEur =
+          Math.round((lastItem.totalPriceEur + remainder) * 100) / 100;
+        lastItem.totalPrice = format(lastItem.totalPriceEur);
+      }
+    }
+
+    return items;
   }
 
   static _formatCouponDescription(coupon) {
@@ -1135,11 +1244,13 @@ class PdfService {
 
     const sign = options.negative ? "+" : "-";
     let discountLabel;
+    let discount = coupon.discount;
 
     if (coupon.type === COUPON_TYPE.FIXED) {
+      discount = PdfService._scaleCurrency(coupon.discount, options.scale ?? 1);
       discountLabel = options.negative
-        ? `+${formatters.formatAmount(coupon.discount)} €`
-        : formatters.formatNegativeCurrency(coupon.discount);
+        ? `+${formatters.formatAmount(discount)} €`
+        : formatters.formatNegativeCurrency(discount);
     } else if (coupon.type === COUPON_TYPE.PERCENTAGE) {
       discountLabel = `${sign}${coupon.discount} %`;
     } else {
@@ -1148,7 +1259,7 @@ class PdfService {
 
     return {
       description: PdfService._formatCouponDescription(coupon),
-      discount: coupon.discount,
+      discount,
       type: coupon.type,
       discountLabel,
     };
@@ -1170,6 +1281,10 @@ class PdfService {
     };
   }
 
+  static _scaleCurrency(value, scale) {
+    return Math.round((Number(value) || 0) * scale * 100) / 100;
+  }
+
   /**
    * Builds the structured rows and totals for aggregated documents
    * (Sammelbeleg, Sammelrechnung, Sammel-Stornorechnung).
@@ -1177,10 +1292,26 @@ class PdfService {
   static _buildAggregatedData(bookings, allBookables, options = {}) {
     let bruttoEur = 0;
     let vatEur = 0;
+    const refundCalculationsByBookingId = new Map(
+      (options.refundCalculations || []).map((calculation) => [
+        calculation.bookingId,
+        calculation,
+      ]),
+    );
 
     const bookingRows = bookings.map((booking) => {
-      bruttoEur += booking.priceEur;
-      vatEur += booking.vatIncludedEur;
+      const refundCalculation = refundCalculationsByBookingId.get(booking.id);
+      const scale = refundCalculation
+        ? refundCalculation.appliedRefundPercentage / 100
+        : options.scale;
+      const bookingOptions = {
+        ...options,
+        scale,
+        targetBruttoEur: refundCalculation?.refundAmountEur,
+        targetVatEur: refundCalculation
+          ? PdfService._scaleCurrency(booking.vatIncludedEur, scale)
+          : undefined,
+      };
 
       const period =
         booking.timeBegin && booking.timeEnd
@@ -1190,8 +1321,10 @@ class PdfService {
         booking.timePaid > 0
           ? formatters.formatDateTime(booking.timePaid)
           : "-";
-      const tableTotals = PdfService._buildTableTotals(booking, options);
-      const coupon = PdfService._buildCoupon(booking, options);
+      const tableTotals = PdfService._buildTableTotals(booking, bookingOptions);
+      const coupon = PdfService._buildCoupon(booking, bookingOptions);
+      bruttoEur += tableTotals.bruttoEur;
+      vatEur += tableTotals.vatEur;
 
       return {
         id: booking.id,
@@ -1204,8 +1337,10 @@ class PdfService {
         vatEur: tableTotals.vatEur,
         brutto: tableTotals.brutto,
         bruttoEur: tableTotals.bruttoEur,
+        refundPercentage: refundCalculation?.appliedRefundPercentage,
+        daysBeforeStart: refundCalculation?.daysBeforeStart,
         coupon,
-        items: PdfService._buildItems(booking, allBookables, options),
+        items: PdfService._buildItems(booking, allBookables, bookingOptions),
         summaryItems: PdfService._buildSummaryItems(booking, allBookables),
       };
     });
@@ -1213,6 +1348,34 @@ class PdfService {
     return {
       bookingRows,
       totals: PdfService._buildTotals(bruttoEur, vatEur, options),
+    };
+  }
+
+  static _buildCancellationCalculationData(calculation) {
+    let calculationMode = "Automatisch durch das System";
+    if (calculation.origin === "user") {
+      calculationMode = "Automatisch nach Mandantenregel";
+    } else if (calculation.origin === "admin" && calculation.adminOverride) {
+      calculationMode =
+        "Manuell durch Administration (Regelvorschlag überschrieben)";
+    } else if (calculation.origin === "admin") {
+      calculationMode =
+        "Manuell durch Administration (Regelvorschlag übernommen)";
+    }
+
+    return {
+      daysBeforeStart: calculation.daysBeforeStart,
+      daysBeforeStartLabel:
+        calculation.daysBeforeStart === null
+          ? "nicht verfügbar"
+          : String(calculation.daysBeforeStart),
+      suggestedRefundPercentage: calculation.suggestedRefundPercentage,
+      refundPercentage: calculation.appliedRefundPercentage,
+      appliedTierDays: calculation.appliedTierDays,
+      calculationMode,
+      adminOverride: calculation.adminOverride,
+      isFullRefund: calculation.appliedRefundPercentage === 100,
+      hasCancellationFee: calculation.cancellationFeeEur > 0,
     };
   }
 

--- a/src/commons/pdf-service/pdf-service.js
+++ b/src/commons/pdf-service/pdf-service.js
@@ -1382,7 +1382,10 @@ class PdfService {
 
   static _buildCancellationCalculationData(calculation) {
     let calculationMode = "Automatisch durch das System";
-    if (calculation.origin === "user") {
+    if (
+      calculation.origin === "user" ||
+      (calculation.origin === "admin" && !calculation.adminOverride)
+    ) {
       calculationMode = "Automatisch nach Mandantenregel";
     } else if (calculation.origin === "admin") {
       calculationMode = "Manuell durch Administration";

--- a/src/commons/pdf-service/templates/default-cancellation-receipt.temp.html
+++ b/src/commons/pdf-service/templates/default-cancellation-receipt.temp.html
@@ -119,7 +119,7 @@
           {{refundPercentage}} % Erstattung ({{refundAmount}}),
           {{calculationMode}}{{#unless @last}}<br />{{/unless}} {{/each}}
           {{else}} {{daysBeforeStartLabel}} Kalendertage vor Buchungsbeginn,
-          {{refundPercentage}} % Erstattung.{{/if}}
+          {{refundPercentage}} % Erstattung, {{calculationMode}}.{{/if}}
         </div>
         {{#if alreadyPaid}}
         <div class="refund-note">

--- a/src/commons/pdf-service/templates/default-cancellation-receipt.temp.html
+++ b/src/commons/pdf-service/templates/default-cancellation-receipt.temp.html
@@ -107,7 +107,8 @@
           hiermit stornieren wir die Rechnung mit der Nummer
           <strong>{{originalInvoiceNumber}}</strong> vom
           {{originalInvoiceDate}}. Die nachfolgend aufgeführten Positionen
-          werden Ihnen in voller Höhe gutgeschrieben.
+          werden Ihnen {{#if isFullRefund}}in voller Höhe{{else}}anteilig gemäß
+          der nachfolgenden Berechnung{{/if}} gutgeschrieben.
         </p>
 
         {{#if cancellationReason}}
@@ -115,17 +116,32 @@
           <strong>Grund der Stornierung:</strong>
           {{cancellationReason}}
         </div>
-        {{/if}} {{#if alreadyPaid}}
+        {{/if}}
+        <div class="cancellation-note">
+          <strong>Berechnung der Erstattung:</strong><br />
+          Stornierungszeitpunkt: {{cancellationDate}}<br />
+          {{#if refundCalculations}} {{#each refundCalculations}} Buchung
+          {{bookingId}}: {{daysBeforeStartLabel}} Kalendertage vor Beginn,
+          {{refundPercentage}} % Erstattung ({{refundAmount}}),
+          {{calculationMode}}{{#unless @last}}<br />{{/unless}} {{/each}}
+          {{else}} {{daysBeforeStartLabel}} Kalendertage vor Buchungsbeginn,
+          {{refundPercentage}} % Erstattung, {{calculationMode}} {{/if}}
+        </div>
+        {{#if alreadyPaid}}
         <div class="refund-note">
           Der bereits gezahlte Betrag in Höhe von
-          <strong>{{refundAmount}}</strong> wird Ihnen erstattet.
+          <strong>{{refundAmount}}</strong> wird Ihnen erstattet. {{#if
+          hasCancellationFee}} Der einbehaltene Betrag beläuft sich auf
+          <strong>{{cancellationFee}}</strong>.{{/if}}
         </div>
         {{#if customerBankDetails}}{{{ customerBankDetails }}}{{/if}} {{else}}
         <p>
-          Sofern noch keine Zahlung erfolgt ist, entfällt die
-          Zahlungsverpflichtung aus der ursprünglichen Rechnung. Bitte beachten
-          Sie, dass diese Stornorechnung die Rechnung
-          <strong>{{originalInvoiceNumber}}</strong> vollständig aufhebt.
+          Sofern noch keine Zahlung erfolgt ist, reduziert sich die
+          Zahlungsverpflichtung um <strong>{{refundAmount}}</strong>. {{#if
+          isFullRefund}}Die ursprüngliche Rechnung
+          <strong>{{originalInvoiceNumber}}</strong> wird damit vollständig
+          aufgehoben.{{else}}Der verbleibende Betrag in Höhe von
+          <strong>{{cancellationFee}}</strong> bleibt bestehen.{{/if}}
         </p>
         {{/if}}
       </div>

--- a/src/commons/pdf-service/templates/default-cancellation-receipt.temp.html
+++ b/src/commons/pdf-service/templates/default-cancellation-receipt.temp.html
@@ -29,13 +29,7 @@
         border-bottom: 1px solid #ddd;
         font-weight: bold;
       }
-      .invoice-box table tr.item td {
-        border-bottom: 1px solid #eee;
-      }
-      /* Die Positionstabelle ({{{mainContent}}}) bringt ihr kompaktes
-         Standard-Styling selbst mit (table.pdf-items). Eigene Anpassungen
-         sind mit spezifischeren Selektoren möglich, z. B.
-         table.pdf-items.booked-items td { ... } */
+      /* Position tables ({{{mainContent}}}) use table.pdf-items styling from PRINT_CSS */
       .header {
         font-weight: bold;
         font-size: x-large;
@@ -125,7 +119,7 @@
           {{refundPercentage}} % Erstattung ({{refundAmount}}),
           {{calculationMode}}{{#unless @last}}<br />{{/unless}} {{/each}}
           {{else}} {{daysBeforeStartLabel}} Kalendertage vor Buchungsbeginn,
-          {{refundPercentage}} % Erstattung, {{calculationMode}} {{/if}}
+          {{refundPercentage}} % Erstattung.{{/if}}
         </div>
         {{#if alreadyPaid}}
         <div class="refund-note">

--- a/src/commons/pdf-service/templates/default-invoice-template.temp.html
+++ b/src/commons/pdf-service/templates/default-invoice-template.temp.html
@@ -29,13 +29,7 @@
         border-bottom: 1px solid #ddd;
         font-weight: bold;
       }
-      .invoice-box table tr.item td {
-        border-bottom: 1px solid #eee;
-      }
-      /* Die Positionstabelle ({{{mainContent}}}) bringt ihr kompaktes
-         Standard-Styling selbst mit (table.pdf-items). Eigene Anpassungen
-         sind mit spezifischeren Selektoren möglich, z. B.
-         table.pdf-items.booked-items td { ... } */
+      /* Position tables ({{{mainContent}}}) use table.pdf-items styling from PRINT_CSS */
       .header {
         font-weight: bold;
         font-size: x-large;

--- a/src/commons/pdf-service/templates/partials/aggregated-bookings-table.temp.html
+++ b/src/commons/pdf-service/templates/partials/aggregated-bookings-table.temp.html
@@ -82,8 +82,14 @@
       </td>
     </tr>
     <tr class="brutto">
+      {{#if tableMeta.useSplitAggregatedInvoiceTotals}}
       <td colspan="{{tableMeta.aggregatedInvoiceLabelColspan}}">Gesamt (brutto)</td>
       <td class="num">{{totals.brutto}}</td>
+      {{else}}
+      <td colspan="{{tableMeta.aggregatedInvoiceColumnCount}}">
+        Gesamt (brutto) <span class="num">{{totals.brutto}}</span>
+      </td>
+      {{/if}}
     </tr>
   </tbody>
 </table>
@@ -119,6 +125,7 @@
       </td>
     </tr>
     {{/each}}
+    {{#if tableMeta.useSplitAggregatedInvoiceTotals}}
     <tr class="netto">
       <td colspan="{{tableMeta.aggregatedInvoiceLabelColspan}}">Gesamt (netto)</td>
       <td class="num">{{totals.netto}}</td>
@@ -131,6 +138,23 @@
       <td colspan="{{tableMeta.aggregatedInvoiceLabelColspan}}">Gesamt (brutto)</td>
       <td class="num">{{totals.brutto}}</td>
     </tr>
+    {{else}}
+    <tr class="netto">
+      <td colspan="{{tableMeta.aggregatedInvoiceColumnCount}}">
+        Gesamt (netto) <span class="num">{{totals.netto}}</span>
+      </td>
+    </tr>
+    <tr class="mwst">
+      <td colspan="{{tableMeta.aggregatedInvoiceColumnCount}}">
+        zzgl. MwSt. <span class="num">{{totals.vat}}</span>
+      </td>
+    </tr>
+    <tr class="brutto">
+      <td colspan="{{tableMeta.aggregatedInvoiceColumnCount}}">
+        Gesamt (brutto) <span class="num">{{totals.brutto}}</span>
+      </td>
+    </tr>
+    {{/if}}
   </tbody>
 </table>
 {{/if}}

--- a/src/commons/pdf-service/templates/partials/aggregated-receipt-table.temp.html
+++ b/src/commons/pdf-service/templates/partials/aggregated-receipt-table.temp.html
@@ -95,8 +95,14 @@
       </td>
     </tr>
     <tr class="brutto">
+      {{#if tableMeta.useSplitAggregatedReceiptTotals}}
       <td colspan="{{tableMeta.aggregatedReceiptLabelColspan}}">Gesamt (brutto)</td>
       <td class="num">{{totals.brutto}}</td>
+      {{else}}
+      <td colspan="{{tableMeta.aggregatedReceiptColumnCount}}">
+        Gesamt (brutto) <span class="num">{{totals.brutto}}</span>
+      </td>
+      {{/if}}
     </tr>
   </tbody>
 </table>
@@ -136,6 +142,7 @@
       </td>
     </tr>
     {{/each}}
+    {{#if tableMeta.useSplitAggregatedReceiptTotals}}
     <tr class="netto">
       <td colspan="{{tableMeta.aggregatedReceiptLabelColspan}}">Gesamt (netto)</td>
       <td class="num">{{totals.netto}}</td>
@@ -148,6 +155,23 @@
       <td colspan="{{tableMeta.aggregatedReceiptLabelColspan}}">Gesamt (brutto)</td>
       <td class="num">{{totals.brutto}}</td>
     </tr>
+    {{else}}
+    <tr class="netto">
+      <td colspan="{{tableMeta.aggregatedReceiptColumnCount}}">
+        Gesamt (netto) <span class="num">{{totals.netto}}</span>
+      </td>
+    </tr>
+    <tr class="mwst">
+      <td colspan="{{tableMeta.aggregatedReceiptColumnCount}}">
+        zzgl. MwSt. <span class="num">{{totals.vat}}</span>
+      </td>
+    </tr>
+    <tr class="brutto">
+      <td colspan="{{tableMeta.aggregatedReceiptColumnCount}}">
+        Gesamt (brutto) <span class="num">{{totals.brutto}}</span>
+      </td>
+    </tr>
+    {{/if}}
   </tbody>
 </table>
 {{/if}}

--- a/src/commons/schemas/bookingSchema.js
+++ b/src/commons/schemas/bookingSchema.js
@@ -146,9 +146,11 @@ const bookingSchemaDefinition = {
     type: Object,
     default: { userCancellable: true, contactHint: "" },
   },
+  cancellationRefund: { type: cancellationAuditSchema, default: undefined },
 };
 
 module.exports = {
   bookingSchemaDefinition,
   bookingHookSchemaDefinition,
+  cancellationAuditSchema,
 };

--- a/src/commons/schemas/bookingSchema.js
+++ b/src/commons/schemas/bookingSchema.js
@@ -16,6 +16,49 @@ const customFieldValueSchema = new Schema(
   { _id: false },
 );
 
+const originalCancellationDocumentSchema = new Schema(
+  {
+    number: { type: String, default: "" },
+    timeCreated: { type: Double, default: null },
+  },
+  { _id: false },
+);
+
+const cancellationAuditSchema = new Schema(
+  {
+    cancelledAt: { type: Double, required: true },
+    daysBeforeStart: { type: Number, default: null },
+    originalAmountEur: { type: Number, required: true, min: 0 },
+    suggestedRefundPercentage: {
+      type: Number,
+      required: true,
+      min: 0,
+      max: 100,
+    },
+    appliedRefundPercentage: {
+      type: Number,
+      required: true,
+      min: 0,
+      max: 100,
+    },
+    refundAmountEur: { type: Number, required: true, min: 0 },
+    cancellationFeeEur: { type: Number, required: true, min: 0 },
+    appliedTierDays: { type: Number, default: null, min: 0 },
+    origin: {
+      type: String,
+      required: true,
+      enum: ["user", "admin", "system"],
+    },
+    adminOverride: { type: Boolean, required: true },
+    cancelledByUserId: { type: String, default: null },
+    originalDocumentRef: {
+      type: originalCancellationDocumentSchema,
+      default: undefined,
+    },
+  },
+  { _id: false },
+);
+
 const attachmentSchemaDefinition = {
   type: {
     type: String,
@@ -32,6 +75,7 @@ const attachmentSchemaDefinition = {
   revision: { type: Number },
   timeCreated: { type: Double },
   mailAttach: { type: Boolean },
+  cancellation: { type: cancellationAuditSchema, default: undefined },
 };
 
 const bookingSchemaDefinition = {

--- a/src/commons/schemas/tenantSchema.js
+++ b/src/commons/schemas/tenantSchema.js
@@ -50,8 +50,7 @@ const tenantSchemaDefinition = {
   cancellationRefundTiers: {
     type: [cancellationRefundTierSchema],
     default: [],
-    validate: (tiers) =>
-      getCancellationRefundTiersError(tiers) ? "validate" : true,
+    validate: (tiers) => !getCancellationRefundTiersError(tiers),
   },
   pdfBookingLayout: {
     type: String,

--- a/src/commons/schemas/tenantSchema.js
+++ b/src/commons/schemas/tenantSchema.js
@@ -1,4 +1,17 @@
 const { customFieldDefinitionSchema } = require("./customFieldDefinition");
+const { Schema } = require("mongoose");
+const {
+  getCancellationRefundTiersError,
+} = require("../utilities/cancellation-refund-tiers");
+
+const cancellationRefundTierSchema = new Schema(
+  {
+    daysBeforeStart: { type: Number, required: true, min: 0 },
+    refundPercentage: { type: Number, required: true, min: 0, max: 100 },
+  },
+  { _id: false },
+);
+
 const tenantSchemaDefinition = {
   id: { type: String, required: true, unique: true },
   name: { type: String, required: true },
@@ -34,6 +47,12 @@ const tenantSchemaDefinition = {
   cancellationCount: { type: Object, default: {} },
   cancellationTemplate: { type: String, default: "" },
   cancellationNumberPrefix: { type: String, default: "" },
+  cancellationRefundTiers: {
+    type: [cancellationRefundTierSchema],
+    default: [],
+    validate: (tiers) =>
+      getCancellationRefundTiersError(tiers) ? "validate" : true,
+  },
   pdfBookingLayout: {
     type: String,
     enum: ["summary", "compact", "detailed"],

--- a/src/commons/services/checkout/booking-service.js
+++ b/src/commons/services/checkout/booking-service.js
@@ -1340,6 +1340,7 @@ class BookingService {
     hookId = null,
     skipWorkflow = false,
     skipCancellation = false,
+    bankDetails = null,
     cancellationContext = {},
   ) {
     const [groupBooking, tenant] = await Promise.all([
@@ -1386,10 +1387,12 @@ class BookingService {
     }));
 
     if (groupBooking.getTotalPrice() > 0 && !skipCancellation) {
+      const sanitizedBankDetails = sanitizeBankDetails(bankDetails);
       const options = {
         alreadyPaid: groupBooking.areSomeBookingsPaid(),
         cancellationReason: reason,
         refundCalculations,
+        bankDetails: sanitizedBankDetails || undefined,
       };
 
       cancellationDocument =

--- a/src/commons/services/checkout/booking-service.js
+++ b/src/commons/services/checkout/booking-service.js
@@ -687,12 +687,16 @@ class BookingService {
         booking.couponCode = oldBooking.couponCode;
         booking._couponUsed = oldBooking._couponUsed;
         booking.rejectionReason = "";
-        booking.cancellationRefund = undefined;
+        delete booking.cancellationRefund;
       }
 
       booking.validate();
 
-      await BookingManager.storeBooking(booking);
+      await BookingManager.storeBooking(
+        booking,
+        true,
+        onUnreject ? { unset: ["cancellationRefund"] } : undefined,
+      );
 
       const onCommit = !oldBooking.isCommitted && isCommit;
       const onPay = !oldBooking.isPayed && isPayed;

--- a/src/commons/services/checkout/booking-service.js
+++ b/src/commons/services/checkout/booking-service.js
@@ -625,6 +625,8 @@ class BookingService {
       });
     }
 
+    const onUnreject = oldBooking.isRejected && !isRejected;
+
     const { checkoutId } = await resolveCheckoutId(
       undefined,
       oldBooking.assignedUserId,
@@ -676,6 +678,17 @@ class BookingService {
       if (!(booking instanceof Booking)) {
         booking = new Booking(booking);
       }
+
+      if (onUnreject) {
+        booking.priceEur = oldBooking.priceEur;
+        booking.vatIncludedEur = oldBooking.vatIncludedEur;
+        booking.bookableItems = oldBooking.bookableItems;
+        booking.couponCode = oldBooking.couponCode;
+        booking._couponUsed = oldBooking._couponUsed;
+        booking.rejectionReason = "";
+        booking.cancellationRefund = undefined;
+      }
+
       booking.validate();
 
       await BookingManager.storeBooking(booking);
@@ -683,7 +696,6 @@ class BookingService {
       const onCommit = !oldBooking.isCommitted && isCommit;
       const onPay = !oldBooking.isPayed && isPayed;
       const onReject = !oldBooking.isRejected && isRejected;
-      const onUnreject = oldBooking.isRejected && !isRejected;
 
       const lockerServiceInstance = LockerService.getInstance();
 
@@ -1049,7 +1061,7 @@ class BookingService {
   static async getGroupCancellationRefundPreview(tenantId, groupBookingId) {
     const [tenant, groupBooking] = await Promise.all([
       TenantManager.getTenant(tenantId),
-      GroupBookingManager.getGroupBooking(tenantId, groupBookingId, true),
+      GroupBookingManager.getGroupBooking(tenantId, groupBookingId, false),
     ]);
 
     if (!tenant) {
@@ -1059,8 +1071,18 @@ class BookingService {
       throw new NotFoundError("group_booking_not_found", { groupBookingId });
     }
 
+    const bookings = await BookingManager.getBookings(
+      tenantId,
+      groupBooking.bookingIds,
+    );
+    if (bookings.length !== groupBooking.bookingIds.length) {
+      throw new NotFoundError("booking_not_found", {
+        groupBookingId,
+      });
+    }
+
     const cancelledAt = Date.now();
-    const bookings = groupBooking.bookings.map((booking) => ({
+    const previewBookings = bookings.map((booking) => ({
       bookingId: booking.id,
       ...CancellationRefundService.calculate({
         tenant,
@@ -1073,20 +1095,20 @@ class BookingService {
     return {
       groupBookingId,
       cancelledAt,
-      bookings,
+      bookings: previewBookings,
       originalAmountEur:
-        bookings.reduce(
+        previewBookings.reduce(
           (total, booking) =>
             total + Math.round(booking.originalAmountEur * 100),
           0,
         ) / 100,
       refundAmountEur:
-        bookings.reduce(
+        previewBookings.reduce(
           (total, booking) => total + Math.round(booking.refundAmountEur * 100),
           0,
         ) / 100,
       cancellationFeeEur:
-        bookings.reduce(
+        previewBookings.reduce(
           (total, booking) =>
             total + Math.round(booking.cancellationFeeEur * 100),
           0,
@@ -1124,17 +1146,19 @@ class BookingService {
         booking.removeHook(hookId);
       }
 
+      const refundCalculation = CancellationRefundService.calculate({
+        tenant,
+        booking,
+        cancelledAt: cancellationContext.cancelledAt ?? Date.now(),
+        origin: cancellationContext.origin || CANCELLATION_ORIGINS.SYSTEM,
+        refundPercentage: cancellationContext.refundPercentage,
+        cancelledByUserId: cancellationContext.cancelledByUserId,
+      });
+      booking.cancellationRefund = { ...refundCalculation };
+
       let attachments;
 
       if (booking.priceEur > 0 && !skipCancellation) {
-        const refundCalculation = CancellationRefundService.calculate({
-          tenant,
-          booking,
-          cancelledAt: cancellationContext.cancelledAt ?? Date.now(),
-          origin: cancellationContext.origin || CANCELLATION_ORIGINS.SYSTEM,
-          refundPercentage: cancellationContext.refundPercentage,
-          cancelledByUserId: cancellationContext.cancelledByUserId,
-        });
         const sanitizedBankDetails = sanitizeBankDetails(bankDetails);
         const options = {
           alreadyPaid: booking.isPayed,
@@ -1268,21 +1292,20 @@ class BookingService {
 
     let attachments;
     let cancellationDocument;
-    let refundCalculations = [];
+    const cancelledAt = cancellationContext.cancelledAt ?? Date.now();
+    const refundCalculations = bookings.map((booking) => ({
+      bookingId: booking.id,
+      ...CancellationRefundService.calculate({
+        tenant,
+        booking,
+        cancelledAt,
+        origin: cancellationContext.origin || CANCELLATION_ORIGINS.SYSTEM,
+        refundPercentage: cancellationContext.refundPercentage,
+        cancelledByUserId: cancellationContext.cancelledByUserId,
+      }),
+    }));
 
     if (groupBooking.getTotalPrice() > 0 && !skipCancellation) {
-      const cancelledAt = cancellationContext.cancelledAt ?? Date.now();
-      refundCalculations = bookings.map((booking) => ({
-        bookingId: booking.id,
-        ...CancellationRefundService.calculate({
-          tenant,
-          booking,
-          cancelledAt,
-          origin: cancellationContext.origin || CANCELLATION_ORIGINS.SYSTEM,
-          refundPercentage: cancellationContext.refundPercentage,
-          cancelledByUserId: cancellationContext.cancelledByUserId,
-        }),
-      }));
       const options = {
         alreadyPaid: groupBooking.areSomeBookingsPaid(),
         cancellationReason: reason,
@@ -1311,10 +1334,16 @@ class BookingService {
       booking.isRejected = true;
       booking.rejectionReason = reason;
 
-      if (cancellationDocument) {
-        const refundCalculation = refundCalculations.find(
-          (calculation) => calculation.bookingId === booking.id,
-        );
+      const refundCalculation = refundCalculations.find(
+        (calculation) => calculation.bookingId === booking.id,
+      );
+      if (refundCalculation) {
+        const refundAudit = { ...refundCalculation };
+        delete refundAudit.bookingId;
+        booking.cancellationRefund = refundAudit;
+      }
+
+      if (cancellationDocument && refundCalculation) {
         const refundAudit = { ...refundCalculation };
         delete refundAudit.bookingId;
         booking.attachments.push({

--- a/src/commons/services/checkout/booking-service.js
+++ b/src/commons/services/checkout/booking-service.js
@@ -36,6 +36,10 @@ const {
 } = require("../booking-consitency-service");
 const CancellationService = require("../payment/cancellation-service");
 const {
+  CancellationRefundService,
+  CANCELLATION_ORIGINS,
+} = require("../payment/cancellation-refund-service");
+const {
   BadRequestError,
   NotFoundError,
   BaseError,
@@ -700,6 +704,10 @@ class BookingService {
           booking.id,
           booking.rejectionReason,
           null,
+          false,
+          false,
+          null,
+          { origin: CANCELLATION_ORIGINS.SYSTEM },
         );
       }
 
@@ -1015,6 +1023,77 @@ class BookingService {
     }
   }
 
+  static async getCancellationRefundPreview(tenantId, bookingId) {
+    const [tenant, booking] = await Promise.all([
+      TenantManager.getTenant(tenantId),
+      BookingManager.getBooking(bookingId, tenantId),
+    ]);
+
+    if (!tenant) {
+      throw new NotFoundError("tenant_not_found", { tenantId });
+    }
+    if (!booking) {
+      throw new NotFoundError("booking_not_found", { bookingId });
+    }
+
+    return {
+      bookingId,
+      ...CancellationRefundService.calculate({
+        tenant,
+        booking,
+        origin: CANCELLATION_ORIGINS.ADMIN,
+      }),
+    };
+  }
+
+  static async getGroupCancellationRefundPreview(tenantId, groupBookingId) {
+    const [tenant, groupBooking] = await Promise.all([
+      TenantManager.getTenant(tenantId),
+      GroupBookingManager.getGroupBooking(tenantId, groupBookingId, true),
+    ]);
+
+    if (!tenant) {
+      throw new NotFoundError("tenant_not_found", { tenantId });
+    }
+    if (!groupBooking) {
+      throw new NotFoundError("group_booking_not_found", { groupBookingId });
+    }
+
+    const cancelledAt = Date.now();
+    const bookings = groupBooking.bookings.map((booking) => ({
+      bookingId: booking.id,
+      ...CancellationRefundService.calculate({
+        tenant,
+        booking,
+        cancelledAt,
+        origin: CANCELLATION_ORIGINS.ADMIN,
+      }),
+    }));
+
+    return {
+      groupBookingId,
+      cancelledAt,
+      bookings,
+      originalAmountEur:
+        bookings.reduce(
+          (total, booking) =>
+            total + Math.round(booking.originalAmountEur * 100),
+          0,
+        ) / 100,
+      refundAmountEur:
+        bookings.reduce(
+          (total, booking) => total + Math.round(booking.refundAmountEur * 100),
+          0,
+        ) / 100,
+      cancellationFeeEur:
+        bookings.reduce(
+          (total, booking) =>
+            total + Math.round(booking.cancellationFeeEur * 100),
+          0,
+        ) / 100,
+    };
+  }
+
   static async rejectBooking(
     tenantId,
     bookingId,
@@ -1023,11 +1102,18 @@ class BookingService {
     skipWorkflow = false,
     skipCancellation = false,
     bankDetails = null,
+    cancellationContext = {},
   ) {
-    const booking = await BookingManager.getBooking(bookingId, tenantId);
+    const [booking, tenant] = await Promise.all([
+      BookingManager.getBooking(bookingId, tenantId),
+      TenantManager.getTenant(tenantId),
+    ]);
 
     if (!booking) {
       throw new NotFoundError("booking_not_found", { bookingId });
+    }
+    if (!tenant) {
+      throw new NotFoundError("tenant_not_found", { tenantId });
     }
 
     try {
@@ -1041,17 +1127,34 @@ class BookingService {
       let attachments;
 
       if (booking.priceEur > 0 && !skipCancellation) {
+        const refundCalculation = CancellationRefundService.calculate({
+          tenant,
+          booking,
+          cancelledAt: cancellationContext.cancelledAt ?? Date.now(),
+          origin: cancellationContext.origin || CANCELLATION_ORIGINS.SYSTEM,
+          refundPercentage: cancellationContext.refundPercentage,
+          cancelledByUserId: cancellationContext.cancelledByUserId,
+        });
         const sanitizedBankDetails = sanitizeBankDetails(bankDetails);
         const options = {
           alreadyPaid: booking.isPayed,
           bankDetails: sanitizedBankDetails || undefined,
+          cancellationReason: reason,
+          refundCalculation,
         };
-        const { cancellation, name, cancellationId, revision, timeCreated } =
-          await CancellationService.createSingleCancellation({
-            tenantId,
-            bookingId,
-            options,
-          });
+        const {
+          cancellation,
+          name,
+          cancellationId,
+          revision,
+          timeCreated,
+          originalInvoiceNumber,
+          originalInvoiceDate,
+        } = await CancellationService.createSingleCancellation({
+          tenantId,
+          bookingId,
+          options,
+        });
 
         attachments = [
           {
@@ -1064,9 +1167,17 @@ class BookingService {
         booking.attachments.push({
           type: "cancellation",
           title: name,
+          name,
           cancellationId: cancellationId,
           revision: revision,
           timeCreated,
+          cancellation: {
+            ...refundCalculation,
+            originalDocumentRef: {
+              number: originalInvoiceNumber,
+              timeCreated: originalInvoiceDate,
+            },
+          },
         });
       }
 
@@ -1125,12 +1236,19 @@ class BookingService {
     hookId = null,
     skipWorkflow = false,
     skipCancellation = false,
+    cancellationContext = {},
   ) {
-    const groupBooking = await GroupBookingManager.getGroupBooking(
-      tenantId,
-      groupBookingId,
-      true,
-    );
+    const [groupBooking, tenant] = await Promise.all([
+      GroupBookingManager.getGroupBooking(tenantId, groupBookingId, true),
+      TenantManager.getTenant(tenantId),
+    ]);
+
+    if (!groupBooking) {
+      throw new NotFoundError("group_booking_not_found", { groupBookingId });
+    }
+    if (!tenant) {
+      throw new NotFoundError("tenant_not_found", { tenantId });
+    }
 
     const bookings = groupBooking.bookings;
 
@@ -1149,18 +1267,36 @@ class BookingService {
     }
 
     let attachments;
-    let bookingAttachment;
+    let cancellationDocument;
+    let refundCalculations = [];
 
     if (groupBooking.getTotalPrice() > 0 && !skipCancellation) {
-      const options = { alreadyPaid: groupBooking.areSomeBookingsPaid() };
+      const cancelledAt = cancellationContext.cancelledAt ?? Date.now();
+      refundCalculations = bookings.map((booking) => ({
+        bookingId: booking.id,
+        ...CancellationRefundService.calculate({
+          tenant,
+          booking,
+          cancelledAt,
+          origin: cancellationContext.origin || CANCELLATION_ORIGINS.SYSTEM,
+          refundPercentage: cancellationContext.refundPercentage,
+          cancelledByUserId: cancellationContext.cancelledByUserId,
+        }),
+      }));
+      const options = {
+        alreadyPaid: groupBooking.areSomeBookingsPaid(),
+        cancellationReason: reason,
+        refundCalculations,
+      };
 
-      const { cancellation, name, cancellationId, revision, timeCreated } =
+      cancellationDocument =
         await CancellationService.createAggregatedCancellation({
           tenantId,
           bookingIds: groupBooking.bookingIds,
           groupBookingId: groupBooking.id,
           options,
         });
+      const { cancellation } = cancellationDocument;
 
       attachments = [
         {
@@ -1169,22 +1305,33 @@ class BookingService {
           contentType: "application/pdf",
         },
       ];
-
-      bookingAttachment = {
-        type: "cancellation",
-        title: name,
-        cancellationId: cancellationId,
-        revision: revision,
-        timeCreated,
-      };
     }
 
     for (const booking of bookings) {
       booking.isRejected = true;
       booking.rejectionReason = reason;
 
-      if (bookingAttachment) {
-        booking.attachments.push(bookingAttachment);
+      if (cancellationDocument) {
+        const refundCalculation = refundCalculations.find(
+          (calculation) => calculation.bookingId === booking.id,
+        );
+        const refundAudit = { ...refundCalculation };
+        delete refundAudit.bookingId;
+        booking.attachments.push({
+          type: "cancellation",
+          title: cancellationDocument.name,
+          name: cancellationDocument.name,
+          cancellationId: cancellationDocument.cancellationId,
+          revision: cancellationDocument.revision,
+          timeCreated: cancellationDocument.timeCreated,
+          cancellation: {
+            ...refundAudit,
+            originalDocumentRef: {
+              number: cancellationDocument.originalInvoiceNumber,
+              timeCreated: cancellationDocument.originalInvoiceDate,
+            },
+          },
+        });
       }
       await BookingManager.storeBooking(booking);
 

--- a/src/commons/services/checkout/booking-service.js
+++ b/src/commons/services/checkout/booking-service.js
@@ -45,6 +45,7 @@ const {
   BaseError,
   MethodNotAllowedError,
   ForbiddenError,
+  UnauthorizedError,
 } = require("../../../errors/BaseError");
 const { resolveCheckoutId } = require("../../utilities/checkout-utils");
 const { CustomFieldService } = require("../custom-field/custom-field-service");
@@ -1058,6 +1059,81 @@ class BookingService {
     };
   }
 
+  static toCustomerCancellationRefundPreview(calculation, bookingId) {
+    return {
+      bookingId,
+      originalAmountEur: calculation.originalAmountEur,
+      refundAmountEur: calculation.refundAmountEur,
+      cancellationFeeEur: calculation.cancellationFeeEur,
+      suggestedRefundPercentage: calculation.suggestedRefundPercentage,
+      appliedRefundPercentage: calculation.appliedRefundPercentage,
+      daysBeforeStart: calculation.daysBeforeStart,
+      appliedTierDays: calculation.appliedTierDays,
+    };
+  }
+
+  static async getUserCancellationRefundPreview(tenantId, bookingId) {
+    const [tenant, booking] = await Promise.all([
+      TenantManager.getTenant(tenantId),
+      BookingManager.getBooking(bookingId, tenantId),
+    ]);
+
+    if (!tenant) {
+      throw new NotFoundError("tenant_not_found", { tenantId });
+    }
+    if (!booking || !booking.id) {
+      throw new NotFoundError("booking_not_found", { bookingId });
+    }
+    if (booking.isRejected === true) {
+      throw new ForbiddenError("booking_already_rejected", { bookingId });
+    }
+    if (booking.cancellationPolicy?.userCancellable !== true) {
+      throw new ForbiddenError("booking_user_cancellation_disabled", {
+        bookingId,
+      });
+    }
+
+    const calculation = CancellationRefundService.calculate({
+      tenant,
+      booking,
+      origin: CANCELLATION_ORIGINS.USER,
+    });
+
+    return this.toCustomerCancellationRefundPreview(calculation, bookingId);
+  }
+
+  static async getPublicCancellationRefundPreview(tenantId, bookingId, name) {
+    if (!name || typeof name !== "string" || !name.trim()) {
+      throw new BadRequestError("missing_name");
+    }
+
+    const ownsBooking = await this.verifyBookingOwnership(
+      tenantId,
+      bookingId,
+      name,
+    );
+    if (!ownsBooking) {
+      throw new UnauthorizedError("booking_name_mismatch", { bookingId });
+    }
+
+    return this.getUserCancellationRefundPreview(tenantId, bookingId);
+  }
+
+  static async getHookCancellationRefundPreview(tenantId, bookingId, hookId) {
+    const booking = await BookingManager.getBooking(bookingId, tenantId);
+
+    if (!booking || !booking.id) {
+      throw new NotFoundError("booking_not_found", { bookingId });
+    }
+
+    const hook = booking.getHook ? booking.getHook(hookId) : null;
+    if (!hook || hook.type !== BOOKING_HOOK_TYPES.REJECT) {
+      throw new NotFoundError("booking_hook_not_found", { bookingId, hookId });
+    }
+
+    return this.getUserCancellationRefundPreview(tenantId, bookingId);
+  }
+
   static async getGroupCancellationRefundPreview(tenantId, groupBookingId) {
     const [tenant, groupBooking] = await Promise.all([
       TenantManager.getTenant(tenantId),
@@ -1436,12 +1512,24 @@ class BookingService {
 
       await BookingManager.storeBooking(booking);
 
+      const tenantEntity = await TenantManager.getTenant(tenant);
+      const refundPreview = this.toCustomerCancellationRefundPreview(
+        CancellationRefundService.calculate({
+          tenant: tenantEntity,
+          booking,
+          origin: CANCELLATION_ORIGINS.USER,
+        }),
+        booking.id,
+      );
+
       await MailController.sendVerifyBookingRejection(
         booking.mail,
         booking.id,
         booking.tenantId,
         hook.id,
         reason,
+        undefined,
+        refundPreview,
       );
 
       logger.info(

--- a/src/commons/services/payment/cancellation-refund-service.js
+++ b/src/commons/services/payment/cancellation-refund-service.js
@@ -132,6 +132,48 @@ class CancellationRefundService {
       });
     }
   }
+
+  /**
+   * Build Handlebars-friendly refund fields for cancellation mails.
+   * Accepts a full calculation or a customer preview object.
+   */
+  static toMailTemplateData(calculation) {
+    if (!calculation || typeof calculation !== "object") {
+      return {
+        hasRefundPreview: false,
+        originalAmountEur: 0,
+        refundAmountEur: 0,
+        cancellationFeeEur: 0,
+        refundPercentage: 0,
+        daysBeforeStart: null,
+        hasCancellationFee: false,
+      };
+    }
+
+    const originalAmountEur = Number(calculation.originalAmountEur) || 0;
+    const refundAmountEur = Number(calculation.refundAmountEur) || 0;
+    const cancellationFeeEur = Number(calculation.cancellationFeeEur) || 0;
+    const refundPercentage = Number(
+      calculation.appliedRefundPercentage ??
+        calculation.suggestedRefundPercentage ??
+        0,
+    );
+    const daysBeforeStart =
+      calculation.daysBeforeStart === undefined ||
+      calculation.daysBeforeStart === null
+        ? null
+        : Number(calculation.daysBeforeStart);
+
+    return {
+      hasRefundPreview: originalAmountEur > 0,
+      originalAmountEur,
+      refundAmountEur,
+      cancellationFeeEur,
+      refundPercentage,
+      daysBeforeStart,
+      hasCancellationFee: cancellationFeeEur > 0,
+    };
+  }
 }
 
 module.exports = {

--- a/src/commons/services/payment/cancellation-refund-service.js
+++ b/src/commons/services/payment/cancellation-refund-service.js
@@ -1,0 +1,139 @@
+const { DateTime } = require("luxon");
+const { BadRequestError } = require("../../../errors/BaseError");
+const {
+  normalizeCancellationRefundTiers,
+} = require("../../utilities/cancellation-refund-tiers");
+
+const CANCELLATION_ORIGINS = Object.freeze({
+  USER: "user",
+  ADMIN: "admin",
+  SYSTEM: "system",
+});
+
+const CANCELLATION_TIME_ZONE = "Europe/Berlin";
+
+class CancellationRefundService {
+  static calculate({
+    tenant,
+    booking,
+    cancelledAt = Date.now(),
+    origin,
+    refundPercentage,
+    cancelledByUserId = null,
+  }) {
+    if (!Object.values(CANCELLATION_ORIGINS).includes(origin)) {
+      throw new BadRequestError("invalid_cancellation_origin", { origin });
+    }
+
+    if (!booking || !Number.isFinite(booking.priceEur)) {
+      throw new BadRequestError("invalid_cancellation_booking");
+    }
+
+    if (!Number.isFinite(cancelledAt)) {
+      throw new BadRequestError("invalid_cancellation_time");
+    }
+
+    const { daysBeforeStart, appliedTierDays, suggestedRefundPercentage } =
+      this.resolvePolicy({
+        tiers: tenant?.cancellationRefundTiers || [],
+        timeBegin: booking.timeBegin,
+        cancelledAt,
+      });
+
+    let appliedRefundPercentage = suggestedRefundPercentage;
+    if (origin === CANCELLATION_ORIGINS.SYSTEM) {
+      appliedRefundPercentage = 100;
+    } else if (
+      origin === CANCELLATION_ORIGINS.ADMIN &&
+      refundPercentage !== undefined
+    ) {
+      this.validateRefundPercentage(refundPercentage);
+      appliedRefundPercentage = refundPercentage;
+    }
+
+    const originalAmountCents = Math.round(booking.priceEur * 100);
+    const refundAmountCents = Math.round(
+      (originalAmountCents * appliedRefundPercentage) / 100,
+    );
+    const cancellationFeeCents = originalAmountCents - refundAmountCents;
+
+    return {
+      cancelledAt,
+      daysBeforeStart,
+      originalAmountEur: originalAmountCents / 100,
+      suggestedRefundPercentage,
+      appliedRefundPercentage,
+      refundAmountEur: refundAmountCents / 100,
+      cancellationFeeEur: cancellationFeeCents / 100,
+      appliedTierDays,
+      origin,
+      adminOverride:
+        origin === CANCELLATION_ORIGINS.ADMIN &&
+        appliedRefundPercentage !== suggestedRefundPercentage,
+      cancelledByUserId: cancelledByUserId || null,
+    };
+  }
+
+  static resolvePolicy({ tiers, timeBegin, cancelledAt }) {
+    const normalizedTiers = normalizeCancellationRefundTiers(tiers || []);
+    const daysBeforeStart = this.calculateDaysBeforeStart(
+      timeBegin,
+      cancelledAt,
+    );
+
+    if (normalizedTiers.length === 0 || daysBeforeStart === null) {
+      return {
+        daysBeforeStart,
+        appliedTierDays: null,
+        suggestedRefundPercentage: 100,
+      };
+    }
+
+    const appliedTier =
+      normalizedTiers.find((tier) => daysBeforeStart >= tier.daysBeforeStart) ||
+      normalizedTiers[normalizedTiers.length - 1];
+
+    return {
+      daysBeforeStart,
+      appliedTierDays: appliedTier.daysBeforeStart,
+      suggestedRefundPercentage: appliedTier.refundPercentage,
+    };
+  }
+
+  static calculateDaysBeforeStart(timeBegin, cancelledAt) {
+    if (!Number.isFinite(timeBegin) || !Number.isFinite(cancelledAt)) {
+      return null;
+    }
+
+    const bookingDay = DateTime.fromMillis(timeBegin, {
+      zone: CANCELLATION_TIME_ZONE,
+    }).startOf("day");
+    const cancellationDay = DateTime.fromMillis(cancelledAt, {
+      zone: CANCELLATION_TIME_ZONE,
+    }).startOf("day");
+
+    if (!bookingDay.isValid || !cancellationDay.isValid) {
+      return null;
+    }
+
+    return Math.round(bookingDay.diff(cancellationDay, "days").days);
+  }
+
+  static validateRefundPercentage(refundPercentage) {
+    if (
+      !Number.isInteger(refundPercentage) ||
+      refundPercentage < 0 ||
+      refundPercentage > 100
+    ) {
+      throw new BadRequestError("invalid_refund_percentage", {
+        refundPercentage,
+      });
+    }
+  }
+}
+
+module.exports = {
+  CancellationRefundService,
+  CANCELLATION_ORIGINS,
+  CANCELLATION_TIME_ZONE,
+};

--- a/src/commons/services/payment/cancellation-refund-service.js
+++ b/src/commons/services/payment/cancellation-refund-service.js
@@ -101,14 +101,16 @@ class CancellationRefundService {
   }
 
   static calculateDaysBeforeStart(timeBegin, cancelledAt) {
-    if (!Number.isFinite(timeBegin) || !Number.isFinite(cancelledAt)) {
+    const beginMs = Number(timeBegin);
+    const cancelledMs = Number(cancelledAt);
+    if (!Number.isFinite(beginMs) || !Number.isFinite(cancelledMs)) {
       return null;
     }
 
-    const bookingDay = DateTime.fromMillis(timeBegin, {
+    const bookingDay = DateTime.fromMillis(beginMs, {
       zone: CANCELLATION_TIME_ZONE,
     }).startOf("day");
-    const cancellationDay = DateTime.fromMillis(cancelledAt, {
+    const cancellationDay = DateTime.fromMillis(cancelledMs, {
       zone: CANCELLATION_TIME_ZONE,
     }).startOf("day");
 

--- a/src/commons/services/payment/cancellation-service.js
+++ b/src/commons/services/payment/cancellation-service.js
@@ -242,8 +242,8 @@ async function _createCancellationNumber(tenantId, bookingId) {
     cancellationId = await IdGenerator.next(tenantId, 4, "cancellation");
   }
 
-  const prefix = tenant.cancellationNumberPrefix || "Storno";
-  const cancellationNumber = `${prefix}-${cancellationId}-${revision}`;
+  const prefix = (tenant.cancellationNumberPrefix || "").trim();
+  const cancellationNumber = `${prefix ? `${prefix}-` : ""}${cancellationId}-${revision}`;
 
   return { cancellationNumber, cancellationId, revision };
 }

--- a/src/commons/services/payment/cancellation-service.js
+++ b/src/commons/services/payment/cancellation-service.js
@@ -66,8 +66,9 @@ class CancellationService {
         cancellationId,
         cancellationNumber,
         originalInvoiceNumber,
+        originalInvoiceDate,
         revision,
-        timeCreated: Date.now(),
+        timeCreated: options.refundCalculation?.cancelledAt ?? Date.now(),
       };
     } catch (err) {
       if (err.isNextcloudError) {
@@ -166,8 +167,9 @@ class CancellationService {
         cancellationId,
         cancellationNumber,
         originalInvoiceNumber,
+        originalInvoiceDate,
         revision,
-        timeCreated: Date.now(),
+        timeCreated: options.refundCalculations?.[0]?.cancelledAt ?? Date.now(),
       };
     } catch (err) {
       if (err.isNextcloudError) {

--- a/src/commons/services/workflow/workflow-action.js
+++ b/src/commons/services/workflow/workflow-action.js
@@ -1,6 +1,9 @@
 const MailController = require("../../mail-service/mail-controller");
 const BookingManager = require("../../data-managers/booking-manager");
 const MembershipManager = require("../../data-managers/membership-manager");
+const {
+  CANCELLATION_ORIGINS,
+} = require("../payment/cancellation-refund-service");
 
 class WorkflowAction {
   constructor(action) {
@@ -102,6 +105,9 @@ class BookingStatusAction extends WorkflowAction {
           "",
           null,
           true,
+          false,
+          null,
+          { origin: CANCELLATION_ORIGINS.SYSTEM },
         );
       }
     }

--- a/src/commons/utilities/cancellation-refund-tiers.js
+++ b/src/commons/utilities/cancellation-refund-tiers.js
@@ -1,0 +1,59 @@
+function getCancellationRefundTiersError(tiers) {
+  if (!Array.isArray(tiers)) {
+    return "cancellationRefundTiers must be an array";
+  }
+
+  const seenDays = new Set();
+  for (const tier of tiers) {
+    if (!tier || typeof tier !== "object" || Array.isArray(tier)) {
+      return "Each cancellation refund tier must be an object";
+    }
+
+    if (!Number.isInteger(tier.daysBeforeStart) || tier.daysBeforeStart < 0) {
+      return "daysBeforeStart must be a non-negative integer";
+    }
+
+    if (
+      !Number.isInteger(tier.refundPercentage) ||
+      tier.refundPercentage < 0 ||
+      tier.refundPercentage > 100
+    ) {
+      return "refundPercentage must be an integer between 0 and 100";
+    }
+
+    if (seenDays.has(tier.daysBeforeStart)) {
+      return "daysBeforeStart must be unique";
+    }
+    seenDays.add(tier.daysBeforeStart);
+  }
+
+  const sorted = [...tiers].sort(
+    (left, right) => right.daysBeforeStart - left.daysBeforeStart,
+  );
+  for (let index = 1; index < sorted.length; index += 1) {
+    if (sorted[index].refundPercentage > sorted[index - 1].refundPercentage) {
+      return "refundPercentage must not decrease with more advance notice";
+    }
+  }
+
+  return null;
+}
+
+function normalizeCancellationRefundTiers(tiers) {
+  const error = getCancellationRefundTiersError(tiers);
+  if (error) {
+    throw new Error(error);
+  }
+
+  return tiers
+    .map(({ daysBeforeStart, refundPercentage }) => ({
+      daysBeforeStart,
+      refundPercentage,
+    }))
+    .sort((left, right) => right.daysBeforeStart - left.daysBeforeStart);
+}
+
+module.exports = {
+  getCancellationRefundTiersError,
+  normalizeCancellationRefundTiers,
+};

--- a/src/commons/utilities/schemaUtils.js
+++ b/src/commons/utilities/schemaUtils.js
@@ -96,7 +96,9 @@ class SchemaUtils {
       if (typeof field.validate === "function") {
         const result = field.validate(value, obj);
         if (result !== true) {
-          addError(key, result);
+          // `false` is the Mongoose-compatible failure signal; map it to the
+          // SchemaUtils error code used by shared schema definitions.
+          addError(key, result === false ? "validate" : result);
         }
       }
 

--- a/src/commons/utilities/schemaUtils.js
+++ b/src/commons/utilities/schemaUtils.js
@@ -30,6 +30,15 @@ const ERROR_CODES = {
   validate: "invalid_custom",
 };
 
+function isMongooseSubdocumentSchema(type) {
+  return (
+    type &&
+    typeof type === "object" &&
+    type.constructor?.name === "Schema" &&
+    typeof type.paths === "object"
+  );
+}
+
 class SchemaUtils {
   static createDefaults(schemaDefinition) {
     const defaults = {};
@@ -44,6 +53,8 @@ class SchemaUtils {
           typeof field.default === "function" ? field.default() : field.default;
       } else if (field.type === Array) {
         defaults[key] = [];
+      } else if (isMongooseSubdocumentSchema(field.type)) {
+        // Optional embedded subdocuments must stay unset, not "".
       } else if (field.type === Object) {
         defaults[key] = {};
       } else if (field.type === Boolean) {

--- a/src/docs/routes/cancellation-refunds.yaml
+++ b/src/docs/routes/cancellation-refunds.yaml
@@ -1,0 +1,237 @@
+/api/{tenant}/bookings/{bookingId}/cancellation-refund-preview:
+  get:
+    tags:
+      - Bookings
+    summary: Preview a booking cancellation refund
+    description: Returns the current tenant-policy refund proposed to an administrator.
+    security:
+      - bearerAuth: []
+    parameters:
+      - $ref: "#/components/parameters/CancellationTenantParam"
+      - $ref: "#/components/parameters/CancellationBookingIdParam"
+    responses:
+      "200":
+        description: Current refund preview
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CancellationRefundCalculation"
+      "401":
+        description: Not authenticated
+      "403":
+        description: Missing booking management permission
+      "404":
+        description: Booking not found
+
+/api/{tenant}/bookings/{bookingId}/reject:
+  post:
+    tags:
+      - Bookings
+    summary: Reject or cancel a booking
+    description: |
+      Administrators may accept the current tenant-policy refund or override it
+      with an integer percentage from 0 through 100. Omitting
+      `refundPercentage` applies the current policy proposal.
+    security:
+      - bearerAuth: []
+    parameters:
+      - $ref: "#/components/parameters/CancellationTenantParam"
+      - $ref: "#/components/parameters/CancellationBookingIdParam"
+    requestBody:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/BookingCancellationRequest"
+    responses:
+      "200":
+        description: Booking cancelled
+      "400":
+        description: Invalid refund percentage
+      "401":
+        description: Not authenticated
+      "403":
+        description: Missing booking management permission
+      "404":
+        description: Booking not found
+
+/api/{tenant}/group-bookings/{groupBookingId}/cancellation-refund-preview:
+  get:
+    tags:
+      - Group bookings
+    summary: Preview a group booking cancellation refund
+    description: Returns policy calculations per booking and aggregate amounts.
+    security:
+      - bearerAuth: []
+    parameters:
+      - $ref: "#/components/parameters/CancellationTenantParam"
+      - $ref: "#/components/parameters/CancellationGroupBookingIdParam"
+    responses:
+      "200":
+        description: Current group refund preview
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GroupCancellationRefundPreview"
+      "401":
+        description: Not authenticated
+      "403":
+        description: Missing booking management permission
+      "404":
+        description: Group booking not found
+
+/api/{tenant}/group-bookings/{groupBookingId}/reject:
+  post:
+    tags:
+      - Group bookings
+    summary: Reject or cancel a group booking
+    description: |
+      Without an override, each booking uses its current policy proposal. An
+      optional `refundPercentage` applies uniformly to every booking in the group.
+    security:
+      - bearerAuth: []
+    parameters:
+      - $ref: "#/components/parameters/CancellationTenantParam"
+      - $ref: "#/components/parameters/CancellationGroupBookingIdParam"
+    requestBody:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/BookingCancellationRequest"
+    responses:
+      "200":
+        description: Group booking cancelled
+      "400":
+        description: Invalid refund percentage or inconsistent group booking
+      "401":
+        description: Not authenticated
+      "403":
+        description: Missing booking management permission
+      "404":
+        description: Group booking not found
+
+components:
+  parameters:
+    CancellationTenantParam:
+      name: tenant
+      in: path
+      required: true
+      description: Tenant identifier
+      schema:
+        type: string
+    CancellationBookingIdParam:
+      name: bookingId
+      in: path
+      required: true
+      description: Booking identifier
+      schema:
+        type: string
+    CancellationGroupBookingIdParam:
+      name: groupBookingId
+      in: path
+      required: true
+      description: Group booking identifier
+      schema:
+        type: string
+
+  schemas:
+    BookingCancellationRequest:
+      type: object
+      properties:
+        reason:
+          type: string
+        skipCancellation:
+          type: boolean
+          description: Skip generation of the cancellation document.
+        refundPercentage:
+          type: integer
+          minimum: 0
+          maximum: 100
+          description: Optional administrator override.
+        bankDetails:
+          type: object
+          description: Optional bank details used only while rendering the document.
+          properties:
+            accountHolder:
+              type: string
+            bankName:
+              type: string
+            iban:
+              type: string
+            bic:
+              type: string
+
+    CancellationRefundCalculation:
+      type: object
+      required:
+        - cancelledAt
+        - originalAmountEur
+        - suggestedRefundPercentage
+        - appliedRefundPercentage
+        - refundAmountEur
+        - cancellationFeeEur
+        - origin
+        - adminOverride
+      properties:
+        bookingId:
+          type: string
+        cancelledAt:
+          type: integer
+          format: int64
+          description: Calculation timestamp in epoch milliseconds.
+        daysBeforeStart:
+          type: integer
+          nullable: true
+          description: Calendar days in Europe/Berlin.
+        originalAmountEur:
+          type: number
+          format: double
+        suggestedRefundPercentage:
+          type: integer
+          minimum: 0
+          maximum: 100
+        appliedRefundPercentage:
+          type: integer
+          minimum: 0
+          maximum: 100
+        refundAmountEur:
+          type: number
+          format: double
+        cancellationFeeEur:
+          type: number
+          format: double
+        appliedTierDays:
+          type: integer
+          nullable: true
+        origin:
+          type: string
+          enum:
+            - user
+            - admin
+            - system
+        adminOverride:
+          type: boolean
+        cancelledByUserId:
+          type: string
+          nullable: true
+
+    GroupCancellationRefundPreview:
+      type: object
+      properties:
+        groupBookingId:
+          type: string
+        cancelledAt:
+          type: integer
+          format: int64
+        bookings:
+          type: array
+          items:
+            $ref: "#/components/schemas/CancellationRefundCalculation"
+        originalAmountEur:
+          type: number
+          format: double
+        refundAmountEur:
+          type: number
+          format: double
+        cancellationFeeEur:
+          type: number
+          format: double

--- a/src/docs/routes/cancellation-refunds.yaml
+++ b/src/docs/routes/cancellation-refunds.yaml
@@ -230,9 +230,6 @@ components:
 
     GroupBookingCancellationRequest:
       type: object
-      description: |
-        Group cancellation body. `bankDetails` is not supported for aggregated
-        group cancellation documents.
       properties:
         reason:
           type: string
@@ -244,6 +241,18 @@ components:
           minimum: 0
           maximum: 100
           description: Optional administrator override applied to every booking.
+        bankDetails:
+          type: object
+          description: Optional bank details used while rendering the aggregated cancellation document.
+          properties:
+            accountHolder:
+              type: string
+            bankName:
+              type: string
+            iban:
+              type: string
+            bic:
+              type: string
 
     CancellationRefundCalculation:
       type: object

--- a/src/docs/routes/cancellation-refunds.yaml
+++ b/src/docs/routes/cancellation-refunds.yaml
@@ -1,3 +1,67 @@
+/api/{tenant}/bookings/{bookingId}/cancellation-refund-preview/public:
+  get:
+    tags:
+      - Bookings
+    summary: Preview cancellation refund for a customer
+    description: |
+      Returns the current tenant-policy refund for a user self-cancellation.
+      Requires the booking owner name (same check as verify-ownership). No JWT.
+    parameters:
+      - $ref: "#/components/parameters/CancellationTenantParam"
+      - $ref: "#/components/parameters/CancellationBookingIdParam"
+      - name: name
+        in: query
+        required: true
+        description: Booking owner name used for ownership verification
+        schema:
+          type: string
+    responses:
+      "200":
+        description: Customer-safe refund preview
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CustomerCancellationRefundPreview"
+      "400":
+        description: Missing required parameters
+      "401":
+        description: Booking name mismatch
+      "403":
+        description: User cancellation disabled or booking already rejected
+      "404":
+        description: Booking not found
+
+/api/{tenant}/bookings/{bookingId}/hooks/{hookId}/cancellation-refund-preview:
+  get:
+    tags:
+      - Bookings
+    summary: Preview cancellation refund via reject hook
+    description: |
+      Returns the current tenant-policy refund for a pending REJECT hook.
+      Access is gated by a valid hook id from the verification email. No JWT.
+    parameters:
+      - $ref: "#/components/parameters/CancellationTenantParam"
+      - $ref: "#/components/parameters/CancellationBookingIdParam"
+      - name: hookId
+        in: path
+        required: true
+        description: Pending REJECT hook identifier
+        schema:
+          type: string
+    responses:
+      "200":
+        description: Customer-safe refund preview
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CustomerCancellationRefundPreview"
+      "400":
+        description: Missing required parameters
+      "403":
+        description: User cancellation disabled or booking already rejected
+      "404":
+        description: Booking or hook not found
+
 /api/{tenant}/bookings/{bookingId}/cancellation-refund-preview:
   get:
     tags:

--- a/src/docs/routes/cancellation-refunds.yaml
+++ b/src/docs/routes/cancellation-refunds.yaml
@@ -151,6 +151,8 @@
     description: |
       Without an override, each booking uses its current policy proposal. An
       optional `refundPercentage` applies uniformly to every booking in the group.
+      Consistency validation failures return HTTP 200 with `success: false`
+      (same envelope as other group-booking mutation endpoints).
     security:
       - bearerAuth: []
     parameters:
@@ -160,12 +162,14 @@
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/BookingCancellationRequest"
+            $ref: "#/components/schemas/GroupBookingCancellationRequest"
     responses:
       "200":
-        description: Group booking cancelled
+        description: |
+          Group booking cancelled (`success: true`) or consistency validation
+          failed (`success: false` with `errors`).
       "400":
-        description: Invalid refund percentage or inconsistent group booking
+        description: Invalid refund percentage
       "401":
         description: Not authenticated
       "403":
@@ -223,6 +227,23 @@ components:
               type: string
             bic:
               type: string
+
+    GroupBookingCancellationRequest:
+      type: object
+      description: |
+        Group cancellation body. `bankDetails` is not supported for aggregated
+        group cancellation documents.
+      properties:
+        reason:
+          type: string
+        skipCancellation:
+          type: boolean
+          description: Skip generation of the cancellation document.
+        refundPercentage:
+          type: integer
+          minimum: 0
+          maximum: 100
+          description: Optional administrator override applied to every booking.
 
     CancellationRefundCalculation:
       type: object

--- a/src/platform/api/api-router-tenant-related.js
+++ b/src/platform/api/api-router-tenant-related.js
@@ -192,6 +192,10 @@ router.get(
   AuthenticationController.isSignedIn,
   BookingController.getCancellationRefundPreview,
 );
+router.get(
+  "/bookings/:id/cancellation-refund-preview/public",
+  BookingController.getPublicCancellationRefundPreview,
+);
 router.post(
   "/bookings/:id/reject",
   AuthenticationController.isSignedIn,
@@ -204,6 +208,10 @@ router.post(
 router.get(
   "/bookings/:id/verify-ownership",
   BookingController.verifyBookingOwnership,
+);
+router.get(
+  "/bookings/:id/hooks/:hookId/cancellation-refund-preview",
+  BookingController.getHookCancellationRefundPreview,
 );
 router.get(
   "/bookings/:id/hooks/:hookId/release",

--- a/src/platform/api/api-router-tenant-related.js
+++ b/src/platform/api/api-router-tenant-related.js
@@ -187,6 +187,11 @@ router.post(
   AuthenticationController.isSignedIn,
   BookingController.payBooking,
 );
+router.get(
+  "/bookings/:id/cancellation-refund-preview",
+  AuthenticationController.isSignedIn,
+  BookingController.getCancellationRefundPreview,
+);
 router.post(
   "/bookings/:id/reject",
   AuthenticationController.isSignedIn,
@@ -268,6 +273,11 @@ router.post(
   "/group-bookings/:id/pay",
   AuthenticationController.isSignedIn,
   GroupBookingController.payGroupBooking,
+);
+router.get(
+  "/group-bookings/:id/cancellation-refund-preview",
+  AuthenticationController.isSignedIn,
+  GroupBookingController.getCancellationRefundPreview,
 );
 router.post(
   "/group-bookings/:id/reject",

--- a/src/platform/api/controllers/booking-controller.js
+++ b/src/platform/api/controllers/booking-controller.js
@@ -637,6 +637,54 @@ class BookingController {
     }
   }
 
+  static async getPublicCancellationRefundPreview(request, response) {
+    try {
+      const tenantId = request.params.tenant;
+      const bookingId = request.params.id;
+      const name = request.query.name;
+
+      if (!tenantId || !bookingId || !name) {
+        return response.status(400).send("Missing required parameters.");
+      }
+
+      const preview = await BookingService.getPublicCancellationRefundPreview(
+        tenantId,
+        bookingId,
+        name,
+      );
+      return response.status(200).send(preview);
+    } catch (err) {
+      logger.error(err);
+      return response
+        .status(err.statusCode || 500)
+        .send(err.message || "Could not calculate cancellation refund");
+    }
+  }
+
+  static async getHookCancellationRefundPreview(request, response) {
+    try {
+      const tenantId = request.params.tenant;
+      const bookingId = request.params.id;
+      const hookId = request.params.hookId;
+
+      if (!tenantId || !bookingId || !hookId) {
+        return response.status(400).send("Missing required parameters.");
+      }
+
+      const preview = await BookingService.getHookCancellationRefundPreview(
+        tenantId,
+        bookingId,
+        hookId,
+      );
+      return response.status(200).send(preview);
+    } catch (err) {
+      logger.error(err);
+      return response
+        .status(err.statusCode || 500)
+        .send(err.message || "Could not calculate cancellation refund");
+    }
+  }
+
   static async rejectBooking(request, response) {
     try {
       const tenantId = request.params.tenant;

--- a/src/platform/api/controllers/booking-controller.js
+++ b/src/platform/api/controllers/booking-controller.js
@@ -23,6 +23,10 @@ const {
 const CancellationReceiptService = require("../../../commons/services/payment/cancellation-service");
 const MailController = require("../../../commons/mail-service/mail-controller");
 const TenantManager = require("../../../commons/data-managers/tenant-manager");
+const {
+  CancellationRefundService,
+  CANCELLATION_ORIGINS,
+} = require("../../../commons/services/payment/cancellation-refund-service");
 
 const logger = bunyan.createLogger({
   name: "booking-controller.js",
@@ -599,14 +603,56 @@ class BookingController {
     }
   }
 
+  static async getCancellationRefundPreview(request, response) {
+    try {
+      const tenantId = request.params.tenant;
+      const bookingId = request.params.id;
+      const user = request.user;
+      const booking = await BookingManager.getBooking(bookingId, tenantId);
+
+      if (!booking) {
+        return response.sendStatus(404);
+      }
+
+      const hasPermission = await PermissionsService._allowUpdate(
+        booking,
+        user.id,
+        tenantId,
+        RolePermission.MANAGE_BOOKINGS,
+      );
+      if (!hasPermission) {
+        return response.sendStatus(403);
+      }
+
+      const preview = await BookingService.getCancellationRefundPreview(
+        tenantId,
+        bookingId,
+      );
+      return response.status(200).send(preview);
+    } catch (err) {
+      logger.error(err);
+      return response
+        .status(err.statusCode || 500)
+        .send(err.message || "Could not calculate cancellation refund");
+    }
+  }
+
   static async rejectBooking(request, response) {
     try {
       const tenantId = request.params.tenant;
       const user = request.user;
       const id = request.params.id;
-      const { reason, skipCancellation, bankDetails } = request.body || {};
+      const { reason, skipCancellation, bankDetails, refundPercentage } =
+        request.body || {};
       if (!id) {
         return response.sendStatus(400);
+      }
+      if (refundPercentage !== undefined) {
+        try {
+          CancellationRefundService.validateRefundPercentage(refundPercentage);
+        } catch (error) {
+          return response.status(400).send(error.code);
+        }
       }
 
       const booking = await BookingManager.getBooking(id, tenantId);
@@ -630,6 +676,11 @@ class BookingController {
           false,
           Boolean(skipCancellation),
           bankDetails || null,
+          {
+            origin: CANCELLATION_ORIGINS.ADMIN,
+            refundPercentage,
+            cancelledByUserId: user.id,
+          },
         );
         return response.sendStatus(200);
       } else {
@@ -704,6 +755,7 @@ class BookingController {
             false,
             false,
             bankDetails || null,
+            { origin: CANCELLATION_ORIGINS.USER },
           );
         } else {
           return response.sendStatus(400);

--- a/src/platform/api/controllers/group-booking-controller.js
+++ b/src/platform/api/controllers/group-booking-controller.js
@@ -334,7 +334,8 @@ class GroupBookingController {
       const tenantId = req.params.tenant;
       const user = req.user;
       const groupBookingId = req.params.id;
-      const { reason, skipCancellation, refundPercentage } = req.body || {};
+      const { reason, skipCancellation, bankDetails, refundPercentage } =
+        req.body || {};
       if (refundPercentage !== undefined) {
         try {
           CancellationRefundService.validateRefundPercentage(refundPercentage);
@@ -364,6 +365,7 @@ class GroupBookingController {
           null,
           false,
           Boolean(skipCancellation),
+          bankDetails || null,
           {
             origin: CANCELLATION_ORIGINS.ADMIN,
             refundPercentage,

--- a/src/platform/api/controllers/group-booking-controller.js
+++ b/src/platform/api/controllers/group-booking-controller.js
@@ -6,6 +6,10 @@ const BookingService = require("../../../commons/services/checkout/booking-servi
 const WorkflowService = require("../../../commons/services/workflow/workflow-service");
 const TenantManager = require("../../../commons/data-managers/tenant-manager");
 const MailController = require("../../../commons/mail-service/mail-controller");
+const {
+  CancellationRefundService,
+  CANCELLATION_ORIGINS,
+} = require("../../../commons/services/payment/cancellation-refund-service");
 
 const logger = bunyan.createLogger({
   name: "group-booking-controller.js",
@@ -288,12 +292,56 @@ class GroupBookingController {
     }
   }
 
+  static async getCancellationRefundPreview(req, res) {
+    try {
+      const tenantId = req.params.tenant;
+      const groupBookingId = req.params.id;
+      const user = req.user;
+      const groupBooking = await GroupBookingManager.getGroupBooking(
+        tenantId,
+        groupBookingId,
+      );
+
+      if (!groupBooking) {
+        return res.sendStatus(404);
+      }
+
+      const hasPermission = await PermissionsService._allowUpdate(
+        groupBooking,
+        user.id,
+        tenantId,
+        RolePermission.MANAGE_BOOKINGS,
+      );
+      if (!hasPermission) {
+        return res.sendStatus(403);
+      }
+
+      const preview = await BookingService.getGroupCancellationRefundPreview(
+        tenantId,
+        groupBookingId,
+      );
+      return res.status(200).send(preview);
+    } catch (error) {
+      logger.error(error);
+      return res
+        .status(error.statusCode || 500)
+        .send(error.message || "Could not calculate cancellation refund");
+    }
+  }
+
   static async rejectGroupBooking(req, res) {
     try {
       const tenantId = req.params.tenant;
       const user = req.user;
       const groupBookingId = req.params.id;
-      const { reason, skipCancellation } = req.body;
+      const { reason, skipCancellation, refundPercentage } = req.body || {};
+      if (refundPercentage !== undefined) {
+        try {
+          CancellationRefundService.validateRefundPercentage(refundPercentage);
+        } catch (error) {
+          return res.status(400).send(error.code);
+        }
+      }
 
       const groupBooking = await GroupBookingManager.getGroupBooking(
         tenantId,
@@ -316,6 +364,11 @@ class GroupBookingController {
           null,
           false,
           Boolean(skipCancellation),
+          {
+            origin: CANCELLATION_ORIGINS.ADMIN,
+            refundPercentage,
+            cancelledByUserId: user.id,
+          },
         );
 
         if (!result.success) {

--- a/src/platform/api/controllers/tenant-controller.js
+++ b/src/platform/api/controllers/tenant-controller.js
@@ -33,6 +33,9 @@ const {
 const {
   validatePdfBookingTableMeta,
 } = require("../../../commons/pdf-service/pdf-booking-table-meta");
+const {
+  getCancellationRefundTiersError,
+} = require("../../../commons/utilities/cancellation-refund-tiers");
 
 const PDF_TEMPLATE_FIELDS = {
   receiptTemplate: "receipt",
@@ -74,6 +77,13 @@ function validatePdfBookingTableMetaField(body) {
     return null;
   }
   return validatePdfBookingTableMeta(body.pdfBookingTableMeta);
+}
+
+function validateCancellationRefundTiersField(body) {
+  if (!Object.prototype.hasOwnProperty.call(body, "cancellationRefundTiers")) {
+    return null;
+  }
+  return getCancellationRefundTiersError(body.cancellationRefundTiers);
 }
 
 const logger = bunyan.createLogger({
@@ -214,6 +224,13 @@ class TenantController {
         return response.status(400).send(tableMetaError);
       }
 
+      const cancellationRefundTiersError = validateCancellationRefundTiersField(
+        request.body,
+      );
+      if (cancellationRefundTiersError) {
+        return response.status(400).send(cancellationRefundTiersError);
+      }
+
       tenant.ownerUserIds = [user.id];
       if ((await TenantManager.checkTenantCount()) === false) {
         throw new Error(`Maximum number of tenants reached.`);
@@ -328,6 +345,7 @@ class TenantController {
           "bookableCustomFields",
           "cancellationTemplate",
           "cancellationNumberPrefix",
+          "cancellationRefundTiers",
           "pdfBookingLayout",
           "pdfBookingTableMeta",
         ];
@@ -365,6 +383,12 @@ class TenantController {
         const tableMetaError = validatePdfBookingTableMetaField(request.body);
         if (tableMetaError) {
           return response.status(400).send(tableMetaError);
+        }
+
+        const cancellationRefundTiersError =
+          validateCancellationRefundTiersField(request.body);
+        if (cancellationRefundTiersError) {
+          return response.status(400).send(cancellationRefundTiersError);
         }
 
         fields.forEach((field) => {

--- a/src/rule-engine/actionRegistry.js
+++ b/src/rule-engine/actionRegistry.js
@@ -1,5 +1,8 @@
 const BookingService = require("../commons/services/checkout/booking-service");
 const MailerService = require("../commons/mail-service/mail-service");
+const {
+  CANCELLATION_ORIGINS,
+} = require("../commons/services/payment/cancellation-refund-service");
 
 module.exports = {
   test(doc, params) {
@@ -11,7 +14,16 @@ module.exports = {
     const tenantId = doc.tenantId;
     const reason = params.reason || "";
 
-    await BookingService.rejectBooking(tenantId, bookingId, reason);
+    await BookingService.rejectBooking(
+      tenantId,
+      bookingId,
+      reason,
+      null,
+      false,
+      false,
+      null,
+      { origin: CANCELLATION_ORIGINS.SYSTEM },
+    );
   },
 
   async sendEmail(doc, params = {}) {

--- a/tests/cancellation-booking-service.test.js
+++ b/tests/cancellation-booking-service.test.js
@@ -1,0 +1,213 @@
+const assert = require("assert");
+const sinon = require("sinon");
+const BookingService = require("../src/commons/services/checkout/booking-service");
+const BookingManager = require("../src/commons/data-managers/booking-manager");
+const GroupBookingManager = require("../src/commons/data-managers/group-booking-manager");
+const TenantManager = require("../src/commons/data-managers/tenant-manager");
+const CancellationService = require("../src/commons/services/payment/cancellation-service");
+const WorkflowService = require("../src/commons/services/workflow/workflow-service");
+const LockerService = require("../src/commons/services/locker/locker-service");
+const MailController = require("../src/commons/mail-service/mail-controller");
+const {
+  CANCELLATION_ORIGINS,
+} = require("../src/commons/services/payment/cancellation-refund-service");
+
+function booking(overrides = {}) {
+  return {
+    id: "booking-1",
+    tenantId: "tenant-1",
+    name: "Test User",
+    mail: "test@example.com",
+    street: "Main Street 1",
+    zipCode: "12345",
+    location: "Test City",
+    priceEur: 100,
+    vatIncludedEur: 15.97,
+    timeBegin: Date.UTC(2026, 7, 21, 8),
+    isCommitted: true,
+    isPayed: true,
+    isRejected: false,
+    attachments: [],
+    bookableItems: [],
+    ...overrides,
+  };
+}
+
+function stubCancellationSideEffects() {
+  sinon.stub(BookingManager, "storeBooking").callsFake(async (value) => value);
+  sinon.stub(WorkflowService, "handleWorkflowEvent").resolves();
+  sinon.stub(LockerService, "getInstance").returns({
+    handleCancel: sinon.stub().resolves(),
+  });
+  sinon.stub(MailController, "sendBookingCancel").resolves();
+  sinon.stub(MailController, "sendBookingRejection").resolves();
+}
+
+describe("BookingService cancellation refunds", function () {
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it("stores the admin refund calculation on a single cancellation", async function () {
+    const storedBooking = booking();
+    sinon.stub(BookingManager, "getBooking").resolves(storedBooking);
+    sinon.stub(TenantManager, "getTenant").resolves({
+      id: "tenant-1",
+      cancellationRefundTiers: [{ daysBeforeStart: 0, refundPercentage: 50 }],
+    });
+    const createCancellation = sinon
+      .stub(CancellationService, "createSingleCancellation")
+      .resolves({
+        cancellation: { name: "cancellation.pdf", buffer: Buffer.from("pdf") },
+        name: "cancellation.pdf",
+        cancellationId: "12",
+        revision: 1,
+        timeCreated: Date.UTC(2026, 7, 20, 8),
+        originalInvoiceNumber: "INV-1-1",
+        originalInvoiceDate: Date.UTC(2026, 6, 1, 8),
+      });
+    stubCancellationSideEffects();
+
+    await BookingService.rejectBooking(
+      "tenant-1",
+      "booking-1",
+      "Customer request",
+      null,
+      false,
+      false,
+      null,
+      {
+        origin: CANCELLATION_ORIGINS.ADMIN,
+        refundPercentage: 25,
+        cancelledByUserId: "admin-1",
+        cancelledAt: Date.UTC(2026, 7, 20, 8),
+      },
+    );
+
+    const attachment = storedBooking.attachments[0];
+    assert.strictEqual(attachment.name, "cancellation.pdf");
+    assert.strictEqual(attachment.cancellation.refundAmountEur, 25);
+    assert.strictEqual(attachment.cancellation.cancellationFeeEur, 75);
+    assert.strictEqual(attachment.cancellation.adminOverride, true);
+    assert.strictEqual(
+      attachment.cancellation.originalDocumentRef.number,
+      "INV-1-1",
+    );
+    assert.strictEqual(
+      createCancellation.firstCall.args[0].options.cancellationReason,
+      "Customer request",
+    );
+  });
+
+  it("returns a group preview with per-booking and aggregate amounts", async function () {
+    sinon.stub(TenantManager, "getTenant").resolves({
+      id: "tenant-1",
+      cancellationRefundTiers: [
+        { daysBeforeStart: 20, refundPercentage: 100 },
+        { daysBeforeStart: 0, refundPercentage: 50 },
+      ],
+    });
+    sinon.stub(GroupBookingManager, "getGroupBooking").resolves({
+      id: "group-1",
+      bookings: [
+        booking({
+          id: "booking-1",
+          priceEur: 10,
+          timeBegin: Date.now() + 30 * 86400000,
+        }),
+        booking({
+          id: "booking-2",
+          priceEur: 20,
+          timeBegin: Date.now() + 5 * 86400000,
+        }),
+      ],
+    });
+
+    const preview = await BookingService.getGroupCancellationRefundPreview(
+      "tenant-1",
+      "group-1",
+    );
+
+    assert.deepStrictEqual(
+      preview.bookings.map((entry) => entry.appliedRefundPercentage),
+      [100, 50],
+    );
+    assert.strictEqual(preview.originalAmountEur, 30);
+    assert.strictEqual(preview.refundAmountEur, 20);
+    assert.strictEqual(preview.cancellationFeeEur, 10);
+  });
+
+  it("stores per-booking audit data for a group cancellation", async function () {
+    const cancelledAt = Date.UTC(2026, 7, 1, 8);
+    const bookings = [
+      booking({
+        id: "booking-1",
+        timeBegin: cancelledAt + 30 * 86400000,
+      }),
+      booking({
+        id: "booking-2",
+        timeBegin: cancelledAt + 5 * 86400000,
+      }),
+    ];
+    sinon.stub(TenantManager, "getTenant").resolves({
+      id: "tenant-1",
+      cancellationRefundTiers: [
+        { daysBeforeStart: 20, refundPercentage: 100 },
+        { daysBeforeStart: 0, refundPercentage: 50 },
+      ],
+    });
+    sinon.stub(GroupBookingManager, "getGroupBooking").resolves({
+      id: "group-1",
+      bookingIds: bookings.map((entry) => entry.id),
+      bookings,
+      getTotalPrice: () => 200,
+      areSomeBookingsPaid: () => true,
+    });
+    sinon.stub(CancellationService, "createAggregatedCancellation").resolves({
+      cancellation: {
+        name: "group-cancellation.pdf",
+        buffer: Buffer.from("pdf"),
+      },
+      name: "group-cancellation.pdf",
+      cancellationId: "13",
+      revision: 1,
+      timeCreated: cancelledAt,
+      originalInvoiceNumber: "INV-GROUP-1",
+      originalInvoiceDate: Date.UTC(2026, 6, 1, 8),
+    });
+    stubCancellationSideEffects();
+
+    const result = await BookingService.rejectGroupBooking(
+      "tenant-1",
+      "group-1",
+      "Group cancellation",
+      null,
+      false,
+      false,
+      {
+        origin: CANCELLATION_ORIGINS.ADMIN,
+        refundPercentage: 25,
+        cancelledByUserId: "admin-1",
+        cancelledAt,
+      },
+    );
+
+    assert.strictEqual(result.success, true);
+    assert.deepStrictEqual(
+      bookings.map(
+        (entry) => entry.attachments[0].cancellation.appliedRefundPercentage,
+      ),
+      [25, 25],
+    );
+    assert.deepStrictEqual(
+      bookings.map(
+        (entry) => entry.attachments[0].cancellation.suggestedRefundPercentage,
+      ),
+      [100, 50],
+    );
+    assert.strictEqual(
+      bookings[0].attachments[0].cancellation.originalDocumentRef.number,
+      "INV-GROUP-1",
+    );
+  });
+});

--- a/tests/cancellation-booking-service.test.js
+++ b/tests/cancellation-booking-service.test.js
@@ -254,6 +254,16 @@ describe("BookingService cancellation refunds", function () {
       ),
       [100, 50],
     );
+    assert.deepStrictEqual(
+      bookings.map((entry) => entry.cancellationRefund.appliedRefundPercentage),
+      [25, 25],
+    );
+    assert.deepStrictEqual(
+      bookings.map(
+        (entry) => entry.cancellationRefund.suggestedRefundPercentage,
+      ),
+      [100, 50],
+    );
     assert.strictEqual(
       bookings[0].attachments[0].cancellation.originalDocumentRef.number,
       "INV-GROUP-1",
@@ -264,6 +274,19 @@ describe("BookingService cancellation refunds", function () {
     const oldBooking = booking({
       isRejected: true,
       rejectionReason: "Changed plans",
+      cancellationRefund: {
+        cancelledAt: Date.UTC(2026, 6, 1, 8),
+        daysBeforeStart: 10,
+        originalAmountEur: 97.5,
+        suggestedRefundPercentage: 50,
+        appliedRefundPercentage: 25,
+        refundAmountEur: 24.38,
+        cancellationFeeEur: 73.12,
+        appliedTierDays: 0,
+        origin: "admin",
+        adminOverride: true,
+        cancelledByUserId: "admin-1",
+      },
       priceEur: 97.5,
       vatIncludedEur: 10.5,
       paymentProvider: "invoice",
@@ -302,5 +325,9 @@ describe("BookingService cancellation refunds", function () {
     assert.strictEqual(storedBooking.vatIncludedEur, 10.5);
     assert.strictEqual(storedBooking.bookableItems.length, 1);
     assert.strictEqual(storedBooking.isRejected, false);
+    assert.strictEqual(storedBooking.cancellationRefund, undefined);
+    assert.deepStrictEqual(storeBooking.firstCall.args[2], {
+      unset: ["cancellationRefund"],
+    });
   });
 });

--- a/tests/cancellation-booking-service.test.js
+++ b/tests/cancellation-booking-service.test.js
@@ -233,6 +233,7 @@ describe("BookingService cancellation refunds", function () {
       null,
       false,
       false,
+      null,
       {
         origin: CANCELLATION_ORIGINS.ADMIN,
         refundPercentage: 25,
@@ -267,6 +268,80 @@ describe("BookingService cancellation refunds", function () {
     assert.strictEqual(
       bookings[0].attachments[0].cancellation.originalDocumentRef.number,
       "INV-GROUP-1",
+    );
+  });
+
+  it("forwards bank details to aggregated group cancellation documents", async function () {
+    const cancelledAt = Date.UTC(2026, 7, 1, 8);
+    const bookings = [
+      booking({
+        id: "booking-1",
+        timeBegin: cancelledAt + 30 * 86400000,
+      }),
+      booking({
+        id: "booking-2",
+        timeBegin: cancelledAt + 5 * 86400000,
+      }),
+    ];
+    sinon.stub(TenantManager, "getTenant").resolves({
+      id: "tenant-1",
+      cancellationRefundTiers: [
+        { daysBeforeStart: 0, refundPercentage: 100 },
+      ],
+    });
+    sinon.stub(GroupBookingManager, "getGroupBooking").resolves({
+      id: "group-1",
+      bookingIds: bookings.map((entry) => entry.id),
+      bookings,
+      getTotalPrice: () => 200,
+      areSomeBookingsPaid: () => true,
+    });
+    const createAggregatedCancellation = sinon
+      .stub(CancellationService, "createAggregatedCancellation")
+      .resolves({
+        cancellation: {
+          name: "group-cancellation.pdf",
+          buffer: Buffer.from("pdf"),
+        },
+        name: "group-cancellation.pdf",
+        cancellationId: "13",
+        revision: 1,
+        timeCreated: cancelledAt,
+        originalInvoiceNumber: "INV-GROUP-1",
+        originalInvoiceDate: Date.UTC(2026, 6, 1, 8),
+      });
+    stubCancellationSideEffects();
+
+    const result = await BookingService.rejectGroupBooking(
+      "tenant-1",
+      "group-1",
+      "Group cancellation",
+      null,
+      false,
+      false,
+      {
+        accountHolder: " Max Mustermann ",
+        bankName: " Musterbank ",
+        iban: "de89 3704 0044 0532 0130 00",
+        bic: " coba deff xxx ",
+      },
+      {
+        origin: CANCELLATION_ORIGINS.ADMIN,
+        refundPercentage: 100,
+        cancelledByUserId: "admin-1",
+        cancelledAt,
+      },
+    );
+
+    assert.strictEqual(result.success, true);
+    assert.deepStrictEqual(
+      createAggregatedCancellation.firstCall.args[0].options.bankDetails,
+      {
+        accountHolder: "Max Mustermann",
+        bankName: "Musterbank",
+        iban: "DE89370400440532013000",
+        bic: "COBADEFFXXX",
+      },
     );
   });
 

--- a/tests/cancellation-booking-service.test.js
+++ b/tests/cancellation-booking-service.test.js
@@ -11,6 +11,10 @@ const MailController = require("../src/commons/mail-service/mail-controller");
 const {
   CANCELLATION_ORIGINS,
 } = require("../src/commons/services/payment/cancellation-refund-service");
+const {
+  ManualBundleCheckoutService,
+} = require("../src/commons/services/checkout/bundle-checkout-service");
+const { Booking } = require("../src/commons/entities/booking/booking");
 
 function booking(overrides = {}) {
   return {
@@ -89,6 +93,8 @@ describe("BookingService cancellation refunds", function () {
     assert.strictEqual(attachment.cancellation.refundAmountEur, 25);
     assert.strictEqual(attachment.cancellation.cancellationFeeEur, 75);
     assert.strictEqual(attachment.cancellation.adminOverride, true);
+    assert.strictEqual(storedBooking.cancellationRefund.refundAmountEur, 25);
+    assert.strictEqual(storedBooking.cancellationRefund.adminOverride, true);
     assert.strictEqual(
       attachment.cancellation.originalDocumentRef.number,
       "INV-1-1",
@@ -99,7 +105,53 @@ describe("BookingService cancellation refunds", function () {
     );
   });
 
+  it("stores cancellation refund audit on the booking when skipping the document", async function () {
+    const storedBooking = booking();
+    sinon.stub(BookingManager, "getBooking").resolves(storedBooking);
+    sinon.stub(TenantManager, "getTenant").resolves({
+      id: "tenant-1",
+      cancellationRefundTiers: [{ daysBeforeStart: 0, refundPercentage: 50 }],
+    });
+    const createCancellation = sinon.stub(
+      CancellationService,
+      "createSingleCancellation",
+    );
+    stubCancellationSideEffects();
+
+    await BookingService.rejectBooking(
+      "tenant-1",
+      "booking-1",
+      "Customer request",
+      null,
+      false,
+      true,
+      null,
+      {
+        origin: CANCELLATION_ORIGINS.ADMIN,
+        cancelledAt: Date.UTC(2026, 7, 20, 8),
+      },
+    );
+
+    assert.strictEqual(createCancellation.called, false);
+    assert.strictEqual(storedBooking.attachments.length, 0);
+    assert.strictEqual(storedBooking.cancellationRefund.refundAmountEur, 50);
+    assert.strictEqual(storedBooking.cancellationRefund.originalAmountEur, 100);
+  });
+
   it("returns a group preview with per-booking and aggregate amounts", async function () {
+    const cancelledAt = Date.UTC(2026, 6, 15, 8);
+    const groupBookings = [
+      booking({
+        id: "booking-1",
+        priceEur: 10,
+        timeBegin: cancelledAt + 30 * 86400000,
+      }),
+      booking({
+        id: "booking-2",
+        priceEur: 20,
+        timeBegin: cancelledAt + 5 * 86400000,
+      }),
+    ];
     sinon.stub(TenantManager, "getTenant").resolves({
       id: "tenant-1",
       cancellationRefundTiers: [
@@ -109,28 +161,25 @@ describe("BookingService cancellation refunds", function () {
     });
     sinon.stub(GroupBookingManager, "getGroupBooking").resolves({
       id: "group-1",
-      bookings: [
-        booking({
-          id: "booking-1",
-          priceEur: 10,
-          timeBegin: Date.now() + 30 * 86400000,
-        }),
-        booking({
-          id: "booking-2",
-          priceEur: 20,
-          timeBegin: Date.now() + 5 * 86400000,
-        }),
-      ],
+      bookingIds: groupBookings.map((entry) => entry.id),
     });
+    sinon.stub(BookingManager, "getBookings").resolves(groupBookings);
+    const clock = sinon.useFakeTimers({ now: cancelledAt, toFake: ["Date"] });
 
     const preview = await BookingService.getGroupCancellationRefundPreview(
       "tenant-1",
       "group-1",
     );
 
+    clock.restore();
+
     assert.deepStrictEqual(
       preview.bookings.map((entry) => entry.appliedRefundPercentage),
       [100, 50],
+    );
+    assert.deepStrictEqual(
+      preview.bookings.map((entry) => entry.daysBeforeStart),
+      [30, 5],
     );
     assert.strictEqual(preview.originalAmountEur, 30);
     assert.strictEqual(preview.refundAmountEur, 20);
@@ -209,5 +258,49 @@ describe("BookingService cancellation refunds", function () {
       bookings[0].attachments[0].cancellation.originalDocumentRef.number,
       "INV-GROUP-1",
     );
+  });
+
+  it("preserves price and bookable items when unrejecting a booking", async function () {
+    const oldBooking = booking({
+      isRejected: true,
+      rejectionReason: "Changed plans",
+      priceEur: 97.5,
+      vatIncludedEur: 10.5,
+      paymentProvider: "invoice",
+      bookableItems: [
+        { bookableId: "room-1", amount: 1, userGrossPriceEur: 97.5 },
+      ],
+    });
+    sinon.stub(BookingManager, "getBooking").resolves(oldBooking);
+    const storeBooking = sinon
+      .stub(BookingManager, "storeBooking")
+      .callsFake(async (value) => value);
+    sinon.stub(LockerService, "getInstance").returns({
+      handleCreate: sinon.stub().resolves(),
+    });
+    sinon
+      .stub(ManualBundleCheckoutService.prototype, "prepareBooking")
+      .resolves(
+        new Booking({
+          ...oldBooking,
+          isRejected: false,
+          rejectionReason: "",
+          priceEur: 0,
+          vatIncludedEur: 0,
+          bookableItems: [],
+        }),
+      );
+
+    await BookingService.updateBooking("tenant-1", {
+      ...oldBooking,
+      isRejected: false,
+      rejectionReason: "",
+    });
+
+    const storedBooking = storeBooking.firstCall.args[0];
+    assert.strictEqual(storedBooking.priceEur, 97.5);
+    assert.strictEqual(storedBooking.vatIncludedEur, 10.5);
+    assert.strictEqual(storedBooking.bookableItems.length, 1);
+    assert.strictEqual(storedBooking.isRejected, false);
   });
 });

--- a/tests/cancellation-refund-controller.test.js
+++ b/tests/cancellation-refund-controller.test.js
@@ -1,0 +1,119 @@
+const assert = require("assert");
+const sinon = require("sinon");
+const {
+  BookingController,
+} = require("../src/platform/api/controllers/booking-controller");
+const {
+  GroupBookingController,
+} = require("../src/platform/api/controllers/group-booking-controller");
+const BookingManager = require("../src/commons/data-managers/booking-manager");
+const GroupBookingManager = require("../src/commons/data-managers/group-booking-manager");
+const PermissionsService = require("../src/commons/services/permission-service");
+const BookingService = require("../src/commons/services/checkout/booking-service");
+
+function response(sandbox) {
+  return {
+    status: sandbox.stub().returnsThis(),
+    send: sandbox.stub().returnsThis(),
+    sendStatus: sandbox.stub().returnsThis(),
+    json: sandbox.stub().returnsThis(),
+  };
+}
+
+describe("cancellation refund controllers", function () {
+  let sandbox;
+
+  beforeEach(function () {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it("returns an authorized single-booking refund preview", async function () {
+    const booking = { id: "booking-1", tenantId: "tenant-1" };
+    const preview = {
+      bookingId: "booking-1",
+      appliedRefundPercentage: 50,
+    };
+    sandbox.stub(BookingManager, "getBooking").resolves(booking);
+    sandbox.stub(PermissionsService, "_allowUpdate").resolves(true);
+    sandbox
+      .stub(BookingService, "getCancellationRefundPreview")
+      .resolves(preview);
+    const res = response(sandbox);
+
+    await BookingController.getCancellationRefundPreview(
+      {
+        params: { tenant: "tenant-1", id: "booking-1" },
+        user: { id: "admin-1" },
+      },
+      res,
+    );
+
+    assert.strictEqual(res.status.calledWith(200), true);
+    assert.strictEqual(res.send.calledWith(preview), true);
+  });
+
+  it("denies a single-booking refund preview without permission", async function () {
+    sandbox
+      .stub(BookingManager, "getBooking")
+      .resolves({ id: "booking-1", tenantId: "tenant-1" });
+    sandbox.stub(PermissionsService, "_allowUpdate").resolves(false);
+    const preview = sandbox.stub(
+      BookingService,
+      "getCancellationRefundPreview",
+    );
+    const res = response(sandbox);
+
+    await BookingController.getCancellationRefundPreview(
+      {
+        params: { tenant: "tenant-1", id: "booking-1" },
+        user: { id: "admin-1" },
+      },
+      res,
+    );
+
+    assert.strictEqual(res.sendStatus.calledWith(403), true);
+    assert.strictEqual(preview.called, false);
+  });
+
+  it("rejects an invalid single-booking admin override", async function () {
+    const res = response(sandbox);
+
+    await BookingController.rejectBooking(
+      {
+        params: { tenant: "tenant-1", id: "booking-1" },
+        user: { id: "admin-1" },
+        body: { refundPercentage: 50.5 },
+      },
+      res,
+    );
+
+    assert.strictEqual(res.status.calledWith(400), true);
+    assert.strictEqual(res.send.calledWith("invalid_refund_percentage"), true);
+  });
+
+  it("returns an authorized group refund preview", async function () {
+    const groupBooking = { id: "group-1", tenantId: "tenant-1" };
+    const preview = { groupBookingId: "group-1", bookings: [] };
+    sandbox.stub(GroupBookingManager, "getGroupBooking").resolves(groupBooking);
+    sandbox.stub(PermissionsService, "_allowUpdate").resolves(true);
+    sandbox
+      .stub(BookingService, "getGroupCancellationRefundPreview")
+      .resolves(preview);
+    const res = response(sandbox);
+
+    await GroupBookingController.getCancellationRefundPreview(
+      {
+        params: { tenant: "tenant-1", id: "group-1" },
+        user: { id: "admin-1" },
+      },
+      res,
+    );
+
+    assert.strictEqual(res.status.calledWith(200), true);
+    assert.strictEqual(res.send.calledWith(preview), true);
+  });
+});

--- a/tests/cancellation-refund-controller.test.js
+++ b/tests/cancellation-refund-controller.test.js
@@ -116,4 +116,80 @@ describe("cancellation refund controllers", function () {
     assert.strictEqual(res.status.calledWith(200), true);
     assert.strictEqual(res.send.calledWith(preview), true);
   });
+
+  it("returns a public refund preview when ownership matches", async function () {
+    const preview = {
+      bookingId: "booking-1",
+      originalAmountEur: 100,
+      refundAmountEur: 50,
+      cancellationFeeEur: 50,
+      suggestedRefundPercentage: 50,
+      appliedRefundPercentage: 50,
+      daysBeforeStart: 5,
+      appliedTierDays: 0,
+    };
+    sandbox
+      .stub(BookingService, "getPublicCancellationRefundPreview")
+      .resolves(preview);
+    const res = response(sandbox);
+
+    await BookingController.getPublicCancellationRefundPreview(
+      {
+        params: { tenant: "tenant-1", id: "booking-1" },
+        query: { name: "Max Mustermann" },
+      },
+      res,
+    );
+
+    assert.strictEqual(res.status.calledWith(200), true);
+    assert.strictEqual(res.send.calledWith(preview), true);
+  });
+
+  it("rejects a public refund preview without a name", async function () {
+    const preview = sandbox.stub(
+      BookingService,
+      "getPublicCancellationRefundPreview",
+    );
+    const res = response(sandbox);
+
+    await BookingController.getPublicCancellationRefundPreview(
+      {
+        params: { tenant: "tenant-1", id: "booking-1" },
+        query: {},
+      },
+      res,
+    );
+
+    assert.strictEqual(res.status.calledWith(400), true);
+    assert.strictEqual(preview.called, false);
+  });
+
+  it("returns a hook-scoped refund preview", async function () {
+    const preview = {
+      bookingId: "booking-1",
+      originalAmountEur: 80,
+      refundAmountEur: 80,
+      cancellationFeeEur: 0,
+      suggestedRefundPercentage: 100,
+      appliedRefundPercentage: 100,
+    };
+    sandbox
+      .stub(BookingService, "getHookCancellationRefundPreview")
+      .resolves(preview);
+    const res = response(sandbox);
+
+    await BookingController.getHookCancellationRefundPreview(
+      {
+        params: {
+          tenant: "tenant-1",
+          id: "booking-1",
+          hookId: "hook-1",
+        },
+      },
+      res,
+    );
+
+    assert.strictEqual(res.status.calledWith(200), true);
+    assert.strictEqual(res.send.calledWith(preview), true);
+  });
 });

--- a/tests/cancellation-refund-service.test.js
+++ b/tests/cancellation-refund-service.test.js
@@ -1,0 +1,180 @@
+const assert = require("assert");
+const { DateTime } = require("luxon");
+const {
+  getCancellationRefundTiersError,
+  normalizeCancellationRefundTiers,
+} = require("../src/commons/utilities/cancellation-refund-tiers");
+const {
+  CancellationRefundService,
+  CANCELLATION_ORIGINS,
+} = require("../src/commons/services/payment/cancellation-refund-service");
+
+const tiers = [
+  { daysBeforeStart: 0, refundPercentage: 50 },
+  { daysBeforeStart: 20, refundPercentage: 100 },
+];
+
+function berlinMillis(value) {
+  return DateTime.fromISO(value, { zone: "Europe/Berlin" }).toMillis();
+}
+
+describe("cancellation refund tiers", function () {
+  it("normalizes tiers by descending day threshold", function () {
+    assert.deepStrictEqual(normalizeCancellationRefundTiers(tiers), [
+      { daysBeforeStart: 20, refundPercentage: 100 },
+      { daysBeforeStart: 0, refundPercentage: 50 },
+    ]);
+  });
+
+  it("rejects duplicate thresholds and invalid percentages", function () {
+    assert.match(
+      getCancellationRefundTiersError([
+        { daysBeforeStart: 5, refundPercentage: 100 },
+        { daysBeforeStart: 5, refundPercentage: 50 },
+      ]),
+      /unique/,
+    );
+    assert.match(
+      getCancellationRefundTiersError([
+        { daysBeforeStart: 0, refundPercentage: 50.5 },
+      ]),
+      /integer between 0 and 100/,
+    );
+  });
+
+  it("rejects refunds that decrease with more advance notice", function () {
+    assert.match(
+      getCancellationRefundTiersError([
+        { daysBeforeStart: 20, refundPercentage: 50 },
+        { daysBeforeStart: 0, refundPercentage: 100 },
+      ]),
+      /must not decrease/,
+    );
+  });
+});
+
+describe("CancellationRefundService", function () {
+  it("defaults to a full refund without configured tiers", function () {
+    const result = CancellationRefundService.calculate({
+      tenant: {},
+      booking: {
+        priceEur: 42,
+        timeBegin: berlinMillis("2026-08-10T10:00:00"),
+      },
+      cancelledAt: berlinMillis("2026-08-09T18:00:00"),
+      origin: CANCELLATION_ORIGINS.USER,
+    });
+
+    assert.strictEqual(result.suggestedRefundPercentage, 100);
+    assert.strictEqual(result.appliedRefundPercentage, 100);
+    assert.strictEqual(result.refundAmountEur, 42);
+  });
+
+  it("uses calendar-day thresholds and freezes the lowest tier", function () {
+    const tenant = { cancellationRefundTiers: tiers };
+    const booking = {
+      priceEur: 100,
+      timeBegin: berlinMillis("2026-08-21T08:00:00"),
+    };
+
+    const twentyDays = CancellationRefundService.calculate({
+      tenant,
+      booking,
+      cancelledAt: berlinMillis("2026-08-01T23:59:00"),
+      origin: CANCELLATION_ORIGINS.USER,
+    });
+    const nineteenDays = CancellationRefundService.calculate({
+      tenant,
+      booking,
+      cancelledAt: berlinMillis("2026-08-02T00:01:00"),
+      origin: CANCELLATION_ORIGINS.USER,
+    });
+    const afterStart = CancellationRefundService.calculate({
+      tenant,
+      booking,
+      cancelledAt: berlinMillis("2026-08-22T00:01:00"),
+      origin: CANCELLATION_ORIGINS.USER,
+    });
+
+    assert.strictEqual(twentyDays.appliedRefundPercentage, 100);
+    assert.strictEqual(nineteenDays.appliedRefundPercentage, 50);
+    assert.strictEqual(afterStart.daysBeforeStart, -1);
+    assert.strictEqual(afterStart.appliedRefundPercentage, 50);
+  });
+
+  it("calculates calendar days across the daylight-saving transition", function () {
+    const days = CancellationRefundService.calculateDaysBeforeStart(
+      berlinMillis("2026-03-30T00:01:00"),
+      berlinMillis("2026-03-28T23:59:00"),
+    );
+
+    assert.strictEqual(days, 2);
+  });
+
+  it("applies and audits an admin override using integer cents", function () {
+    const result = CancellationRefundService.calculate({
+      tenant: { cancellationRefundTiers: tiers },
+      booking: {
+        priceEur: 10.01,
+        timeBegin: berlinMillis("2026-08-10T10:00:00"),
+      },
+      cancelledAt: berlinMillis("2026-08-09T10:00:00"),
+      origin: CANCELLATION_ORIGINS.ADMIN,
+      refundPercentage: 33,
+      cancelledByUserId: "admin-1",
+    });
+
+    assert.strictEqual(result.suggestedRefundPercentage, 50);
+    assert.strictEqual(result.appliedRefundPercentage, 33);
+    assert.strictEqual(result.refundAmountEur, 3.3);
+    assert.strictEqual(result.cancellationFeeEur, 6.71);
+    assert.strictEqual(result.adminOverride, true);
+    assert.strictEqual(result.cancelledByUserId, "admin-1");
+  });
+
+  it("ignores refund overrides for user cancellations", function () {
+    const result = CancellationRefundService.calculate({
+      tenant: { cancellationRefundTiers: tiers },
+      booking: {
+        priceEur: 100,
+        timeBegin: berlinMillis("2026-08-10T10:00:00"),
+      },
+      cancelledAt: berlinMillis("2026-08-09T10:00:00"),
+      origin: CANCELLATION_ORIGINS.USER,
+      refundPercentage: 0,
+    });
+
+    assert.strictEqual(result.appliedRefundPercentage, 50);
+    assert.strictEqual(result.refundAmountEur, 50);
+  });
+
+  it("keeps system cancellations at 100 percent", function () {
+    const result = CancellationRefundService.calculate({
+      tenant: { cancellationRefundTiers: tiers },
+      booking: {
+        priceEur: 100,
+        timeBegin: berlinMillis("2026-08-10T10:00:00"),
+      },
+      cancelledAt: berlinMillis("2026-08-09T10:00:00"),
+      origin: CANCELLATION_ORIGINS.SYSTEM,
+    });
+
+    assert.strictEqual(result.suggestedRefundPercentage, 50);
+    assert.strictEqual(result.appliedRefundPercentage, 100);
+    assert.strictEqual(result.refundAmountEur, 100);
+  });
+
+  it("rejects invalid admin refund percentages", function () {
+    assert.doesNotThrow(() =>
+      CancellationRefundService.validateRefundPercentage(0),
+    );
+    assert.doesNotThrow(() =>
+      CancellationRefundService.validateRefundPercentage(100),
+    );
+    assert.throws(
+      () => CancellationRefundService.validateRefundPercentage(50.5),
+      (error) =>
+        error.code === "invalid_refund_percentage" && error.statusCode === 400,
+    );
+  });
+});

--- a/tests/cancellation-refund-service.test.js
+++ b/tests/cancellation-refund-service.test.js
@@ -111,6 +111,16 @@ describe("CancellationRefundService", function () {
     assert.strictEqual(days, 2);
   });
 
+  it("coerces MongoDB Double timestamps before calculating days", function () {
+    const { Double } = require("mongodb");
+    const days = CancellationRefundService.calculateDaysBeforeStart(
+      new Double(berlinMillis("2026-08-10T10:00:00")),
+      berlinMillis("2026-08-09T18:00:00"),
+    );
+
+    assert.strictEqual(days, 1);
+  });
+
   it("applies and audits an admin override using integer cents", function () {
     const result = CancellationRefundService.calculate({
       tenant: { cancellationRefundTiers: tiers },

--- a/tests/cancellation-refund-service.test.js
+++ b/tests/cancellation-refund-service.test.js
@@ -187,4 +187,31 @@ describe("CancellationRefundService", function () {
         error.code === "invalid_refund_percentage" && error.statusCode === 400,
     );
   });
+
+  it("maps refund calculations to mail template variables", function () {
+    const mailData = CancellationRefundService.toMailTemplateData({
+      originalAmountEur: 100,
+      refundAmountEur: 50,
+      cancellationFeeEur: 50,
+      appliedRefundPercentage: 50,
+      daysBeforeStart: 7,
+    });
+
+    assert.strictEqual(mailData.hasRefundPreview, true);
+    assert.strictEqual(mailData.refundPercentage, 50);
+    assert.strictEqual(mailData.hasCancellationFee, true);
+    assert.strictEqual(mailData.daysBeforeStart, 7);
+  });
+
+  it("marks zero-amount bookings as without refund preview", function () {
+    const mailData = CancellationRefundService.toMailTemplateData({
+      originalAmountEur: 0,
+      refundAmountEur: 0,
+      cancellationFeeEur: 0,
+      suggestedRefundPercentage: 100,
+    });
+
+    assert.strictEqual(mailData.hasRefundPreview, false);
+    assert.strictEqual(mailData.hasCancellationFee, false);
+  });
 });

--- a/tests/pdf-service.test.js
+++ b/tests/pdf-service.test.js
@@ -308,6 +308,7 @@ describe("PdfService document generation (rendering only)", () => {
     const html = result.buffer.toString();
     assert.ok(html.includes("50 % Erstattung"));
     assert.ok(html.includes("12 Kalendertage"));
+    assert.ok(html.includes("Automatisch nach Mandantenregel"));
     assert.ok(html.includes("-59,50"));
     assert.ok(html.includes("59,50"));
     assert.ok(!html.includes("-119,00"));
@@ -369,6 +370,8 @@ describe("PdfService document generation (rendering only)", () => {
     assert.ok(html.includes("2026-0014-1"));
     assert.ok(html.includes("pdf-items--detailed booked-items"));
     assert.ok(html.includes("Details / Artikel:"));
+    assert.ok(html.includes("Automatisch nach Mandantenregel"));
+    assert.ok(!html.includes("Manuell durch Administration"));
     assert.match(html, /Buchung\s+booking-1/);
     assert.match(html, /Buchung\s+booking-2/);
     assert.ok(html.includes("-178,50"));

--- a/tests/pdf-service.test.js
+++ b/tests/pdf-service.test.js
@@ -334,6 +334,12 @@ describe("PdfService document generation (rendering only)", () => {
       {
         alreadyPaid: true,
         groupBookingId: "group-1",
+        bankDetails: {
+          accountHolder: "Max Mustermann",
+          bankName: "Musterbank",
+          iban: "DE89370400440532013000",
+          bic: "COBADEFFXXX",
+        },
         refundCalculations: [
           {
             bookingId: "booking-1",
@@ -372,6 +378,8 @@ describe("PdfService document generation (rendering only)", () => {
     assert.ok(html.includes("Details / Artikel:"));
     assert.ok(html.includes("Automatisch nach Mandantenregel"));
     assert.ok(!html.includes("Manuell durch Administration"));
+    assert.ok(html.includes("Bankverbindung für die Rückerstattung"));
+    assert.ok(html.includes("IBAN: DE89370400440532013000"));
     assert.match(html, /Buchung\s+booking-1/);
     assert.match(html, /Buchung\s+booking-2/);
     assert.ok(html.includes("-178,50"));

--- a/tests/pdf-service.test.js
+++ b/tests/pdf-service.test.js
@@ -274,6 +274,104 @@ describe("PdfService document generation (rendering only)", () => {
     assert.ok(html.includes("-119,00"));
   });
 
+  it("renders a partial cancellation with scaled amounts and audit details", async () => {
+    sinon.stub(TenantManager, "getTenant").resolves({
+      id: "tenant-1",
+      cancellationTemplate: "",
+      location: "Musterstadt",
+    });
+    sinon.stub(BookingManager, "getBooking").resolves(makeBooking());
+    sinon.stub(BookableManager, "getBookables").resolves(BOOKABLES);
+
+    const result = await PdfService.generateSingleCancellationReceipt(
+      "tenant-1",
+      "booking-1",
+      "ST-1-1",
+      "RE-1-1",
+      {
+        alreadyPaid: true,
+        refundCalculation: {
+          cancelledAt: Date.parse("2026-07-20T12:00:00+02:00"),
+          daysBeforeStart: 12,
+          originalAmountEur: 119,
+          suggestedRefundPercentage: 50,
+          appliedRefundPercentage: 50,
+          refundAmountEur: 59.5,
+          cancellationFeeEur: 59.5,
+          appliedTierDays: 0,
+          origin: "user",
+          adminOverride: false,
+        },
+      },
+    );
+
+    const html = result.buffer.toString();
+    assert.ok(html.includes("50 % Erstattung"));
+    assert.ok(html.includes("12 Kalendertage"));
+    assert.ok(html.includes("Automatisch nach Mandantenregel"));
+    assert.ok(html.includes("-59,50"));
+    assert.ok(html.includes("59,50"));
+    assert.ok(!html.includes("-119,00"));
+  });
+
+  it("renders aggregated cancellations using each booking refund", async () => {
+    sinon.stub(TenantManager, "getTenant").resolves({
+      id: "tenant-1",
+      cancellationTemplate: "",
+      location: "Musterstadt",
+    });
+    sinon
+      .stub(BookingManager, "getBookings")
+      .resolves([makeBooking(), makeBooking({ id: "booking-2" })]);
+    sinon.stub(BookableManager, "getBookables").resolves(BOOKABLES);
+
+    const cancelledAt = Date.parse("2026-07-20T12:00:00+02:00");
+    const result = await PdfService.generateAggregatedCancellationReceipt(
+      "tenant-1",
+      ["booking-1", "booking-2"],
+      "ST-1-1",
+      "RE-1-1",
+      {
+        alreadyPaid: true,
+        groupBookingId: "group-1",
+        refundCalculations: [
+          {
+            bookingId: "booking-1",
+            cancelledAt,
+            daysBeforeStart: 12,
+            originalAmountEur: 119,
+            suggestedRefundPercentage: 100,
+            appliedRefundPercentage: 100,
+            refundAmountEur: 119,
+            cancellationFeeEur: 0,
+            appliedTierDays: 20,
+            origin: "admin",
+            adminOverride: false,
+          },
+          {
+            bookingId: "booking-2",
+            cancelledAt,
+            daysBeforeStart: 5,
+            originalAmountEur: 119,
+            suggestedRefundPercentage: 50,
+            appliedRefundPercentage: 50,
+            refundAmountEur: 59.5,
+            cancellationFeeEur: 59.5,
+            appliedTierDays: 0,
+            origin: "admin",
+            adminOverride: false,
+          },
+        ],
+      },
+    );
+
+    const html = result.buffer.toString();
+    assert.match(html, /Buchung\s+booking-1/);
+    assert.match(html, /Buchung\s+booking-2/);
+    assert.ok(html.includes("-178,50"));
+    assert.ok(html.includes("59,50"));
+  });
+
   it("legacy templates using only bookingEntries still render", async () => {
     sinon.stub(TenantManager, "getTenant").resolves({
       id: "tenant-1",

--- a/tests/pdf-service.test.js
+++ b/tests/pdf-service.test.js
@@ -308,7 +308,6 @@ describe("PdfService document generation (rendering only)", () => {
     const html = result.buffer.toString();
     assert.ok(html.includes("50 % Erstattung"));
     assert.ok(html.includes("12 Kalendertage"));
-    assert.ok(html.includes("Automatisch nach Mandantenregel"));
     assert.ok(html.includes("-59,50"));
     assert.ok(html.includes("59,50"));
     assert.ok(!html.includes("-119,00"));
@@ -329,7 +328,7 @@ describe("PdfService document generation (rendering only)", () => {
     const result = await PdfService.generateAggregatedCancellationReceipt(
       "tenant-1",
       ["booking-1", "booking-2"],
-      "ST-1-1",
+      "2026-0014-1",
       "RE-1-1",
       {
         alreadyPaid: true,
@@ -366,10 +365,79 @@ describe("PdfService document generation (rendering only)", () => {
     );
 
     const html = result.buffer.toString();
+    assert.strictEqual(result.name, "Sammel-Stornorechnung-2026-0014-1.pdf");
+    assert.ok(html.includes("2026-0014-1"));
+    assert.ok(html.includes("pdf-items--detailed booked-items"));
+    assert.ok(html.includes("Details / Artikel:"));
     assert.match(html, /Buchung\s+booking-1/);
     assert.match(html, /Buchung\s+booking-2/);
     assert.ok(html.includes("-178,50"));
     assert.ok(html.includes("59,50"));
+  });
+
+  it("uses aggregated invoice table layout for aggregated cancellations", async () => {
+    sinon.stub(TenantManager, "getTenant").resolves({
+      id: "tenant-1",
+      cancellationTemplate: "",
+      invoiceTemplate: "",
+      location: "Musterstadt",
+      paymentPurposeSuffix: "Musterstadt",
+    });
+    sinon.stub(TenantManager, "getTenantApp").resolves({
+      daysUntilPaymentDue: 14,
+      bank: "Musterbank",
+      iban: "DE00",
+      bic: "XXX",
+    });
+    sinon
+      .stub(BookingManager, "getBookings")
+      .resolves([makeBooking(), makeBooking({ id: "booking-2" })]);
+    sinon.stub(BookableManager, "getBookables").resolves(BOOKABLES);
+
+    const invoiceResult = await PdfService.generateAggregatedInvoice(
+      "tenant-1",
+      ["booking-1", "booking-2"],
+      "2026-0014-1",
+      { groupBookingId: "group-1" },
+    );
+    const cancellationResult =
+      await PdfService.generateAggregatedCancellationReceipt(
+        "tenant-1",
+        ["booking-1", "booking-2"],
+        "2026-0014-1",
+        "2026-0014-1",
+        {
+          groupBookingId: "group-1",
+        },
+      );
+
+    const extractTable = (html) => {
+      const start = html.indexOf('<table class="pdf-items');
+      const end = html.indexOf("</table>", start) + 8;
+      return html.slice(start, end);
+    };
+    const normalizeTable = (table) =>
+      table.replace(/[−-]?\d+,\d+\s*€/g, "AMT").replace(/x/g, "×");
+
+    assert.strictEqual(
+      normalizeTable(extractTable(invoiceResult.buffer.toString())),
+      normalizeTable(extractTable(cancellationResult.buffer.toString())),
+    );
+  });
+
+  it("builds cancellation filenames from the cancellation number", () => {
+    assert.strictEqual(
+      PdfService._buildCancellationFilename("aggregated", "2026-0014-1"),
+      "Sammel-Stornorechnung-2026-0014-1.pdf",
+    );
+    assert.strictEqual(
+      PdfService._buildCancellationFilename("single", "2026-0014-1"),
+      "Stornorechnung-2026-0014-1.pdf",
+    );
+    assert.strictEqual(
+      PdfService._buildCancellationFilename("aggregated", "STO-2026-0014-1"),
+      "Sammel-Stornorechnung-STO-2026-0014-1.pdf",
+    );
   });
 
   it("legacy templates using only bookingEntries still render", async () => {
@@ -464,6 +532,8 @@ describe("pdf booking table meta", () => {
       aggregatedInvoiceColumnCount: 3,
       aggregatedReceiptLabelColspan: 4,
       aggregatedInvoiceLabelColspan: 2,
+      useSplitAggregatedReceiptTotals: true,
+      useSplitAggregatedInvoiceTotals: true,
       showAggregatedPaymentColumn: true,
     });
   });
@@ -493,6 +563,78 @@ describe("pdf booking table meta", () => {
       validatePdfBookingTableMeta({ showBookingId: false }),
       null,
     );
+  });
+
+  it("keeps single-booking total amounts in right-aligned cells", () => {
+    const html = Handlebars.renderPartial("pdfBookingItemsTable", {
+      layout: "detailed",
+      tableClass: "booked-items",
+      items: [
+        {
+          title: "Tisch",
+          amount: 1,
+          unitPrice: "-20,00 €",
+          totalPrice: "-20,00 €",
+        },
+      ],
+      coupon: null,
+      totals: {
+        netto: "-20,00 €",
+        vat: "-3,80 €",
+        brutto: "-23,80 €",
+      },
+      booking: null,
+      tableMeta: resolveBookingTableMeta({}),
+    });
+
+    assert.match(
+      html,
+      /<tr class="netto">\s*<td colspan="3">Gesamt \(netto\)<\/td>\s*<td class="num">-20,00 €<\/td>/,
+    );
+    assert.match(
+      html,
+      /<tr class="brutto">\s*<td colspan="3">Gesamt \(brutto\)<\/td>\s*<td class="num">-23,80 €<\/td>/,
+    );
+
+    const { documentHtml } = PdfService._prepareDocument(
+      `<!DOCTYPE html><html><head></head><body>${html}</body></html>`,
+    );
+    assert.ok(documentHtml.includes("tr.netto td.num"));
+    assert.ok(documentHtml.includes("tr.netto td:not(.num) .num"));
+  });
+
+  it("renders single-column aggregated tables without invalid colspans", () => {
+    const tableMeta = resolveBookingTableMeta({
+      pdfBookingTableMeta: {
+        showBookingId: false,
+        showBookingPeriod: false,
+        showPaymentDate: false,
+        showPaymentMethod: false,
+      },
+    });
+    const html = Handlebars.renderPartial("pdfAggregatedBookingsTable", {
+      layout: "detailed",
+      tableMeta,
+      bookings: [
+        {
+          id: "QMEY-FCNJ",
+          period: "20.07.2026, 10:00 – 20.07.2026, 12:00",
+          netto: "0,00 €",
+          items: [{ title: "Serie", amount: 1, totalPrice: "0,00 €" }],
+          coupon: null,
+        },
+      ],
+      totals: {
+        netto: "0,00 €",
+        vat: "0,00 €",
+        brutto: "0,00 €",
+      },
+    });
+
+    assert.strictEqual(tableMeta.useSplitAggregatedInvoiceTotals, false);
+    assert.ok(!html.includes('colspan="0"'));
+    assert.ok(html.includes("Details / Artikel:"));
+    assert.ok(html.includes('colspan="1"'));
   });
 
   it("hides booking metadata in detailed receipt tables when disabled", () => {

--- a/tests/tenant-cancellation-refund-tiers.test.js
+++ b/tests/tenant-cancellation-refund-tiers.test.js
@@ -1,0 +1,78 @@
+const assert = require("assert");
+const sinon = require("sinon");
+const {
+  TenantController,
+} = require("../src/platform/api/controllers/tenant-controller");
+const TenantManager = require("../src/commons/data-managers/tenant-manager");
+const PermissionService = require("../src/commons/services/permission-service");
+
+function response(sandbox) {
+  return {
+    status: sandbox.stub().returnsThis(),
+    send: sandbox.stub().returnsThis(),
+    sendStatus: sandbox.stub().returnsThis(),
+  };
+}
+
+describe("TenantController cancellation refund tiers", function () {
+  let sandbox;
+
+  beforeEach(function () {
+    sandbox = sinon.createSandbox();
+    sandbox.stub(PermissionService, "_isTenantOwner").resolves(true);
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it("updates valid cancellation refund tiers", async function () {
+    const tenant = { id: "tenant-1", name: "Tenant" };
+    const tiers = [
+      { daysBeforeStart: 0, refundPercentage: 50 },
+      { daysBeforeStart: 20, refundPercentage: 100 },
+    ];
+    sandbox.stub(TenantManager, "getTenant").resolves(tenant);
+    const storeTenant = sandbox
+      .stub(TenantManager, "storeTenant")
+      .callsFake(async (value) => value);
+    const res = response(sandbox);
+
+    await TenantController.updateTenant(
+      {
+        user: { id: "admin-1" },
+        body: { id: "tenant-1", cancellationRefundTiers: tiers },
+      },
+      res,
+    );
+
+    assert.strictEqual(storeTenant.calledOnce, true);
+    assert.deepStrictEqual(tenant.cancellationRefundTiers, tiers);
+    assert.strictEqual(res.status.calledWith(200), true);
+  });
+
+  it("returns 400 for invalid cancellation refund tiers", async function () {
+    sandbox.stub(TenantManager, "getTenant").resolves({
+      id: "tenant-1",
+      name: "Tenant",
+    });
+    const storeTenant = sandbox.stub(TenantManager, "storeTenant");
+    const res = response(sandbox);
+
+    await TenantController.updateTenant(
+      {
+        user: { id: "admin-1" },
+        body: {
+          id: "tenant-1",
+          cancellationRefundTiers: [
+            { daysBeforeStart: 0, refundPercentage: 101 },
+          ],
+        },
+      },
+      res,
+    );
+
+    assert.strictEqual(res.status.calledWith(400), true);
+    assert.strictEqual(storeTenant.called, false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add tenant-wide cancellation refund tiers with calendar-day calculation, admin previews/overrides, and auditable partial refund documents for single and group cancellations
- Persist `cancellationRefund` audit data on rejected bookings (including when cancellation documents are skipped) and restore pricing correctly on unreject
- Fix cancellation PDF numbering (optional `cancellationNumberPrefix` only) and aggregated/single cancellation table layout

## Test plan
- [ ] Configure cancellation refund tiers on a tenant and verify user/admin cancellations apply the correct percentage by calendar days
- [ ] Preview and override refund amount as admin; confirm audit data is stored on the booking
- [ ] Cancel a paid booking and verify partial cancellation PDF/receipt content and numbering
- [ ] Cancel a group booking and verify aggregated cancellation document layout
- [ ] Reject with documents skipped → confirm `cancellationRefund` still persists; unreject restores pricing
- [ ] Run `npm test` and `npm run lint:check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tenant-wide cancellation refund tiers (calendar-day based) and validation.
  * Added cancellation refund preview endpoints (public, hook-scoped, and admin) for individual and group bookings, plus reject/cancel flows with optional refund percentage and bank details for group aggregated PDFs.
  * Cancellation records now store detailed refund/fee data, audit details, and support partial cancellation documents and enriched cancellation PDF rendering.

* **Bug Fixes**
  * Improved cancellation PDF table alignment/totals when columns are hidden, and corrected cancellation number/PDF filename prefix behavior.
  * Unrejecting now clears persisted cancellation refund audit data.

* **Documentation**
  * Expanded API, entities, and PDF template documentation for refund previews and cancellation fields.

* **Tests**
  * Added/updated coverage for refund tiers, previews, controllers, PDFs, and email templating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->