### PR TITLE
Add tenant presets for booking period formatting in emails.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 ## [Unreleased]
 
+### Added
+
+- Tenant setting `mailBookingPeriodFormat` (`default`, `fromTo`, `timeFirst`, `long`, `compact`) to control how booking periods are rendered in email booking details
+
 ## [4.2.2] — 2026-07-29
 
 ### Added

--- a/src/commons/mail-service/mail-data.service.js
+++ b/src/commons/mail-service/mail-data.service.js
@@ -1,8 +1,10 @@
 const BookingManager = require("../data-managers/booking-manager");
 const { BookableManager } = require("../data-managers/bookable-manager");
 const EventManager = require("../data-managers/event-manager");
+const TenantManager = require("../data-managers/tenant-manager");
 const QRCode = require("qrcode");
 const { renderSnippet } = require("./templates/template-loader");
+const Formatters = require("../utilities/formatters");
 
 class MailDataService {
   static buildCancellationMailContext(
@@ -92,14 +94,21 @@ class MailDataService {
 
   static async generateBookingDetails(bookingId, tenantId) {
     const booking = await BookingManager.getBooking(bookingId, tenantId);
+    const tenant = await TenantManager.getTenant(tenantId);
     const bookables = await this.getPopulatedBookables(bookingId, tenantId);
     const bookingItems = this.buildBookingItems(booking, bookables);
     const coupon = this.buildCouponInfo(booking);
+    const bookingPeriod = Formatters.formatBookingPeriod(
+      booking.timeBegin,
+      booking.timeEnd,
+      tenant.mailBookingPeriodFormat,
+    );
 
     return renderSnippet("booking-details", {
       booking,
       bookingItems,
       coupon,
+      bookingPeriod,
     });
   }
 
@@ -109,6 +118,7 @@ class MailDataService {
     addRejectionLink = false,
   ) {
     const booking = await BookingManager.getBooking(bookingId, tenantId);
+    const tenant = await TenantManager.getTenant(tenantId);
     const bookables = await this.getPopulatedBookables(bookingId, tenantId);
 
     const bookingItems = booking.bookableItems.map((item) => {
@@ -118,12 +128,18 @@ class MailDataService {
 
     const { rejectionUrl, cancellationContactHint } =
       this.buildCancellationMailContext(booking, tenantId, addRejectionLink);
+    const bookingPeriod = Formatters.formatBookingPeriod(
+      booking.timeBegin,
+      booking.timeEnd,
+      tenant.mailBookingPeriodFormat,
+    );
 
     return renderSnippet("short-booking-details", {
       booking,
       bookingItems,
       rejectionUrl,
       cancellationContactHint,
+      bookingPeriod,
     });
   }
 

--- a/src/commons/mail-service/templates/snippets/booking-details.hbs
+++ b/src/commons/mail-service/templates/snippets/booking-details.hbs
@@ -8,7 +8,7 @@
   <br> {{booking.comment}}
 {{else}} {{/gt}}
 
-{{#if booking.timeBegin}}
+{{#if bookingPeriod}}
   <br><strong>Buchungszeitraum:</strong> {{bookingPeriod}}
 {{/if}}
 <br>

--- a/src/commons/mail-service/templates/snippets/booking-details.hbs
+++ b/src/commons/mail-service/templates/snippets/booking-details.hbs
@@ -9,7 +9,7 @@
 {{else}} {{/gt}}
 
 {{#if booking.timeBegin}}
-  <br><strong>Buchungszeitraum:</strong> {{formatDateTime booking.timeBegin}} - {{formatDateTime booking.timeEnd}}
+  <br><strong>Buchungszeitraum:</strong> {{bookingPeriod}}
 {{/if}}
 <br>
 <h2>Bestellübersicht</h2>

--- a/src/commons/mail-service/templates/snippets/short-booking-details.hbs
+++ b/src/commons/mail-service/templates/snippets/short-booking-details.hbs
@@ -1,7 +1,7 @@
 <p>
   <strong>Buchungsnummer:</strong>
   {{booking.id}}
-  {{#if booking.timeBegin}}
+  {{#if bookingPeriod}}
     <br /><strong>Buchungszeitraum:</strong>
     {{bookingPeriod}}
   {{/if}}

--- a/src/commons/mail-service/templates/snippets/short-booking-details.hbs
+++ b/src/commons/mail-service/templates/snippets/short-booking-details.hbs
@@ -3,9 +3,7 @@
   {{booking.id}}
   {{#if booking.timeBegin}}
     <br /><strong>Buchungszeitraum:</strong>
-    {{formatDateTime booking.timeBegin}}
-    -
-    {{formatDateTime booking.timeEnd}}
+    {{bookingPeriod}}
   {{/if}}
   <br /><strong>Gesamtbetrag:</strong>
   {{priceFormatted booking.priceEur}}

--- a/src/commons/schemas/tenantSchema.js
+++ b/src/commons/schemas/tenantSchema.js
@@ -26,6 +26,11 @@ const tenantSchemaDefinition = {
   mailSnippets: { type: Object, default: {} },
   mailSubjects: { type: Object, default: {} },
   mailShowSupportFooter: { type: Boolean, default: true },
+  mailBookingPeriodFormat: {
+    type: String,
+    enum: ["default", "fromTo", "timeFirst", "long", "compact"],
+    default: "default",
+  },
   useInstanceMail: { type: Boolean, default: true },
   noreplyMail: { type: String, default: "" },
   noreplyDisplayName: { type: String, default: "" },

--- a/src/commons/utilities/formatters.js
+++ b/src/commons/utilities/formatters.js
@@ -1,15 +1,56 @@
+const MAIL_BOOKING_PERIOD_FORMATS = [
+  "default",
+  "fromTo",
+  "timeFirst",
+  "long",
+  "compact",
+];
+
+const TIME_ZONE = "Europe/Berlin";
+
+const dateTimeFormatter = new Intl.DateTimeFormat("de-DE", {
+  day: "2-digit",
+  month: "2-digit",
+  year: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  timeZone: TIME_ZONE,
+});
+
+const compactDateTimeFormatter = new Intl.DateTimeFormat("de-DE", {
+  day: "2-digit",
+  month: "2-digit",
+  year: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+  timeZone: TIME_ZONE,
+});
+
+const dateFormatter = new Intl.DateTimeFormat("de-DE", {
+  day: "2-digit",
+  month: "2-digit",
+  year: "numeric",
+  timeZone: TIME_ZONE,
+});
+
+const timeFormatter = new Intl.DateTimeFormat("de-DE", {
+  hour: "2-digit",
+  minute: "2-digit",
+  timeZone: TIME_ZONE,
+});
+
+const longDateFormatter = new Intl.DateTimeFormat("de-DE", {
+  weekday: "long",
+  day: "numeric",
+  month: "long",
+  year: "numeric",
+  timeZone: TIME_ZONE,
+});
+
 class Formatters {
   static formatDateTime(value) {
     if (!value) return "-";
-    const formatter = new Intl.DateTimeFormat("de-DE", {
-      day: "2-digit",
-      month: "2-digit",
-      year: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-      timeZone: "Europe/Berlin",
-    });
-    return formatter.format(new Date(value));
+    return dateTimeFormatter.format(new Date(value));
   }
 
   static formatDate(value) {
@@ -30,6 +71,39 @@ class Formatters {
       currency: "EUR",
     });
     return formatter.format(value);
+  }
+
+  /**
+   * Format a booking period for email templates using a tenant preset.
+   * @param {number|string|Date} timeBegin
+   * @param {number|string|Date} timeEnd
+   * @param {string} [format="default"]
+   * @returns {string}
+   */
+  static formatBookingPeriod(timeBegin, timeEnd, format = "default") {
+    if (!timeBegin || !timeEnd) {
+      return "";
+    }
+
+    const begin = new Date(timeBegin);
+    const end = new Date(timeEnd);
+    const preset = MAIL_BOOKING_PERIOD_FORMATS.includes(format)
+      ? format
+      : "default";
+
+    switch (preset) {
+      case "fromTo":
+        return `von ${timeFormatter.format(begin)} Uhr am ${dateFormatter.format(begin)} bis ${timeFormatter.format(end)} Uhr am ${dateFormatter.format(end)}`;
+      case "timeFirst":
+        return `${timeFormatter.format(begin)} Uhr, ${dateFormatter.format(begin)} - ${timeFormatter.format(end)} Uhr, ${dateFormatter.format(end)}`;
+      case "long":
+        return `${longDateFormatter.format(begin)}, ${timeFormatter.format(begin)} Uhr - ${longDateFormatter.format(end)}, ${timeFormatter.format(end)} Uhr`;
+      case "compact":
+        return `${compactDateTimeFormatter.format(begin)} - ${compactDateTimeFormatter.format(end)}`;
+      case "default":
+      default:
+        return `${dateTimeFormatter.format(begin)} - ${dateTimeFormatter.format(end)}`;
+    }
   }
 
   static translatePayMethod(value) {
@@ -69,5 +143,7 @@ class Formatters {
     }
   }
 }
+
+Formatters.MAIL_BOOKING_PERIOD_FORMATS = MAIL_BOOKING_PERIOD_FORMATS;
 
 module.exports = Formatters;

--- a/src/platform/api/controllers/tenant-controller.js
+++ b/src/platform/api/controllers/tenant-controller.js
@@ -36,6 +36,7 @@ const {
 const {
   getCancellationRefundTiersError,
 } = require("../../../commons/utilities/cancellation-refund-tiers");
+const Formatters = require("../../../commons/utilities/formatters");
 
 const PDF_TEMPLATE_FIELDS = {
   receiptTemplate: "receipt",
@@ -70,6 +71,21 @@ function validatePdfBookingLayout(body) {
     return null;
   }
   return `Invalid pdfBookingLayout "${body.pdfBookingLayout}". Allowed values: summary, compact, detailed`;
+}
+
+function validateMailBookingPeriodFormat(body) {
+  if (!Object.prototype.hasOwnProperty.call(body, "mailBookingPeriodFormat")) {
+    return null;
+  }
+  if (
+    !body.mailBookingPeriodFormat ||
+    Formatters.MAIL_BOOKING_PERIOD_FORMATS.includes(
+      body.mailBookingPeriodFormat,
+    )
+  ) {
+    return null;
+  }
+  return `Invalid mailBookingPeriodFormat "${body.mailBookingPeriodFormat}". Allowed values: ${Formatters.MAIL_BOOKING_PERIOD_FORMATS.join(", ")}`;
 }
 
 function validatePdfBookingTableMetaField(body) {
@@ -224,6 +240,13 @@ class TenantController {
         return response.status(400).send(tableMetaError);
       }
 
+      const mailBookingPeriodFormatError = validateMailBookingPeriodFormat(
+        request.body,
+      );
+      if (mailBookingPeriodFormatError) {
+        return response.status(400).send(mailBookingPeriodFormatError);
+      }
+
       const cancellationRefundTiersError = validateCancellationRefundTiersField(
         request.body,
       );
@@ -318,6 +341,7 @@ class TenantController {
           "mailSnippets",
           "mailSubjects",
           "mailShowSupportFooter",
+          "mailBookingPeriodFormat",
           "useInstanceMail",
           "noreplyMail",
           "noreplyDisplayName",
@@ -384,6 +408,13 @@ class TenantController {
         const tableMetaError = validatePdfBookingTableMetaField(request.body);
         if (tableMetaError) {
           return response.status(400).send(tableMetaError);
+        }
+
+        const mailBookingPeriodFormatError = validateMailBookingPeriodFormat(
+          request.body,
+        );
+        if (mailBookingPeriodFormatError) {
+          return response.status(400).send(mailBookingPeriodFormatError);
         }
 
         const cancellationRefundTiersError =

--- a/src/platform/api/controllers/tenant-controller.js
+++ b/src/platform/api/controllers/tenant-controller.js
@@ -78,7 +78,6 @@ function validateMailBookingPeriodFormat(body) {
     return null;
   }
   if (
-    !body.mailBookingPeriodFormat ||
     Formatters.MAIL_BOOKING_PERIOD_FORMATS.includes(
       body.mailBookingPeriodFormat,
     )

--- a/tests/formatters-booking-period.test.js
+++ b/tests/formatters-booking-period.test.js
@@ -1,0 +1,96 @@
+const { expect } = require("chai");
+const Formatters = require("../src/commons/utilities/formatters");
+
+describe("Formatters.formatBookingPeriod", () => {
+  // 2026-07-09 05:15–08:00 Europe/Berlin (CEST, UTC+2)
+  const timeBegin = Date.UTC(2026, 6, 9, 3, 15, 0);
+  const timeEnd = Date.UTC(2026, 6, 9, 6, 0, 0);
+
+  function normalizeSpaces(value) {
+    return String(value).replace(/[\u00a0\u202f]/g, " ");
+  }
+
+  it("exposes the allowed mail booking period formats", () => {
+    expect(Formatters.MAIL_BOOKING_PERIOD_FORMATS).to.deep.equal([
+      "default",
+      "fromTo",
+      "timeFirst",
+      "long",
+      "compact",
+    ]);
+  });
+
+  it("returns an empty string when begin or end is missing", () => {
+    expect(Formatters.formatBookingPeriod(null, timeEnd, "default")).to.equal(
+      "",
+    );
+    expect(Formatters.formatBookingPeriod(timeBegin, null, "default")).to.equal(
+      "",
+    );
+    expect(Formatters.formatBookingPeriod(undefined, undefined)).to.equal("");
+  });
+
+  it("formats default like the previous email helper output", () => {
+    expect(
+      normalizeSpaces(
+        Formatters.formatBookingPeriod(timeBegin, timeEnd, "default"),
+      ),
+    ).to.equal("09.07.2026, 05:15 - 09.07.2026, 08:00");
+  });
+
+  it("formats fromTo with von/bis wording", () => {
+    expect(
+      normalizeSpaces(
+        Formatters.formatBookingPeriod(timeBegin, timeEnd, "fromTo"),
+      ),
+    ).to.equal("von 05:15 Uhr am 09.07.2026 bis 08:00 Uhr am 09.07.2026");
+  });
+
+  it("formats timeFirst with time before date", () => {
+    expect(
+      normalizeSpaces(
+        Formatters.formatBookingPeriod(timeBegin, timeEnd, "timeFirst"),
+      ),
+    ).to.equal("05:15 Uhr, 09.07.2026 - 08:00 Uhr, 09.07.2026");
+  });
+
+  it("formats long with weekday and month name", () => {
+    expect(
+      normalizeSpaces(
+        Formatters.formatBookingPeriod(timeBegin, timeEnd, "long"),
+      ),
+    ).to.equal(
+      "Donnerstag, 9. Juli 2026, 05:15 Uhr - Donnerstag, 9. Juli 2026, 08:00 Uhr",
+    );
+  });
+
+  it("formats compact with two-digit year", () => {
+    expect(
+      normalizeSpaces(
+        Formatters.formatBookingPeriod(timeBegin, timeEnd, "compact"),
+      ),
+    ).to.equal("09.07.26, 05:15 - 09.07.26, 08:00");
+  });
+
+  it("falls back to default for unknown presets", () => {
+    expect(
+      normalizeSpaces(
+        Formatters.formatBookingPeriod(timeBegin, timeEnd, "unknown"),
+      ),
+    ).to.equal(
+      normalizeSpaces(
+        Formatters.formatBookingPeriod(timeBegin, timeEnd, "default"),
+      ),
+    );
+  });
+
+  it("defaults to the default preset when format is omitted", () => {
+    expect(
+      normalizeSpaces(Formatters.formatBookingPeriod(timeBegin, timeEnd)),
+    ).to.equal(
+      normalizeSpaces(
+        Formatters.formatBookingPeriod(timeBegin, timeEnd, "default"),
+      ),
+    );
+  });
+});


### PR DESCRIPTION
Tenants can choose how Buchungszeitraum is rendered (default, fromTo, timeFirst, long, compact) via mailBookingPeriodFormat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable booking-period formats for booking details in emails.
  - Available formats include default, date-first, time-first, long, and compact styles.
  - Tenant settings can be configured during creation or updated later.
  - Invalid format values are rejected with a clear validation error.

- **Documentation**
  - Added the new email booking-period setting to the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->