### PR TITLE
Fix/admin booking update self block

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 ### Fixed
 
+- Manual/admin booking create no longer applies the creating user's bookable booking discounts (list price is kept; Admin UI does not send `bookWithoutDiscount`)
 - Admin booking update no longer self-blocks on capacity and no longer applies non-capacity checkout rules (lead time, opening hours, …); `excludeBookingIds` and capacity-only checks run on the update path, while prices are recomputed from edited `_bookableUsed.priceCategories`
 
 ## [4.2.3] — 2026-07-31

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Admin booking update no longer self-blocks on capacity and no longer applies non-capacity checkout rules (lead time, opening hours, …); `excludeBookingIds` and capacity-only checks run on the update path, while prices are recomputed from edited `_bookableUsed.priceCategories`
+
 ## [4.2.3] — 2026-07-31
 
 ### Added

--- a/src/commons/services/checkout/booking-service.js
+++ b/src/commons/services/checkout/booking-service.js
@@ -673,6 +673,8 @@ class BookingService {
         checkoutId,
         customFieldValues: updatedBooking.customFieldValues,
         cancellationPolicy: updatedBooking.cancellationPolicy,
+        excludeBookingIds: [oldBooking.id],
+        capacityChecksOnly: true,
       });
 
       let booking = await bundleCheckoutService.prepareBooking({

--- a/src/commons/services/checkout/booking-service.js
+++ b/src/commons/services/checkout/booking-service.js
@@ -281,7 +281,9 @@ class BookingService {
         isRejected: Boolean(isRejected),
         attachmentStatus,
         paymentProvider,
-        bookWithoutDiscount,
+        // Manual/admin create must not apply the creating user's booking discounts
+        // (Admin UI shows list prices; discounts belong to self-service checkout).
+        bookWithoutDiscount: true,
         checkoutId: providedCheckoutId,
         customFieldValues,
         cancellationPolicy,

--- a/src/commons/services/checkout/bundle-checkout-service.js
+++ b/src/commons/services/checkout/bundle-checkout-service.js
@@ -537,6 +537,10 @@ class ManualBundleCheckoutService extends BundleCheckoutService {
    * @param {Object} [cancellationPolicy] - Admin override for the booking's
    *   cancellation policy. When provided, it replaces the value aggregated
    *   from the underlying bookables.
+   * @param {string|string[]|null} [excludeBookingIds] Booking IDs ignored in
+   *   capacity checks (admin update of an existing booking).
+   * @param {boolean} [capacityChecksOnly] When true, item checks are limited to
+   *   capacity/overlap (update path only — do not set on create).
    */
   constructor({
     user,
@@ -570,6 +574,8 @@ class ManualBundleCheckoutService extends BundleCheckoutService {
     lockerInfo,
     customFieldValues,
     cancellationPolicy,
+    excludeBookingIds,
+    capacityChecksOnly = false,
   }) {
     super({
       user,
@@ -604,6 +610,8 @@ class ManualBundleCheckoutService extends BundleCheckoutService {
     this.rejectionReason = rejectionReason || "";
     this.lockerInfo = lockerInfo || null;
     this.cancellationPolicyOverride = cancellationPolicy;
+    this.excludeBookingIds = excludeBookingIds;
+    this.capacityChecksOnly = Boolean(capacityChecksOnly);
   }
 
   async createItemCheckoutService(bookableItem) {
@@ -616,6 +624,8 @@ class ManualBundleCheckoutService extends BundleCheckoutService {
       amount: bookableItem.amount,
       couponCode: await this._itemCouponCode(),
       bookWithoutDiscount: this.bookWithoutDiscount,
+      excludeBookingIds: this.excludeBookingIds,
+      capacityChecksOnly: this.capacityChecksOnly,
     });
 
     await itemCheckoutService.init(bookableItem._bookableUsed);

--- a/src/commons/services/checkout/item-checkout-service.js
+++ b/src/commons/services/checkout/item-checkout-service.js
@@ -833,6 +833,8 @@ class ManualItemCheckoutService extends ItemCheckoutService {
     amount,
     couponCode,
     bookWithoutDiscount,
+    excludeBookingIds,
+    capacityChecksOnly = false,
   }) {
     super({
       user,
@@ -843,7 +845,9 @@ class ManualItemCheckoutService extends ItemCheckoutService {
       amount,
       couponCode,
       bookWithoutDiscount,
+      excludeBookingIds,
     });
+    this.capacityChecksOnly = Boolean(capacityChecksOnly);
   }
 
   async init(originBookable) {
@@ -856,6 +860,26 @@ class ManualItemCheckoutService extends ItemCheckoutService {
       this.originBookable = await super.getBookable();
     }
     this.externalProviders = await this._resolveExternalProviders();
+  }
+
+  /**
+   * On admin booking update, only capacity/overlap checks run (with excludeBookingIds).
+   * Create and other call sites omit capacityChecksOnly and keep the full check set.
+   */
+  async checkAll(stopOnFirstError = true) {
+    if (!this.capacityChecksOnly) {
+      return super.checkAll(stopOnFirstError);
+    }
+
+    const checks = [
+      this.checkMaxAmount(),
+      this.checkAvailability(),
+      this.checkEventSeats(),
+      this.checkParentAvailability(),
+      this.checkChildBookings(),
+    ];
+
+    return stopOnFirstError ? Promise.all(checks) : Promise.allSettled(checks);
   }
 }
 

--- a/tests/admin-booking-update-self-block.test.js
+++ b/tests/admin-booking-update-self-block.test.js
@@ -1,0 +1,432 @@
+const assert = require("assert");
+const sinon = require("sinon");
+const BookingManager = require("../src/commons/data-managers/booking-manager");
+const {
+  BookableManager,
+} = require("../src/commons/data-managers/bookable-manager");
+const MembershipManager = require("../src/commons/data-managers/membership-manager");
+const TenantManager = require("../src/commons/data-managers/tenant-manager");
+const EventManager = require("../src/commons/data-managers/event-manager");
+const UserManager = require("../src/commons/data-managers/user-manager");
+const OpeningHoursManager = require("../src/commons/utilities/opening-hours-manager");
+const LockerService = require("../src/commons/services/locker/locker-service");
+const BookingService = require("../src/commons/services/checkout/booking-service");
+const {
+  CHECK_TYPES,
+} = require("../src/commons/availability/checkout-check-types");
+
+const TENANT_ID = "tenant-1";
+const BOOKING_ID = "EDIT-ME";
+const OTHER_BOOKING_ID = "OTHER-1";
+const SIBLING_BOOKING_ID = "SIBLING-1";
+const TIME_BEGIN = Date.UTC(2026, 5, 15, 10, 0, 0);
+const TIME_END = Date.UTC(2026, 5, 15, 11, 0, 0);
+const NEW_TIME_BEGIN = Date.UTC(2026, 5, 15, 12, 0, 0);
+const NEW_TIME_END = Date.UTC(2026, 5, 15, 13, 0, 0);
+
+function priceCategories(priceEur = 10) {
+  return [
+    {
+      priceEur,
+      interval: { start: null, end: null },
+      fixedPrice: true,
+      holidays: [],
+      weekdays: [],
+    },
+  ];
+}
+
+function bookableSnapshot(overrides = {}) {
+  return {
+    id: "room-1",
+    tenantId: TENANT_ID,
+    title: "Room 1",
+    type: "resource",
+    isBookable: true,
+    isScheduleRelated: true,
+    amount: 1,
+    priceType: "per-item",
+    priceValueAddedTax: 19,
+    priceCategories: priceCategories(10),
+    permittedUsers: [],
+    permittedRoles: [],
+    autoCommitBooking: false,
+    preparationLeadTimeMinutes: null,
+    serviceHours: [
+      {
+        weekdays: [1, 2, 3, 4, 5],
+        startTime: "08:00",
+        endTime: "18:00",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function bookingRecord({
+  id = BOOKING_ID,
+  timeBegin = TIME_BEGIN,
+  timeEnd = TIME_END,
+  snapshot = bookableSnapshot(),
+  priceEur = 11.9,
+  vatIncludedEur = 1.9,
+  itemNet = 10,
+  itemGross = 11.9,
+} = {}) {
+  return {
+    id,
+    tenantId: TENANT_ID,
+    assignedUserId: "user@example.com",
+    timeBegin,
+    timeEnd,
+    timeCreated: TIME_BEGIN - 86_400_000,
+    name: "Admin Edit",
+    company: "",
+    street: "",
+    zipCode: "",
+    location: "",
+    mail: "user@example.com",
+    phone: "",
+    comment: "",
+    isCommitted: false,
+    isPayed: false,
+    isRejected: false,
+    paymentProvider: "invoice",
+    paymentMethod: "",
+    priceEur,
+    vatIncludedEur,
+    bookableItems: [
+      {
+        bookableId: "room-1",
+        amount: 1,
+        userPriceEur: itemNet,
+        userGrossPriceEur: itemGross,
+        regularPriceEur: itemNet,
+        regularGrossPriceEur: itemGross,
+        _bookableUsed: snapshot,
+      },
+    ],
+    attachmentStatus: [],
+    attachments: [],
+    customFieldValues: [],
+  };
+}
+
+describe("BookingService.updateBooking — admin edit self-block & prices", () => {
+  /** @type {ReturnType<typeof bookingRecord>[]} */
+  let concurrent;
+  /** @type {sinon.SinonStub} */
+  let storeBooking;
+  /** @type {ReturnType<typeof bookableSnapshot>} */
+  let catalogBookable;
+
+  beforeEach(() => {
+    concurrent = [bookingRecord()];
+    catalogBookable = bookableSnapshot();
+
+    sinon.stub(BookingManager, "getBooking").callsFake(async (id) => {
+      if (id === BOOKING_ID) {
+        return concurrent.find((b) => b.id === BOOKING_ID) || bookingRecord();
+      }
+      return { id: null };
+    });
+    storeBooking = sinon
+      .stub(BookingManager, "storeBooking")
+      .callsFake(async (value) => value);
+    sinon
+      .stub(BookingManager, "getConcurrentBookings")
+      .callsFake(async (bookableId, _tenantId, timeBegin, timeEnd) =>
+        BookingManager.filterConcurrentBookings(
+          concurrent.filter((b) =>
+            b.bookableItems.some((item) => item.bookableId === bookableId),
+          ),
+          timeBegin,
+          timeEnd,
+        ),
+      );
+    sinon
+      .stub(BookingManager, "getRelatedBookings")
+      .callsFake(async (_tenantId, bookableId) =>
+        concurrent.filter((b) =>
+          b.bookableItems.some((item) => item.bookableId === bookableId),
+        ),
+      );
+    sinon.stub(BookingManager, "getEventBookings").resolves([]);
+
+    sinon
+      .stub(BookableManager, "getBookable")
+      .callsFake(async () => catalogBookable);
+    sinon.stub(BookableManager, "getAncestorBookables").resolves([]);
+    sinon.stub(BookableManager, "getRelatedBookables").resolves([]);
+    sinon.stub(BookableManager, "getCustomFieldDefinitions").resolves({
+      instanceFields: [],
+      tenantFields: [],
+    });
+
+    sinon
+      .stub(MembershipManager, "getMembershipByTenantAndUserID")
+      .resolves(null);
+    sinon
+      .stub(MembershipManager, "getMembershipsByTenantAndRoles")
+      .resolves([]);
+    sinon.stub(TenantManager, "getTenant").resolves(null);
+    sinon.stub(EventManager, "getEvent").resolves(null);
+    sinon.stub(UserManager, "getRawUser").resolves(null);
+    sinon.stub(OpeningHoursManager, "hasOpeningHoursConflict").resolves(false);
+
+    sinon.stub(LockerService, "getInstance").returns({
+      handleUpdate: sinon.stub().resolves(),
+      handleCreate: sinon.stub().resolves(),
+      handlePreReserve: sinon.stub().resolves(),
+      getAvailableLocker: sinon.stub().resolves([]),
+    });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  function lastPreparedStore() {
+    const stored = storeBooking
+      .getCalls()
+      .map((c) => c.args[0])
+      .filter((b) => b && b.id === BOOKING_ID);
+    assert.ok(stored.length > 0, "expected prepared booking to be stored");
+    return stored[stored.length - 1];
+  }
+
+  it("allows updating an existing booking that would otherwise conflict with itself", async () => {
+    const updated = bookingRecord();
+
+    const result = await BookingService.updateBooking(TENANT_ID, updated);
+
+    assert.strictEqual(result.id, BOOKING_ID);
+    assert.strictEqual(lastPreparedStore().id, BOOKING_ID);
+  });
+
+  it("allows moving into a window that conflicts only with the booking being edited", async () => {
+    concurrent = [
+      bookingRecord({
+        timeBegin: NEW_TIME_BEGIN,
+        timeEnd: NEW_TIME_END,
+      }),
+    ];
+
+    const updated = bookingRecord({
+      timeBegin: NEW_TIME_BEGIN,
+      timeEnd: NEW_TIME_END,
+    });
+
+    const result = await BookingService.updateBooking(TENANT_ID, updated);
+
+    assert.strictEqual(result.id, BOOKING_ID);
+    assert.strictEqual(result.timeBegin, NEW_TIME_BEGIN);
+  });
+
+  it("rejects an update that overlaps a different booking", async () => {
+    concurrent = [
+      bookingRecord(),
+      bookingRecord({
+        id: OTHER_BOOKING_ID,
+        timeBegin: TIME_BEGIN,
+        timeEnd: TIME_END,
+      }),
+    ];
+
+    await assert.rejects(
+      () => BookingService.updateBooking(TENANT_ID, bookingRecord()),
+      (error) => {
+        assert.strictEqual(error.checkType, CHECK_TYPES.AVAILABILITY);
+        assert.strictEqual(error.available, false);
+        return true;
+      },
+    );
+  });
+
+  it("does not let insufficient lead time block an update", async () => {
+    const snapshot = bookableSnapshot({
+      preparationLeadTimeMinutes: 10_000,
+    });
+    concurrent = [bookingRecord({ snapshot })];
+
+    const updated = bookingRecord({ snapshot });
+    const result = await BookingService.updateBooking(TENANT_ID, updated);
+
+    assert.strictEqual(result.id, BOOKING_ID);
+  });
+
+  it("recomputes item and booking prices from edited priceCategories including zero", async () => {
+    const snapshot = bookableSnapshot({
+      priceCategories: priceCategories(0),
+    });
+    concurrent = [
+      bookingRecord({
+        snapshot,
+        priceEur: 11.9,
+        vatIncludedEur: 1.9,
+        itemNet: 10,
+        itemGross: 11.9,
+      }),
+    ];
+
+    const updated = bookingRecord({
+      snapshot,
+      // Stale top-level / item prices as the Admin UI sends today
+      priceEur: 11.9,
+      vatIncludedEur: 1.9,
+      itemNet: 10,
+      itemGross: 11.9,
+    });
+
+    await BookingService.updateBooking(TENANT_ID, updated);
+    const stored = lastPreparedStore();
+
+    assert.strictEqual(stored.bookableItems[0].userPriceEur, 0);
+    assert.strictEqual(stored.bookableItems[0].userGrossPriceEur, 0);
+    assert.strictEqual(stored.bookableItems[0].regularPriceEur, 0);
+    assert.strictEqual(stored.bookableItems[0].regularGrossPriceEur, 0);
+    assert.strictEqual(stored.priceEur, 0);
+    assert.strictEqual(stored.vatIncludedEur, 0);
+  });
+
+  it("overwrites stale booking prices when admin edits priceCategories to a new non-zero value", async () => {
+    const snapshot = bookableSnapshot({
+      priceCategories: priceCategories(20),
+    });
+    concurrent = [
+      bookingRecord({
+        snapshot,
+        priceEur: 11.9,
+        vatIncludedEur: 1.9,
+        itemNet: 10,
+        itemGross: 11.9,
+      }),
+    ];
+
+    const updated = bookingRecord({
+      snapshot,
+      priceEur: 11.9,
+      vatIncludedEur: 1.9,
+      itemNet: 10,
+      itemGross: 11.9,
+    });
+
+    await BookingService.updateBooking(TENANT_ID, updated);
+    const stored = lastPreparedStore();
+
+    assert.strictEqual(stored.bookableItems[0].userPriceEur, 20);
+    assert.strictEqual(stored.bookableItems[0].userGrossPriceEur, 23.8);
+    assert.strictEqual(stored.priceEur, 23.8);
+    assert.strictEqual(stored.vatIncludedEur, 3.8);
+  });
+
+  it("excludes only the edited booking id, not a group sibling", async () => {
+    concurrent = [
+      bookingRecord(),
+      bookingRecord({
+        id: SIBLING_BOOKING_ID,
+        timeBegin: TIME_BEGIN,
+        timeEnd: TIME_END,
+      }),
+    ];
+
+    await assert.rejects(
+      () => BookingService.updateBooking(TENANT_ID, bookingRecord()),
+      (error) => {
+        assert.strictEqual(error.checkType, CHECK_TYPES.AVAILABILITY);
+        return true;
+      },
+    );
+  });
+});
+
+describe("BookingService.createBooking — create path still runs full checks", () => {
+  let clock;
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers(new Date("2026-06-15T09:00:00Z").getTime());
+
+    const snapshot = bookableSnapshot({
+      preparationLeadTimeMinutes: 120,
+    });
+
+    sinon.stub(BookingManager, "getBooking").resolves({ id: null });
+    sinon
+      .stub(BookingManager, "storeBooking")
+      .callsFake(async (value) => value);
+    sinon.stub(BookingManager, "getConcurrentBookings").resolves([]);
+    sinon.stub(BookingManager, "getRelatedBookings").resolves([]);
+    sinon.stub(BookingManager, "getEventBookings").resolves([]);
+
+    sinon.stub(BookableManager, "getBookable").resolves(snapshot);
+    sinon.stub(BookableManager, "getAncestorBookables").resolves([]);
+    sinon.stub(BookableManager, "getRelatedBookables").resolves([]);
+    sinon.stub(BookableManager, "getCustomFieldDefinitions").resolves({
+      instanceFields: [],
+      tenantFields: [],
+    });
+
+    sinon
+      .stub(MembershipManager, "getMembershipByTenantAndUserID")
+      .resolves(null);
+    sinon
+      .stub(MembershipManager, "getMembershipsByTenantAndRoles")
+      .resolves([]);
+    sinon.stub(TenantManager, "getTenant").resolves(null);
+    sinon.stub(EventManager, "getEvent").resolves(null);
+    sinon.stub(UserManager, "getRawUser").resolves(null);
+    sinon.stub(OpeningHoursManager, "hasOpeningHoursConflict").resolves(false);
+
+    sinon.stub(LockerService, "getInstance").returns({
+      handleUpdate: sinon.stub().resolves(),
+      handleCreate: sinon.stub().resolves(),
+      handlePreReserve: sinon.stub().resolves(),
+      getAvailableLocker: sinon.stub().resolves([]),
+    });
+  });
+
+  afterEach(() => {
+    if (clock) {
+      clock.restore();
+      clock = null;
+    }
+    sinon.restore();
+  });
+
+  it("still rejects create when lead time is insufficient", async () => {
+    const snapshot = bookableSnapshot({
+      preparationLeadTimeMinutes: 120,
+    });
+
+    await assert.rejects(
+      () =>
+        BookingService.createBooking({
+          tenantId: TENANT_ID,
+          user: { id: "admin@example.com" },
+          simulate: true,
+          manualBooking: true,
+          bookingAttempt: {
+            timeBegin: Date.UTC(2026, 5, 15, 10, 0, 0),
+            timeEnd: Date.UTC(2026, 5, 15, 11, 0, 0),
+            bookableItems: [
+              {
+                bookableId: "room-1",
+                amount: 1,
+                _bookableUsed: snapshot,
+              },
+            ],
+            name: "Create Smoke",
+            mail: "user@example.com",
+            paymentProvider: "invoice",
+            isCommitted: false,
+            isPayed: false,
+            isRejected: false,
+          },
+        }),
+      (error) => {
+        assert.strictEqual(error.checkType, CHECK_TYPES.INSUFFICIENT_LEAD_TIME);
+        return true;
+      },
+    );
+  });
+});

--- a/tests/booking-discount-checkout.test.js
+++ b/tests/booking-discount-checkout.test.js
@@ -154,3 +154,110 @@ describe("ItemCheckoutService booking discount pricing", function () {
     assert.strictEqual(await service.userPriceEur(), 100);
   });
 });
+
+describe("BookingService.createBooking — manual create ignores booking discounts", function () {
+  const ADMIN_ID = "admin@stadt.de";
+  const CUSTOMER_MAIL = "kunde@example.com";
+  const LIST_PRICE = 100;
+  const TIME_BEGIN = Date.UTC(2026, 5, 20, 10, 0, 0);
+  const TIME_END = Date.UTC(2026, 5, 20, 11, 0, 0);
+
+  let BookingService;
+  let BookingManager;
+  let BookableManager;
+  let TenantManager;
+  let EventManager;
+  let OpeningHoursManager;
+  let LockerService;
+  let WorkflowService;
+
+  before(function () {
+    BookingService = require("../src/commons/services/checkout/booking-service");
+    BookingManager = require("../src/commons/data-managers/booking-manager");
+    ({
+      BookableManager,
+    } = require("../src/commons/data-managers/bookable-manager"));
+    TenantManager = require("../src/commons/data-managers/tenant-manager");
+    EventManager = require("../src/commons/data-managers/event-manager");
+    OpeningHoursManager = require("../src/commons/utilities/opening-hours-manager");
+    LockerService = require("../src/commons/services/locker/locker-service");
+    WorkflowService = require("../src/commons/services/workflow/workflow-service");
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it("does not apply the creating admin's booking discount on manual create", async function () {
+    const bookable = discountBookable({
+      isBookable: true,
+      isScheduleRelated: true,
+      amount: 5,
+      permittedUsers: [],
+      permittedRoles: [],
+      priceValueAddedTax: 0,
+      preparationLeadTimeMinutes: null,
+      serviceHours: [],
+      bookingDiscounts: {
+        users: [{ userId: ADMIN_ID, discountPercent: 100 }],
+        roles: [],
+      },
+    });
+
+    sinon.stub(BookingManager, "getBooking").resolves({ id: null });
+    const storeBooking = sinon
+      .stub(BookingManager, "storeBooking")
+      .callsFake(async (value) => value);
+    sinon.stub(BookingManager, "getConcurrentBookings").resolves([]);
+    sinon.stub(BookingManager, "getRelatedBookings").resolves([]);
+    sinon.stub(BookingManager, "getEventBookings").resolves([]);
+    sinon.stub(BookableManager, "getBookable").resolves(bookable);
+    sinon.stub(BookableManager, "getAncestorBookables").resolves([]);
+    sinon.stub(BookableManager, "getRelatedBookables").resolves([]);
+    sinon.stub(BookableManager, "getCustomFieldDefinitions").resolves({
+      instanceFields: [],
+      tenantFields: [],
+    });
+    sinon
+      .stub(MembershipManager, "getMembershipByTenantAndUserID")
+      .resolves({ userId: ADMIN_ID, roles: [] });
+    sinon
+      .stub(MembershipManager, "getMembershipsByTenantAndRoles")
+      .resolves([]);
+    sinon.stub(TenantManager, "getTenant").resolves(null);
+    sinon.stub(EventManager, "getEvent").resolves(null);
+    sinon.stub(OpeningHoursManager, "hasOpeningHoursConflict").resolves(false);
+    sinon.stub(LockerService, "getInstance").returns({
+      getAvailableLocker: sinon.stub().resolves([]),
+      handleCreate: sinon.stub().resolves(),
+      handlePreReserve: sinon.stub().resolves(),
+    });
+    sinon.stub(CouponService, "incrementCouponUsage").resolves();
+    sinon.stub(WorkflowService, "handleWorkflowEvent").resolves();
+
+    await BookingService.createBooking({
+      tenantId: TENANT_ID,
+      user: { id: ADMIN_ID },
+      simulate: false,
+      manualBooking: true,
+      bookingAttempt: {
+        timeBegin: TIME_BEGIN,
+        timeEnd: TIME_END,
+        bookableItems: [
+          { bookableId: bookable.id, amount: 1, _bookableUsed: bookable },
+        ],
+        name: "Kunde",
+        mail: CUSTOMER_MAIL,
+        paymentProvider: "invoice",
+        isCommitted: false,
+        isPayed: false,
+        isRejected: false,
+      },
+    });
+
+    const stored = storeBooking.firstCall.args[0];
+    assert.strictEqual(stored.bookableItems[0].regularPriceEur, LIST_PRICE);
+    assert.strictEqual(stored.bookableItems[0].userPriceEur, LIST_PRICE);
+    assert.strictEqual(stored.priceEur, LIST_PRICE);
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Manual and administrative bookings now preserve standard list prices without applying creator discounts.
  - Updating an existing booking no longer incorrectly conflicts with itself.
  - Booking updates continue to enforce capacity and availability checks while allowing other non-capacity validations to be bypassed.
  - Prices are recalculated correctly when booking categories are edited, including zero-price bookings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->