### PR TITLE
Add optional flag to skip self-booking name sync on user rename

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 ### Added
 
+- Optional request body flag `syncSelfBookingNames` (default `true`) on user name updates (`PUT /user`, `PUT /users`, `updateUserNames`) to skip syncing assigned self-booking names when set to `false`
 - Group booking cancellations accept optional `bankDetails` for the aggregated cancellation PDF (same fields as single-booking reject)
 - Public and hook-scoped cancellation refund preview endpoints for customer self-cancellation, plus refund amounts in verify-rejection and booking-cancel mails
 - Tenant-wide cancellation refund tiers with calendar-day calculation, administrator previews and overrides, per-cancellation audit data, and partial single/group cancellation documents

--- a/src/commons/services/user-service.js
+++ b/src/commons/services/user-service.js
@@ -337,6 +337,7 @@ class UserService {
     firstName,
     lastName,
     keycloakId = null,
+    syncSelfBookingNames = true,
   }) {
     const normalizedUserId = String(userId || "")
       .trim()
@@ -367,11 +368,13 @@ class UserService {
       throw { message: "User not found", status: 404 };
     }
 
-    await UserService.syncSelfBookingNames(
-      updated.id,
-      normalizedFirstName,
-      normalizedLastName,
-    );
+    if (syncSelfBookingNames !== false) {
+      await UserService.syncSelfBookingNames(
+        updated.id,
+        normalizedFirstName,
+        normalizedLastName,
+      );
+    }
 
     return {
       id: updated.id,

--- a/src/platform/api/controllers/user-controller.js
+++ b/src/platform/api/controllers/user-controller.js
@@ -238,8 +238,9 @@ class UserController {
         await UserManager.updateUser(newInfos);
 
         if (
-          Object.prototype.hasOwnProperty.call(newInfos, "firstName") ||
-          Object.prototype.hasOwnProperty.call(newInfos, "lastName")
+          (Object.prototype.hasOwnProperty.call(newInfos, "firstName") ||
+            Object.prototype.hasOwnProperty.call(newInfos, "lastName")) &&
+          request.body.syncSelfBookingNames !== false
         ) {
           const firstName = Object.prototype.hasOwnProperty.call(
             newInfos,
@@ -403,8 +404,9 @@ class UserController {
       await UserManager.updateUser(user);
 
       if (
-        Object.prototype.hasOwnProperty.call(request.body, "firstName") ||
-        Object.prototype.hasOwnProperty.call(request.body, "lastName")
+        (Object.prototype.hasOwnProperty.call(request.body, "firstName") ||
+          Object.prototype.hasOwnProperty.call(request.body, "lastName")) &&
+        request.body.syncSelfBookingNames !== false
       ) {
         await UserService.syncSelfBookingNames(
           user.id,

--- a/tests/sync-self-booking-names-flag.test.js
+++ b/tests/sync-self-booking-names-flag.test.js
@@ -1,4 +1,4 @@
-const { expect } = require("chai");
+const assert = require("assert");
 const sinon = require("sinon");
 
 const UserController = require("../src/platform/api/controllers/user-controller");
@@ -50,9 +50,8 @@ describe("syncSelfBookingNames flag", () => {
         res,
       );
 
-      expect(syncStub.calledOnceWith(user.id, "Augusta", "Lovelace")).to.be
-        .true;
-      expect(res.status.calledWith(200)).to.be.true;
+      assert.ok(syncStub.calledOnceWith(user.id, "Augusta", "Lovelace"));
+      assert.ok(res.status.calledWith(200));
     });
 
     it("skips booking name sync when syncSelfBookingNames is false", async () => {
@@ -70,9 +69,9 @@ describe("syncSelfBookingNames flag", () => {
         res,
       );
 
-      expect(updateStub.calledOnce).to.be.true;
-      expect(syncStub.called).to.be.false;
-      expect(res.status.calledWith(200)).to.be.true;
+      assert.ok(updateStub.calledOnce);
+      assert.ok(!syncStub.called);
+      assert.ok(res.status.calledWith(200));
     });
   });
 
@@ -103,9 +102,8 @@ describe("syncSelfBookingNames flag", () => {
 
       await UserController.updateUser(buildRequest({ lastName: "Byron" }), res);
 
-      expect(syncStub.calledOnceWith(existingUser.id, "Ada", "Byron")).to.be
-        .true;
-      expect(res.sendStatus.calledWith(200)).to.be.true;
+      assert.ok(syncStub.calledOnceWith(existingUser.id, "Ada", "Byron"));
+      assert.ok(res.sendStatus.calledWith(200));
     });
 
     it("skips booking name sync when syncSelfBookingNames is false", async () => {
@@ -122,8 +120,8 @@ describe("syncSelfBookingNames flag", () => {
         res,
       );
 
-      expect(syncStub.called).to.be.false;
-      expect(res.sendStatus.calledWith(200)).to.be.true;
+      assert.ok(!syncStub.called);
+      assert.ok(res.sendStatus.calledWith(200));
     });
   });
 
@@ -157,8 +155,7 @@ describe("syncSelfBookingNames flag", () => {
         lastName: "Byron",
       });
 
-      expect(syncStub.calledOnceWith(currentUser.id, "Augusta Byron")).to.be
-        .true;
+      assert.ok(syncStub.calledOnceWith(currentUser.id, "Augusta Byron"));
     });
 
     it("skips booking name sync when syncSelfBookingNames is false", async () => {
@@ -173,12 +170,12 @@ describe("syncSelfBookingNames flag", () => {
         syncSelfBookingNames: false,
       });
 
-      expect(result).to.deep.equal({
+      assert.deepStrictEqual(result, {
         id: currentUser.id,
         firstName: "Augusta",
         lastName: "Byron",
       });
-      expect(syncStub.called).to.be.false;
+      assert.ok(!syncStub.called);
     });
   });
 });

--- a/tests/sync-self-booking-names-flag.test.js
+++ b/tests/sync-self-booking-names-flag.test.js
@@ -1,0 +1,184 @@
+const { expect } = require("chai");
+const sinon = require("sinon");
+
+const UserController = require("../src/platform/api/controllers/user-controller");
+const UserService = require("../src/commons/services/user-service");
+const UserManager = require("../src/commons/data-managers/user-manager");
+const PermissionService = require("../src/commons/services/permission-service");
+const BookingManager = require("../src/commons/data-managers/booking-manager");
+
+describe("syncSelfBookingNames flag", () => {
+  let sandbox;
+  let res;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    res = {
+      status: sandbox.stub().returnsThis(),
+      send: sandbox.stub(),
+      sendStatus: sandbox.stub(),
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("UserController.updateMe", () => {
+    const user = {
+      id: "user@example.com",
+      firstName: "Ada",
+      lastName: "Lovelace",
+    };
+
+    function buildRequest(body) {
+      return {
+        user: { id: user.id },
+        body,
+      };
+    }
+
+    it("syncs booking names by default when firstName changes", async () => {
+      sandbox.stub(UserManager, "getUser").resolves({ ...user });
+      sandbox.stub(UserManager, "updateUser").resolves();
+      const syncStub = sandbox
+        .stub(UserService, "syncSelfBookingNames")
+        .resolves();
+
+      await UserController.updateMe(
+        buildRequest({ firstName: "Augusta" }),
+        res,
+      );
+
+      expect(syncStub.calledOnceWith(user.id, "Augusta", "Lovelace")).to.be
+        .true;
+      expect(res.status.calledWith(200)).to.be.true;
+    });
+
+    it("skips booking name sync when syncSelfBookingNames is false", async () => {
+      const updateStub = sandbox.stub(UserManager, "updateUser").resolves();
+      sandbox.stub(UserManager, "getUser").resolves({ ...user });
+      const syncStub = sandbox
+        .stub(UserService, "syncSelfBookingNames")
+        .resolves();
+
+      await UserController.updateMe(
+        buildRequest({
+          firstName: "Augusta",
+          syncSelfBookingNames: false,
+        }),
+        res,
+      );
+
+      expect(updateStub.calledOnce).to.be.true;
+      expect(syncStub.called).to.be.false;
+      expect(res.status.calledWith(200)).to.be.true;
+    });
+  });
+
+  describe("UserController.updateUser", () => {
+    const existingUser = {
+      id: "user@example.com",
+      firstName: "Ada",
+      lastName: "Lovelace",
+    };
+
+    function buildRequest(body) {
+      return {
+        user: { id: existingUser.id },
+        body: { id: existingUser.id, ...body },
+      };
+    }
+
+    beforeEach(() => {
+      sandbox.stub(PermissionService, "_isInstanceOwner").resolves(true);
+      sandbox.stub(UserManager, "getUser").resolves({ ...existingUser });
+      sandbox.stub(UserManager, "updateUser").resolves();
+    });
+
+    it("syncs booking names by default when lastName changes", async () => {
+      const syncStub = sandbox
+        .stub(UserService, "syncSelfBookingNames")
+        .resolves();
+
+      await UserController.updateUser(buildRequest({ lastName: "Byron" }), res);
+
+      expect(syncStub.calledOnceWith(existingUser.id, "Ada", "Byron")).to.be
+        .true;
+      expect(res.sendStatus.calledWith(200)).to.be.true;
+    });
+
+    it("skips booking name sync when syncSelfBookingNames is false", async () => {
+      const syncStub = sandbox
+        .stub(UserService, "syncSelfBookingNames")
+        .resolves();
+
+      await UserController.updateUser(
+        buildRequest({
+          firstName: "Augusta",
+          lastName: "Byron",
+          syncSelfBookingNames: false,
+        }),
+        res,
+      );
+
+      expect(syncStub.called).to.be.false;
+      expect(res.sendStatus.calledWith(200)).to.be.true;
+    });
+  });
+
+  describe("UserService.updateUserNames", () => {
+    const currentUser = {
+      _id: "mongo-id-1",
+      id: "user@example.com",
+      firstName: "Ada",
+      lastName: "Lovelace",
+    };
+
+    beforeEach(() => {
+      sandbox
+        .stub(UserManager, "findRawUserByIdOrKeycloak")
+        .resolves(currentUser);
+      sandbox.stub(UserManager, "updateUserNamesByMongoId").resolves({
+        id: currentUser.id,
+        firstName: "Augusta",
+        lastName: "Byron",
+      });
+    });
+
+    it("syncs booking names by default", async () => {
+      const syncStub = sandbox
+        .stub(BookingManager, "updateAssignedSelfBookingNames")
+        .resolves();
+
+      await UserService.updateUserNames({
+        userId: currentUser.id,
+        firstName: "Augusta",
+        lastName: "Byron",
+      });
+
+      expect(syncStub.calledOnceWith(currentUser.id, "Augusta Byron")).to.be
+        .true;
+    });
+
+    it("skips booking name sync when syncSelfBookingNames is false", async () => {
+      const syncStub = sandbox
+        .stub(BookingManager, "updateAssignedSelfBookingNames")
+        .resolves();
+
+      const result = await UserService.updateUserNames({
+        userId: currentUser.id,
+        firstName: "Augusta",
+        lastName: "Byron",
+        syncSelfBookingNames: false,
+      });
+
+      expect(result).to.deep.equal({
+        id: currentUser.id,
+        firstName: "Augusta",
+        lastName: "Byron",
+      });
+      expect(syncStub.called).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds optional request body / service flag `syncSelfBookingNames` (default `true`) on user name updates
- When set to `false`, `firstName`/`lastName` are saved without updating assigned self-booking names
- Covers `PUT /user`, `PUT /users`, and `UserService.updateUserNames`; anonymize via `changeUserId` still always syncs

## Test plan
- [ ] Run `npx mocha tests/sync-self-booking-names-flag.test.js`
- [ ] Update a user name without the flag and confirm self-booking `name` fields update
- [ ] Update a user name with `syncSelfBookingNames: false` and confirm booking names stay unchanged
- [ ] Confirm anonymize/`changeUserId` still updates booking names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional `syncSelfBookingNames` flag to user name update requests.
  * Set the flag to `false` to prevent assigned self-booking names from being synchronized; synchronization remains enabled by default.

* **Documentation**
  * Updated the changelog with details about the new request option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->