### PR TITLE
Add batch group-booking validation endpoint (DEV-817)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 ### Added
 
+- `POST /api/v2/:tenant/checkout/validate-group` — batch-validate series / group booking attempts in one request (avoids storefront 429s from parallel single validates)
 - Full-stack operator guide ([getting-started.md](getting-started.md)): wire Admin UI and Storefront to the API, local npm setup, and Docker Compose example (`docker-compose.full-stack.example.yml`)
 - Public JSON bookable responses (`/json/:tenant/bookables*`, event tickets) include the tenant `cancellationRefundTiers`
 

--- a/src/commons/services/checkout/bundle-checkout-service.js
+++ b/src/commons/services/checkout/bundle-checkout-service.js
@@ -350,19 +350,16 @@ class BundleCheckoutService {
   }
 
   /**
-   * Prepares a booking by checking all bookable items and generating a booking reference.
-   *
-   * @async
-   * @function prepareBooking
-   * @param {Object} [options={}] - The options for preparing the booking.
-   * @param {boolean} [options.keepExistingId=false] - Whether to keep the existing booking ID.
-   * @param {string|null} [options.existingId=null] - The existing booking ID to keep, if any.
-   * @returns {Promise<Booking>} - A promise that resolves to the prepared booking object.
+   * Enrich bookable items with per-item prices after a successful checkAll().
+   * Also returns free-booking / discount metadata for validate responses.
+   * @returns {Promise<{freeBookingAllowed: boolean, bookingDiscountPercent: number}>}
    */
-  async prepareBooking({ keepExistingId = false, existingId = null } = {}) {
-    await this.checkAll();
+  async _enrichBookableItemPrices() {
+    let freeBookingAllowed = true;
+    let bookingDiscountPercent = 0;
 
-    for (const bookableItem of this.bookableItems) {
+    for (let i = 0; i < this.bookableItems.length; i++) {
+      const bookableItem = this.bookableItems[i];
       let itemCheckoutService = null;
       try {
         itemCheckoutService =
@@ -377,6 +374,14 @@ class BundleCheckoutService {
         bookableItem._bookableUsed = itemCheckoutService.bookableUsed;
         bookableItem.ignoreAmount = itemCheckoutService.ignoreAmount;
         delete bookableItem._bookableUsed._id;
+
+        if (!(await itemCheckoutService.freeBookingAllowed())) {
+          freeBookingAllowed = false;
+        }
+        if (i === 0) {
+          bookingDiscountPercent =
+            await itemCheckoutService.bookingDiscountPercent();
+        }
       } finally {
         if (itemCheckoutService) {
           itemCheckoutService.cleanup();
@@ -384,6 +389,59 @@ class BundleCheckoutService {
         }
       }
     }
+
+    return { freeBookingAllowed, bookingDiscountPercent };
+  }
+
+  /**
+   * Validate all items and return aggregate prices without creating a booking.
+   * Throws the same check errors as checkAll() / prepareBooking().
+   * @returns {Promise<{
+   *   regularPriceEur: number,
+   *   userPriceEur: number,
+   *   regularGrossPriceEur: number,
+   *   userGrossPriceEur: number,
+   *   freeBookingAllowed: boolean,
+   *   bookingDiscountPercent: number
+   * }>}
+   */
+  async validateAndGetPrices() {
+    await this.checkAll();
+
+    const { freeBookingAllowed, bookingDiscountPercent } =
+      await this._enrichBookableItemPrices();
+
+    let regularPriceEur = 0;
+    let regularGrossPriceEur = 0;
+    for (const bookableItem of this.bookableItems) {
+      const multiplier = bookableItem.ignoreAmount ? 1 : bookableItem.amount;
+      regularPriceEur += bookableItem.regularPriceEur * multiplier;
+      regularGrossPriceEur += bookableItem.regularGrossPriceEur * multiplier;
+    }
+
+    return {
+      regularPriceEur: Math.round(regularPriceEur * 100) / 100,
+      userPriceEur: await this.userPriceEur(),
+      regularGrossPriceEur: Math.round(regularGrossPriceEur * 100) / 100,
+      userGrossPriceEur: await this.userGrossPriceEur(),
+      freeBookingAllowed,
+      bookingDiscountPercent,
+    };
+  }
+
+  /**
+   * Prepares a booking by checking all bookable items and generating a booking reference.
+   *
+   * @async
+   * @function prepareBooking
+   * @param {Object} [options={}] - The options for preparing the booking.
+   * @param {boolean} [options.keepExistingId=false] - Whether to keep the existing booking ID.
+   * @param {string|null} [options.existingId=null] - The existing booking ID to keep, if any.
+   * @returns {Promise<Booking>} - A promise that resolves to the prepared booking object.
+   */
+  async prepareBooking({ keepExistingId = false, existingId = null } = {}) {
+    await this.checkAll();
+    await this._enrichBookableItemPrices();
 
     const mergedAttachments = mergeAttachments(
       this.attachments,

--- a/src/commons/services/checkout/bundle-checkout-service.js
+++ b/src/commons/services/checkout/bundle-checkout-service.js
@@ -191,6 +191,52 @@ class BundleCheckoutService {
     return true;
   }
 
+  /**
+   * Run per-item checks and enrich bookable items with prices in one pass
+   * so each ItemCheckoutService is initialized only once.
+   * @returns {Promise<{freeBookingAllowed: boolean, bookingDiscountPercent: number}>}
+   */
+  async _checkAndEnrichBookableItemPrices() {
+    let freeBookingAllowed = true;
+    let bookingDiscountPercent = 0;
+
+    for (let i = 0; i < this.bookableItems.length; i++) {
+      const bookableItem = this.bookableItems[i];
+      let itemCheckoutService = null;
+      try {
+        itemCheckoutService =
+          await this.createItemCheckoutService(bookableItem);
+        await itemCheckoutService.checkAll();
+
+        bookableItem.regularPriceEur =
+          await itemCheckoutService.regularPriceEur();
+        bookableItem.regularGrossPriceEur =
+          await itemCheckoutService.regularGrossPriceEur();
+        bookableItem.userPriceEur = await itemCheckoutService.userPriceEur();
+        bookableItem.userGrossPriceEur =
+          await itemCheckoutService.userGrossPriceEur();
+        bookableItem._bookableUsed = itemCheckoutService.bookableUsed;
+        bookableItem.ignoreAmount = itemCheckoutService.ignoreAmount;
+        delete bookableItem._bookableUsed._id;
+
+        if (!(await itemCheckoutService.freeBookingAllowed())) {
+          freeBookingAllowed = false;
+        }
+        if (i === 0) {
+          bookingDiscountPercent =
+            await itemCheckoutService.bookingDiscountPercent();
+        }
+      } finally {
+        if (itemCheckoutService) {
+          itemCheckoutService.cleanup();
+          itemCheckoutService = null;
+        }
+      }
+    }
+
+    return { freeBookingAllowed, bookingDiscountPercent };
+  }
+
   async userPriceEur() {
     let total = 0;
     for (const bookableItem of this.bookableItems) {
@@ -350,50 +396,6 @@ class BundleCheckoutService {
   }
 
   /**
-   * Enrich bookable items with per-item prices after a successful checkAll().
-   * Also returns free-booking / discount metadata for validate responses.
-   * @returns {Promise<{freeBookingAllowed: boolean, bookingDiscountPercent: number}>}
-   */
-  async _enrichBookableItemPrices() {
-    let freeBookingAllowed = true;
-    let bookingDiscountPercent = 0;
-
-    for (let i = 0; i < this.bookableItems.length; i++) {
-      const bookableItem = this.bookableItems[i];
-      let itemCheckoutService = null;
-      try {
-        itemCheckoutService =
-          await this.createItemCheckoutService(bookableItem);
-        bookableItem.regularPriceEur =
-          await itemCheckoutService.regularPriceEur();
-        bookableItem.regularGrossPriceEur =
-          await itemCheckoutService.regularGrossPriceEur();
-        bookableItem.userPriceEur = await itemCheckoutService.userPriceEur();
-        bookableItem.userGrossPriceEur =
-          await itemCheckoutService.userGrossPriceEur();
-        bookableItem._bookableUsed = itemCheckoutService.bookableUsed;
-        bookableItem.ignoreAmount = itemCheckoutService.ignoreAmount;
-        delete bookableItem._bookableUsed._id;
-
-        if (!(await itemCheckoutService.freeBookingAllowed())) {
-          freeBookingAllowed = false;
-        }
-        if (i === 0) {
-          bookingDiscountPercent =
-            await itemCheckoutService.bookingDiscountPercent();
-        }
-      } finally {
-        if (itemCheckoutService) {
-          itemCheckoutService.cleanup();
-          itemCheckoutService = null;
-        }
-      }
-    }
-
-    return { freeBookingAllowed, bookingDiscountPercent };
-  }
-
-  /**
    * Validate all items and return aggregate prices without creating a booking.
    * Throws the same check errors as checkAll() / prepareBooking().
    * @returns {Promise<{
@@ -406,10 +408,8 @@ class BundleCheckoutService {
    * }>}
    */
   async validateAndGetPrices() {
-    await this.checkAll();
-
     const { freeBookingAllowed, bookingDiscountPercent } =
-      await this._enrichBookableItemPrices();
+      await this._checkAndEnrichBookableItemPrices();
 
     let regularPriceEur = 0;
     let regularGrossPriceEur = 0;
@@ -440,8 +440,7 @@ class BundleCheckoutService {
    * @returns {Promise<Booking>} - A promise that resolves to the prepared booking object.
    */
   async prepareBooking({ keepExistingId = false, existingId = null } = {}) {
-    await this.checkAll();
-    await this._enrichBookableItemPrices();
+    await this._checkAndEnrichBookableItemPrices();
 
     const mergedAttachments = mergeAttachments(
       this.attachments,

--- a/src/commons/utilities/checkout-utils.js
+++ b/src/commons/utilities/checkout-utils.js
@@ -1,5 +1,6 @@
 const { v4: uuidv4 } = require("uuid");
 const UserManager = require("../data-managers/user-manager");
+const { BookableManager } = require("../data-managers/bookable-manager");
 
 function primaryEmailFromMail(mail) {
   if (!mail) {
@@ -31,4 +32,62 @@ async function resolveCheckoutId(checkoutId, userID, tenantId) {
   return { checkoutId: "01" + uuidv4(), generated: true };
 }
 
-module.exports = { resolveCheckoutId, primaryEmailFromMail };
+/**
+ * Append mandatory checkout addons that are missing from the given items.
+ * Matches the behaviour of BookingService.createBooking.
+ * @param {Array<{bookableId: string, amount: number}>} bookableItems
+ * @param {string} tenantId
+ * @returns {Promise<Array<{bookableId: string, amount: number}>>}
+ */
+async function withMandatoryAddons(bookableItems, tenantId) {
+  const bookableIds = bookableItems.map((item) => item.bookableId);
+  const bookables = await Promise.all(
+    bookableIds.map((id) => BookableManager.getBookable(id, tenantId)),
+  );
+
+  const bookableMap = new Map();
+  for (let i = 0; i < bookableIds.length; i++) {
+    bookableMap.set(bookableIds[i], bookables[i]);
+  }
+
+  const mandatoryAddons = [];
+  for (const item of bookableItems) {
+    const bookable = bookableMap.get(item.bookableId);
+    if (bookable && Array.isArray(bookable.checkoutBookableIds)) {
+      for (const addon of bookable.checkoutBookableIds) {
+        if (addon.mandatory) {
+          mandatoryAddons.push({
+            bookableId: addon.bookableId,
+            amount: item.amount,
+          });
+        }
+      }
+    }
+  }
+
+  const items = bookableItems.map((item) => ({ ...item }));
+  for (const mandatoryAddon of mandatoryAddons) {
+    const existingAddon = items.find(
+      (item) => item.bookableId === mandatoryAddon.bookableId,
+    );
+
+    if (existingAddon) {
+      if (existingAddon.amount !== mandatoryAddon.amount) {
+        existingAddon.amount = mandatoryAddon.amount;
+      }
+    } else {
+      items.push({
+        bookableId: mandatoryAddon.bookableId,
+        amount: mandatoryAddon.amount,
+      });
+    }
+  }
+
+  return items;
+}
+
+module.exports = {
+  resolveCheckoutId,
+  primaryEmailFromMail,
+  withMandatoryAddons,
+};

--- a/src/platform/api/v2/controllers/checkout.controller.js
+++ b/src/platform/api/v2/controllers/checkout.controller.js
@@ -12,6 +12,7 @@ const {
 } = require("../../../../commons/utilities/group-booking-permissions");
 const {
   resolveCheckoutId,
+  withMandatoryAddons,
 } = require("../../../../commons/utilities/checkout-utils");
 const {
   normalizeCheckError,
@@ -19,6 +20,9 @@ const {
 const {
   CHECKOUT_REASONS,
 } = require("../../../../commons/services/checkout/checkout-reasons");
+const {
+  BundleCheckoutService,
+} = require("../../../../commons/services/checkout/bundle-checkout-service");
 const { CheckoutError } = require("../../../../errors/CheckoutError");
 const { BaseError } = require("../../../../errors/BaseError");
 const PaymentUtils = require("../../../../commons/utilities/payment-utils");
@@ -224,6 +228,222 @@ class CheckoutControllerV2 {
         context: {
           tenantId: req.params.tenant,
           userId: req.user?.id,
+        },
+      });
+    }
+  }
+
+  /**
+   * Batch-validate a series / group booking without creating bookings.
+   * Always responds with HTTP 200.
+   *
+   * Request-level failures (missing params, group booking disabled, …)
+   * → `{ success: false, error }`.
+   *
+   * Otherwise `{ success: true, data: { attempts, allValid, totals } }`
+   * with one result per booking attempt (Ampel / per-slot UX).
+   */
+  static async validateGroup(req, res) {
+    const tenantId = req.params.tenant;
+    const user = req.user;
+    const {
+      checkoutId: requestCheckoutId,
+      bookableItems: rawBookableItems,
+      bookingAttempts: rawBookingAttempts,
+      couponCode,
+      bookWithoutDiscount,
+    } = req.body;
+
+    const { checkoutId, generated } = await resolveCheckoutId(
+      requestCheckoutId,
+      user?.id,
+      tenantId,
+    );
+
+    const bookableItems = Array.isArray(rawBookableItems)
+      ? rawBookableItems.filter((item) => item && item.bookableId)
+      : [];
+
+    if (bookableItems.length === 0) {
+      return res.status(200).json({
+        success: false,
+        checkoutId,
+        checkoutIdGenerated: generated,
+        error: {
+          reason: CHECKOUT_REASONS.INVALID_BOOKABLE_ITEMS,
+          checkType: null,
+          params: {},
+        },
+      });
+    }
+
+    const rawAttempts = Array.isArray(rawBookingAttempts)
+      ? rawBookingAttempts
+      : [];
+
+    if (rawAttempts.length === 0) {
+      return res.status(200).json({
+        success: false,
+        checkoutId,
+        checkoutIdGenerated: generated,
+        error: {
+          reason: CHECKOUT_REASONS.BOOKING_ATTEMPTS_MISSING,
+          checkType: null,
+          params: {},
+        },
+      });
+    }
+
+    try {
+      const leadBookableId = bookableItems[0].bookableId;
+      const bookable = await BookableManager.getBookable(
+        leadBookableId,
+        tenantId,
+      );
+      const gb = bookable?.groupBooking;
+      if (!gb?.enabled) {
+        return res.status(200).json({
+          success: false,
+          checkoutId,
+          checkoutIdGenerated: generated,
+          error: {
+            reason: CHECKOUT_REASONS.GROUP_BOOKING_DISABLED,
+            checkType: null,
+            params: { bookableId: leadBookableId },
+          },
+        });
+      }
+
+      const permitted = Array.isArray(gb.permittedRoles)
+        ? gb.permittedRoles
+        : [];
+      if (permitted.length > 0 && !user) {
+        return res.status(200).json({
+          success: false,
+          checkoutId,
+          checkoutIdGenerated: generated,
+          error: {
+            reason: CHECKOUT_REASONS.UNAUTHORIZED,
+            checkType: null,
+            params: {},
+          },
+        });
+      }
+
+      let userRoles = [];
+      if (user) {
+        const membership =
+          await MembershipManager.getMembershipByTenantAndUserID(
+            tenantId,
+            user.id,
+          );
+        userRoles = membership?.roles || [];
+      }
+
+      if (!GroupBookingPermissions.isAllowed(bookable, user, userRoles)) {
+        return res.status(200).json({
+          success: false,
+          checkoutId,
+          checkoutIdGenerated: generated,
+          error: {
+            reason: CHECKOUT_REASONS.GROUP_BOOKING_ROLE_REQUIRED,
+            checkType: null,
+            params: { requiredRoles: permitted },
+          },
+        });
+      }
+
+      const resolvedItems = await withMandatoryAddons(bookableItems, tenantId);
+
+      const attempts = await Promise.all(
+        rawAttempts.map(async (attempt, index) => {
+          const timeBegin = attempt?.timeBegin;
+          const timeEnd = attempt?.timeEnd;
+          const base = { index, timeBegin, timeEnd };
+
+          const service = new BundleCheckoutService({
+            user: user?.id,
+            tenant: tenantId,
+            timeBegin,
+            timeEnd,
+            bookableItems: resolvedItems.map((item) => ({ ...item })),
+            couponCode,
+            bookWithoutDiscount,
+            checkoutId,
+          });
+
+          try {
+            const prices = await service.validateAndGetPrices();
+            return {
+              ...base,
+              success: true,
+              data: prices,
+            };
+          } catch (checkErr) {
+            const normalized = normalizeCheckError(checkErr);
+            logger.info(
+              {
+                tenantId,
+                userId: user?.id,
+                attemptIndex: index,
+                reason: normalized.reason,
+                checkType: normalized.checkType,
+                debugMessage: normalized.debugMessage,
+              },
+              "validateGroup: attempt failed",
+            );
+            return {
+              ...base,
+              success: false,
+              error: {
+                reason: normalized.reason,
+                checkType: normalized.checkType,
+                params: normalized.params,
+              },
+            };
+          }
+        }),
+      );
+
+      const allValid = attempts.every((attempt) => attempt.success);
+      const totals = allValid
+        ? CheckoutControllerV2._sumAttemptTotals(attempts)
+        : null;
+
+      logger.info(
+        {
+          tenantId,
+          userId: user?.id,
+          attemptCount: attempts.length,
+          allValid,
+        },
+        "validateGroup: done",
+      );
+
+      return res.status(200).json({
+        success: true,
+        checkoutId,
+        checkoutIdGenerated: generated,
+        data: {
+          attempts,
+          allValid,
+          totals,
+        },
+      });
+    } catch (err) {
+      logger.error(
+        { err, tenantId, userId: user?.id },
+        "validateGroup: unexpected error",
+      );
+
+      return res.status(200).json({
+        success: false,
+        checkoutId,
+        checkoutIdGenerated: generated,
+        error: {
+          reason: CHECKOUT_REASONS.UNKNOWN,
+          checkType: null,
+          params: {},
         },
       });
     }
@@ -438,6 +658,33 @@ class CheckoutControllerV2 {
   }
 
   // --- helpers ---
+
+  /**
+   * Sum price fields across successful validate-group attempts.
+   */
+  static _sumAttemptTotals(attempts) {
+    const totals = {
+      regularPriceEur: 0,
+      userPriceEur: 0,
+      regularGrossPriceEur: 0,
+      userGrossPriceEur: 0,
+    };
+
+    for (const attempt of attempts) {
+      if (!attempt.success || !attempt.data) continue;
+      totals.regularPriceEur += attempt.data.regularPriceEur || 0;
+      totals.userPriceEur += attempt.data.userPriceEur || 0;
+      totals.regularGrossPriceEur += attempt.data.regularGrossPriceEur || 0;
+      totals.userGrossPriceEur += attempt.data.userGrossPriceEur || 0;
+    }
+
+    return {
+      regularPriceEur: Math.round(totals.regularPriceEur * 100) / 100,
+      userPriceEur: Math.round(totals.userPriceEur * 100) / 100,
+      regularGrossPriceEur: Math.round(totals.regularGrossPriceEur * 100) / 100,
+      userGrossPriceEur: Math.round(totals.userGrossPriceEur * 100) / 100,
+    };
+  }
 
   /**
    * Determines whether the booking still needs to go through the payment

--- a/src/platform/api/v2/controllers/checkout.controller.js
+++ b/src/platform/api/v2/controllers/checkout.controller.js
@@ -260,99 +260,29 @@ class CheckoutControllerV2 {
       tenantId,
     );
 
-    const bookableItems = Array.isArray(rawBookableItems)
-      ? rawBookableItems.filter((item) => item && item.bookableId)
-      : [];
+    const resolved = await CheckoutControllerV2._resolveGroupCheckoutRequest({
+      tenantId,
+      user,
+      rawBookableItems,
+      rawBookingAttempts,
+    });
 
-    if (bookableItems.length === 0) {
+    if (resolved.error) {
       return res.status(200).json({
         success: false,
         checkoutId,
         checkoutIdGenerated: generated,
         error: {
-          reason: CHECKOUT_REASONS.INVALID_BOOKABLE_ITEMS,
-          checkType: null,
-          params: {},
+          reason: resolved.error.reason,
+          checkType: resolved.error.checkType,
+          params: resolved.error.params,
         },
       });
     }
 
-    const rawAttempts = Array.isArray(rawBookingAttempts)
-      ? rawBookingAttempts
-      : [];
-
-    if (rawAttempts.length === 0) {
-      return res.status(200).json({
-        success: false,
-        checkoutId,
-        checkoutIdGenerated: generated,
-        error: {
-          reason: CHECKOUT_REASONS.BOOKING_ATTEMPTS_MISSING,
-          checkType: null,
-          params: {},
-        },
-      });
-    }
+    const { bookableItems, bookingAttempts: rawAttempts } = resolved;
 
     try {
-      const leadBookableId = bookableItems[0].bookableId;
-      const bookable = await BookableManager.getBookable(
-        leadBookableId,
-        tenantId,
-      );
-      const gb = bookable?.groupBooking;
-      if (!gb?.enabled) {
-        return res.status(200).json({
-          success: false,
-          checkoutId,
-          checkoutIdGenerated: generated,
-          error: {
-            reason: CHECKOUT_REASONS.GROUP_BOOKING_DISABLED,
-            checkType: null,
-            params: { bookableId: leadBookableId },
-          },
-        });
-      }
-
-      const permitted = Array.isArray(gb.permittedRoles)
-        ? gb.permittedRoles
-        : [];
-      if (permitted.length > 0 && !user) {
-        return res.status(200).json({
-          success: false,
-          checkoutId,
-          checkoutIdGenerated: generated,
-          error: {
-            reason: CHECKOUT_REASONS.UNAUTHORIZED,
-            checkType: null,
-            params: {},
-          },
-        });
-      }
-
-      let userRoles = [];
-      if (user) {
-        const membership =
-          await MembershipManager.getMembershipByTenantAndUserID(
-            tenantId,
-            user.id,
-          );
-        userRoles = membership?.roles || [];
-      }
-
-      if (!GroupBookingPermissions.isAllowed(bookable, user, userRoles)) {
-        return res.status(200).json({
-          success: false,
-          checkoutId,
-          checkoutIdGenerated: generated,
-          error: {
-            reason: CHECKOUT_REASONS.GROUP_BOOKING_ROLE_REQUIRED,
-            checkType: null,
-            params: { requiredRoles: permitted },
-          },
-        });
-      }
-
       const resolvedItems = await withMandatoryAddons(bookableItems, tenantId);
 
       const attempts = await Promise.all(
@@ -472,69 +402,23 @@ class CheckoutControllerV2 {
         comment,
       } = req.body;
 
-      const bookableItems = Array.isArray(rawBookableItems)
-        ? rawBookableItems.filter((item) => item && item.bookableId)
-        : [];
-
-      if (bookableItems.length === 0) {
-        throw new CheckoutError({
-          reason: CHECKOUT_REASONS.INVALID_BOOKABLE_ITEMS,
-          statusCode: 400,
-        });
-      }
-
-      const rawAttempts = Array.isArray(rawBookingAttempts)
-        ? rawBookingAttempts
-        : [];
-
-      if (rawAttempts.length === 0) {
-        throw new CheckoutError({
-          reason: CHECKOUT_REASONS.BOOKING_ATTEMPTS_MISSING,
-          statusCode: 400,
-        });
-      }
-
-      const leadBookableId = bookableItems[0].bookableId;
-      const bookable = await BookableManager.getBookable(
-        leadBookableId,
+      const resolved = await CheckoutControllerV2._resolveGroupCheckoutRequest({
         tenantId,
-      );
-      const gb = bookable?.groupBooking;
-      if (!gb?.enabled) {
+        user,
+        rawBookableItems,
+        rawBookingAttempts,
+      });
+
+      if (resolved.error) {
         throw new CheckoutError({
-          reason: CHECKOUT_REASONS.GROUP_BOOKING_DISABLED,
-          statusCode: 403,
-          params: { bookableId: leadBookableId },
+          reason: resolved.error.reason,
+          statusCode: resolved.error.statusCode,
+          params: resolved.error.params,
+          checkType: resolved.error.checkType,
         });
       }
 
-      const permitted = Array.isArray(gb.permittedRoles)
-        ? gb.permittedRoles
-        : [];
-      if (permitted.length > 0 && !user) {
-        throw new CheckoutError({
-          reason: CHECKOUT_REASONS.UNAUTHORIZED,
-          statusCode: 401,
-        });
-      }
-
-      let userRoles = [];
-      if (user) {
-        const membership =
-          await MembershipManager.getMembershipByTenantAndUserID(
-            tenantId,
-            user.id,
-          );
-        userRoles = membership?.roles || [];
-      }
-
-      if (!GroupBookingPermissions.isAllowed(bookable, user, userRoles)) {
-        throw new CheckoutError({
-          reason: CHECKOUT_REASONS.GROUP_BOOKING_ROLE_REQUIRED,
-          statusCode: 403,
-          params: { requiredRoles: permitted },
-        });
-      }
+      const { bookableItems, bookingAttempts: rawAttempts } = resolved;
 
       const bookingAttempts = rawAttempts.map((attempt) => ({
         timeBegin: attempt?.timeBegin,
@@ -658,6 +542,99 @@ class CheckoutControllerV2 {
   }
 
   // --- helpers ---
+
+  /**
+   * Shared request + permission gate for group checkout / validate-group.
+   * Returns either `{ bookableItems, bookingAttempts, bookable, userRoles }`
+   * or `{ error: { reason, statusCode, checkType, params } }`.
+   */
+  static async _resolveGroupCheckoutRequest({
+    tenantId,
+    user,
+    rawBookableItems,
+    rawBookingAttempts,
+  }) {
+    const bookableItems = Array.isArray(rawBookableItems)
+      ? rawBookableItems.filter((item) => item && item.bookableId)
+      : [];
+
+    if (bookableItems.length === 0) {
+      return {
+        error: {
+          reason: CHECKOUT_REASONS.INVALID_BOOKABLE_ITEMS,
+          statusCode: 400,
+          checkType: null,
+          params: {},
+        },
+      };
+    }
+
+    const bookingAttempts = Array.isArray(rawBookingAttempts)
+      ? rawBookingAttempts
+      : [];
+
+    if (bookingAttempts.length === 0) {
+      return {
+        error: {
+          reason: CHECKOUT_REASONS.BOOKING_ATTEMPTS_MISSING,
+          statusCode: 400,
+          checkType: null,
+          params: {},
+        },
+      };
+    }
+
+    const leadBookableId = bookableItems[0].bookableId;
+    const bookable = await BookableManager.getBookable(
+      leadBookableId,
+      tenantId,
+    );
+    const gb = bookable?.groupBooking;
+    if (!gb?.enabled) {
+      return {
+        error: {
+          reason: CHECKOUT_REASONS.GROUP_BOOKING_DISABLED,
+          statusCode: 403,
+          checkType: null,
+          params: { bookableId: leadBookableId },
+        },
+      };
+    }
+
+    const permitted = Array.isArray(gb.permittedRoles) ? gb.permittedRoles : [];
+    if (permitted.length > 0 && !user) {
+      return {
+        error: {
+          reason: CHECKOUT_REASONS.UNAUTHORIZED,
+          statusCode: 401,
+          checkType: null,
+          params: {},
+        },
+      };
+    }
+
+    let userRoles = [];
+    if (user) {
+      const membership = await MembershipManager.getMembershipByTenantAndUserID(
+        tenantId,
+        user.id,
+      );
+      userRoles = membership?.roles || [];
+    }
+
+    if (!GroupBookingPermissions.isAllowed(bookable, user, userRoles)) {
+      return {
+        error: {
+          reason: CHECKOUT_REASONS.GROUP_BOOKING_ROLE_REQUIRED,
+          statusCode: 403,
+          checkType: null,
+          params: { requiredRoles: permitted },
+        },
+      };
+    }
+
+    return { bookableItems, bookingAttempts, bookable, userRoles };
+  }
 
   /**
    * Sum price fields across successful validate-group attempts.

--- a/src/platform/api/v2/routes/tenant.checkout.routes.js
+++ b/src/platform/api/v2/routes/tenant.checkout.routes.js
@@ -4,6 +4,11 @@ const { optionalAuth } = require("../../../../middleware/auth-middleware");
 
 const router = asyncRouter();
 
+router.post(
+  "/validate-group",
+  optionalAuth,
+  CheckoutControllerV2.validateGroup,
+);
 router.post("/validate/:id", optionalAuth, CheckoutControllerV2.validateItem);
 router.post("/", optionalAuth, CheckoutControllerV2.checkout);
 router.post("/group", optionalAuth, CheckoutControllerV2.groupCheckout);

--- a/tests/checkout-validate-group.test.js
+++ b/tests/checkout-validate-group.test.js
@@ -1,0 +1,258 @@
+const assert = require("assert");
+const sinon = require("sinon");
+
+const CheckoutControllerV2 = require("../src/platform/api/v2/controllers/checkout.controller");
+const {
+  BookableManager,
+} = require("../src/commons/data-managers/bookable-manager");
+const MembershipManager = require("../src/commons/data-managers/membership-manager");
+const {
+  BundleCheckoutService,
+} = require("../src/commons/services/checkout/bundle-checkout-service");
+const {
+  withMandatoryAddons,
+} = require("../src/commons/utilities/checkout-utils");
+const {
+  CHECKOUT_REASONS,
+} = require("../src/commons/services/checkout/checkout-reasons");
+
+const TENANT_ID = "tenant-1";
+
+function response(sandbox) {
+  return {
+    status: sandbox.stub().returnsThis(),
+    json: sandbox.stub().returnsThis(),
+  };
+}
+
+function groupBookable(overrides = {}) {
+  return {
+    id: "room-a",
+    tenantId: TENANT_ID,
+    groupBooking: { enabled: true, permittedRoles: [] },
+    checkoutBookableIds: [],
+    ...overrides,
+  };
+}
+
+describe("CheckoutControllerV2.validateGroup", function () {
+  let sandbox;
+
+  beforeEach(function () {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it("rejects missing bookableItems", async function () {
+    const res = response(sandbox);
+
+    await CheckoutControllerV2.validateGroup(
+      {
+        params: { tenant: TENANT_ID },
+        user: null,
+        body: { bookingAttempts: [{ timeBegin: 1, timeEnd: 2 }] },
+      },
+      res,
+    );
+
+    assert.strictEqual(res.status.calledWith(200), true);
+    const body = res.json.firstCall.args[0];
+    assert.strictEqual(body.success, false);
+    assert.strictEqual(
+      body.error.reason,
+      CHECKOUT_REASONS.INVALID_BOOKABLE_ITEMS,
+    );
+  });
+
+  it("rejects when group booking is disabled", async function () {
+    sandbox.stub(BookableManager, "getBookable").resolves(
+      groupBookable({
+        groupBooking: { enabled: false, permittedRoles: [] },
+      }),
+    );
+    const res = response(sandbox);
+
+    await CheckoutControllerV2.validateGroup(
+      {
+        params: { tenant: TENANT_ID },
+        user: null,
+        body: {
+          bookableItems: [{ bookableId: "room-a", amount: 1 }],
+          bookingAttempts: [{ timeBegin: 1, timeEnd: 2 }],
+        },
+      },
+      res,
+    );
+
+    const body = res.json.firstCall.args[0];
+    assert.strictEqual(body.success, false);
+    assert.strictEqual(
+      body.error.reason,
+      CHECKOUT_REASONS.GROUP_BOOKING_DISABLED,
+    );
+  });
+
+  it("returns per-attempt success and failure without failing the request", async function () {
+    sandbox.stub(BookableManager, "getBookable").resolves(groupBookable());
+    sandbox
+      .stub(BundleCheckoutService.prototype, "validateAndGetPrices")
+      .onFirstCall()
+      .resolves({
+        regularPriceEur: 100,
+        userPriceEur: 100,
+        regularGrossPriceEur: 119,
+        userGrossPriceEur: 119,
+        freeBookingAllowed: false,
+        bookingDiscountPercent: 0,
+      })
+      .onSecondCall()
+      .rejects({
+        checkType: "availability",
+        message: "nicht verfügbar",
+      });
+
+    const res = response(sandbox);
+
+    await CheckoutControllerV2.validateGroup(
+      {
+        params: { tenant: TENANT_ID },
+        user: null,
+        body: {
+          checkoutId: "01fixed",
+          bookableItems: [{ bookableId: "room-a", amount: 1 }],
+          bookingAttempts: [
+            { timeBegin: 1000, timeEnd: 2000 },
+            { timeBegin: 3000, timeEnd: 4000 },
+          ],
+        },
+      },
+      res,
+    );
+
+    const body = res.json.firstCall.args[0];
+    assert.strictEqual(body.success, true);
+    assert.strictEqual(body.checkoutId, "01fixed");
+    assert.strictEqual(body.data.allValid, false);
+    assert.strictEqual(body.data.totals, null);
+    assert.strictEqual(body.data.attempts.length, 2);
+    assert.strictEqual(body.data.attempts[0].success, true);
+    assert.strictEqual(body.data.attempts[0].data.userGrossPriceEur, 119);
+    assert.strictEqual(body.data.attempts[1].success, false);
+    assert.strictEqual(
+      body.data.attempts[1].error.reason,
+      CHECKOUT_REASONS.BOOKABLE_UNAVAILABLE,
+    );
+  });
+
+  it("sums totals when all attempts are valid", async function () {
+    sandbox
+      .stub(MembershipManager, "getMembershipByTenantAndUserID")
+      .resolves({ roles: [] });
+    sandbox.stub(BookableManager, "getBookable").resolves(groupBookable());
+    sandbox
+      .stub(BundleCheckoutService.prototype, "validateAndGetPrices")
+      .resolves({
+        regularPriceEur: 50,
+        userPriceEur: 50,
+        regularGrossPriceEur: 59.5,
+        userGrossPriceEur: 59.5,
+        freeBookingAllowed: false,
+        bookingDiscountPercent: 0,
+      });
+
+    const res = response(sandbox);
+
+    await CheckoutControllerV2.validateGroup(
+      {
+        params: { tenant: TENANT_ID },
+        user: { id: "user-1" },
+        body: {
+          checkoutId: "01fixed",
+          bookableItems: [{ bookableId: "room-a", amount: 1 }],
+          bookingAttempts: [
+            { timeBegin: 1000, timeEnd: 2000 },
+            { timeBegin: 3000, timeEnd: 4000 },
+          ],
+        },
+      },
+      res,
+    );
+
+    const body = res.json.firstCall.args[0];
+    assert.strictEqual(body.success, true);
+    assert.strictEqual(body.data.allValid, true);
+    assert.deepStrictEqual(body.data.totals, {
+      regularPriceEur: 100,
+      userPriceEur: 100,
+      regularGrossPriceEur: 119,
+      userGrossPriceEur: 119,
+    });
+  });
+});
+
+describe("withMandatoryAddons", function () {
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it("appends missing mandatory addons", async function () {
+    sinon.stub(BookableManager, "getBookable").callsFake(async (id) => {
+      if (id === "room-a") {
+        return {
+          id: "room-a",
+          checkoutBookableIds: [
+            { bookableId: "addon-1", mandatory: true },
+            { bookableId: "addon-2", mandatory: false },
+          ],
+        };
+      }
+      return { id, checkoutBookableIds: [] };
+    });
+
+    const items = await withMandatoryAddons(
+      [{ bookableId: "room-a", amount: 2 }],
+      TENANT_ID,
+    );
+
+    assert.deepStrictEqual(items, [
+      { bookableId: "room-a", amount: 2 },
+      { bookableId: "addon-1", amount: 2 },
+    ]);
+  });
+});
+
+describe("CheckoutControllerV2._sumAttemptTotals", function () {
+  it("sums only successful attempts", function () {
+    const totals = CheckoutControllerV2._sumAttemptTotals([
+      {
+        success: true,
+        data: {
+          regularPriceEur: 10,
+          userPriceEur: 8,
+          regularGrossPriceEur: 11.9,
+          userGrossPriceEur: 9.52,
+        },
+      },
+      { success: false },
+      {
+        success: true,
+        data: {
+          regularPriceEur: 5,
+          userPriceEur: 5,
+          regularGrossPriceEur: 5.95,
+          userGrossPriceEur: 5.95,
+        },
+      },
+    ]);
+
+    assert.deepStrictEqual(totals, {
+      regularPriceEur: 15,
+      userPriceEur: 13,
+      regularGrossPriceEur: 17.85,
+      userGrossPriceEur: 15.47,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `POST /api/v2/:tenant/checkout/validate-group` to validate all series booking attempts in one request (no persistence), so the storefront no longer fans out hundreds of parallel single validates and hits BFF 429s.
- Returns per-attempt validity, prices, and `CHECKOUT_REASONS` errors for Ampel UI, plus `allValid` / `totals` when the whole series is OK.
- Storefront contract lives on the Notion ticket (DEV-817); submit remains on existing `POST /checkout/group`.

## Test plan
- [ ] `npm test` / `tests/checkout-validate-group.test.js` green
- [ ] Validate a series (≥100 occurrences) via the new endpoint without 429
- [ ] Mixed valid/invalid slots: per-attempt `success` / `error.reason` correct in UI
- [ ] Coupon + addons: prices match previous single-validate behaviour; create still via `/checkout/group`
- [ ] Re-validate after series / amount / coupon changes uses the batch endpoint only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch validation for group checkout attempts without creating bookings.
  * Validation now reports individual attempt results and combined pricing totals when all attempts are valid.
  * Mandatory add-ons are automatically included in checkout validation.
* **Bug Fixes**
  * Improved bundle pricing consistency across checkout items and booking preparation.
* **Documentation**
  * Added release notes for the new group checkout validation capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->