### PR TITLE
Allow admin booking updates despite availability conflicts.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 ### Fixed
 
 - Manual/admin booking create no longer applies the creating user's bookable booking discounts (list price is kept; Admin UI does not send `bookWithoutDiscount`)
-- Admin booking update no longer self-blocks on capacity and no longer applies non-capacity checkout rules (lead time, opening hours, …); `excludeBookingIds` and capacity-only checks run on the update path, while prices are recomputed from edited `_bookableUsed.priceCategories`
+- Admin booking update never hard-fails on checkout rules (including capacity/overlap); prices are still recomputed from edited `_bookableUsed.priceCategories`. Use validate endpoints with `excludeBookingIds` for informational availability while editing
 
 ## [4.2.3] — 2026-07-31
 

--- a/src/commons/services/checkout/bundle-checkout-service.js
+++ b/src/commons/services/checkout/bundle-checkout-service.js
@@ -538,9 +538,9 @@ class ManualBundleCheckoutService extends BundleCheckoutService {
    *   cancellation policy. When provided, it replaces the value aggregated
    *   from the underlying bookables.
    * @param {string|string[]|null} [excludeBookingIds] Booking IDs ignored in
-   *   capacity checks (admin update of an existing booking).
-   * @param {boolean} [capacityChecksOnly] When true, item checks are limited to
-   *   capacity/overlap (update path only — do not set on create).
+   *   capacity checks (e.g. validate while editing an existing booking).
+   * @param {boolean} [capacityChecksOnly] When true, item checkAll is a no-op
+   *   so admin updates never hard-fail (update path only — do not set on create).
    */
   constructor({
     user,

--- a/src/commons/services/checkout/item-checkout-service.js
+++ b/src/commons/services/checkout/item-checkout-service.js
@@ -863,23 +863,16 @@ class ManualItemCheckoutService extends ItemCheckoutService {
   }
 
   /**
-   * On admin booking update, only capacity/overlap checks run (with excludeBookingIds).
-   * Create and other call sites omit capacityChecksOnly and keep the full check set.
+   * Admin booking update sets capacityChecksOnly so saves never hard-fail on
+   * checkout rules (including capacity/overlap). Informational availability is
+   * via validate endpoints with excludeBookingIds. Create keeps the full set.
    */
   async checkAll(stopOnFirstError = true) {
-    if (!this.capacityChecksOnly) {
-      return super.checkAll(stopOnFirstError);
+    if (this.capacityChecksOnly) {
+      return true;
     }
 
-    const checks = [
-      this.checkMaxAmount(),
-      this.checkAvailability(),
-      this.checkEventSeats(),
-      this.checkParentAvailability(),
-      this.checkChildBookings(),
-    ];
-
-    return stopOnFirstError ? Promise.all(checks) : Promise.allSettled(checks);
+    return super.checkAll(stopOnFirstError);
   }
 }
 

--- a/tests/admin-booking-update-self-block.test.js
+++ b/tests/admin-booking-update-self-block.test.js
@@ -223,7 +223,7 @@ describe("BookingService.updateBooking — admin edit self-block & prices", () =
     assert.strictEqual(result.timeBegin, NEW_TIME_BEGIN);
   });
 
-  it("rejects an update that overlaps a different booking", async () => {
+  it("allows admin update even when overlapping a different booking", async () => {
     concurrent = [
       bookingRecord(),
       bookingRecord({
@@ -233,14 +233,13 @@ describe("BookingService.updateBooking — admin edit self-block & prices", () =
       }),
     ];
 
-    await assert.rejects(
-      () => BookingService.updateBooking(TENANT_ID, bookingRecord()),
-      (error) => {
-        assert.strictEqual(error.checkType, CHECK_TYPES.AVAILABILITY);
-        assert.strictEqual(error.available, false);
-        return true;
-      },
+    const result = await BookingService.updateBooking(
+      TENANT_ID,
+      bookingRecord(),
     );
+
+    assert.strictEqual(result.id, BOOKING_ID);
+    assert.strictEqual(lastPreparedStore().id, BOOKING_ID);
   });
 
   it("does not let insufficient lead time block an update", async () => {
@@ -320,7 +319,7 @@ describe("BookingService.updateBooking — admin edit self-block & prices", () =
     assert.strictEqual(stored.vatIncludedEur, 3.8);
   });
 
-  it("excludes only the edited booking id, not a group sibling", async () => {
+  it("allows admin update even when a group sibling overlaps the same window", async () => {
     concurrent = [
       bookingRecord(),
       bookingRecord({
@@ -330,13 +329,12 @@ describe("BookingService.updateBooking — admin edit self-block & prices", () =
       }),
     ];
 
-    await assert.rejects(
-      () => BookingService.updateBooking(TENANT_ID, bookingRecord()),
-      (error) => {
-        assert.strictEqual(error.checkType, CHECK_TYPES.AVAILABILITY);
-        return true;
-      },
+    const result = await BookingService.updateBooking(
+      TENANT_ID,
+      bookingRecord(),
     );
+
+    assert.strictEqual(result.id, BOOKING_ID);
   });
 });
 


### PR DESCRIPTION
Capacity checks on the update path were hard-failing saves; they are now skipped so admins can always update while validate endpoints remain informational.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Admin booking updates now succeed even when capacity or overlap rules would otherwise block checkout.
  - Booking prices continue to be recalculated from the edited booking details.
  - Availability checks during booking edits provide informational results without preventing the update.

- **Documentation**
  - Clarified how capacity-only checks and excluded bookings behave during administrative updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->