### PR TITLE
Allow admin manual booking create despite availability conflicts.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Admin manual booking create never hard-fails on checkout rules (including capacity/overlap), matching admin update; use validate endpoints for informational availability
+
 ## [4.2.4] — 2026-08-10
 
 ### Fixed

--- a/src/commons/services/checkout/booking-service.js
+++ b/src/commons/services/checkout/booking-service.js
@@ -287,6 +287,9 @@ class BookingService {
         checkoutId: providedCheckoutId,
         customFieldValues,
         cancellationPolicy,
+        // Same as admin update: never hard-fail on checkout rules. Informational
+        // availability is via validate endpoints.
+        capacityChecksOnly: true,
       });
     } else {
       const filteredAddons = await validateMandatoryAddons(bookableItems);

--- a/src/commons/services/checkout/bundle-checkout-service.js
+++ b/src/commons/services/checkout/bundle-checkout-service.js
@@ -540,7 +540,8 @@ class ManualBundleCheckoutService extends BundleCheckoutService {
    * @param {string|string[]|null} [excludeBookingIds] Booking IDs ignored in
    *   capacity checks (e.g. validate while editing an existing booking).
    * @param {boolean} [capacityChecksOnly] When true, item checkAll is a no-op
-   *   so admin updates never hard-fail (update path only — do not set on create).
+   *   so admin manual create/update never hard-fail. Use validate endpoints for
+   *   informational availability.
    */
   constructor({
     user,

--- a/src/commons/services/checkout/item-checkout-service.js
+++ b/src/commons/services/checkout/item-checkout-service.js
@@ -863,9 +863,9 @@ class ManualItemCheckoutService extends ItemCheckoutService {
   }
 
   /**
-   * Admin booking update sets capacityChecksOnly so saves never hard-fail on
-   * checkout rules (including capacity/overlap). Informational availability is
-   * via validate endpoints with excludeBookingIds. Create keeps the full set.
+   * Admin manual create/update sets capacityChecksOnly so saves never hard-fail
+   * on checkout rules (including capacity/overlap). Informational availability
+   * is via validate endpoints (with excludeBookingIds when editing).
    */
   async checkAll(stopOnFirstError = true) {
     if (this.capacityChecksOnly) {

--- a/tests/admin-booking-update-self-block.test.js
+++ b/tests/admin-booking-update-self-block.test.js
@@ -11,9 +11,6 @@ const UserManager = require("../src/commons/data-managers/user-manager");
 const OpeningHoursManager = require("../src/commons/utilities/opening-hours-manager");
 const LockerService = require("../src/commons/services/locker/locker-service");
 const BookingService = require("../src/commons/services/checkout/booking-service");
-const {
-  CHECK_TYPES,
-} = require("../src/commons/availability/checkout-check-types");
 
 const TENANT_ID = "tenant-1";
 const BOOKING_ID = "EDIT-ME";
@@ -338,7 +335,7 @@ describe("BookingService.updateBooking — admin edit self-block & prices", () =
   });
 });
 
-describe("BookingService.createBooking — create path still runs full checks", () => {
+describe("BookingService.createBooking — admin create never hard-fails checks", () => {
   let clock;
 
   beforeEach(() => {
@@ -391,40 +388,36 @@ describe("BookingService.createBooking — create path still runs full checks", 
     sinon.restore();
   });
 
-  it("still rejects create when lead time is insufficient", async () => {
+  it("does not let insufficient lead time block a manual create", async () => {
     const snapshot = bookableSnapshot({
       preparationLeadTimeMinutes: 120,
     });
 
-    await assert.rejects(
-      () =>
-        BookingService.createBooking({
-          tenantId: TENANT_ID,
-          user: { id: "admin@example.com" },
-          simulate: true,
-          manualBooking: true,
-          bookingAttempt: {
-            timeBegin: Date.UTC(2026, 5, 15, 10, 0, 0),
-            timeEnd: Date.UTC(2026, 5, 15, 11, 0, 0),
-            bookableItems: [
-              {
-                bookableId: "room-1",
-                amount: 1,
-                _bookableUsed: snapshot,
-              },
-            ],
-            name: "Create Smoke",
-            mail: "user@example.com",
-            paymentProvider: "invoice",
-            isCommitted: false,
-            isPayed: false,
-            isRejected: false,
+    const result = await BookingService.createBooking({
+      tenantId: TENANT_ID,
+      user: { id: "admin@example.com" },
+      simulate: true,
+      manualBooking: true,
+      bookingAttempt: {
+        timeBegin: Date.UTC(2026, 5, 15, 10, 0, 0),
+        timeEnd: Date.UTC(2026, 5, 15, 11, 0, 0),
+        bookableItems: [
+          {
+            bookableId: "room-1",
+            amount: 1,
+            _bookableUsed: snapshot,
           },
-        }),
-      (error) => {
-        assert.strictEqual(error.checkType, CHECK_TYPES.INSUFFICIENT_LEAD_TIME);
-        return true;
+        ],
+        name: "Create Smoke",
+        mail: "user@example.com",
+        paymentProvider: "invoice",
+        isCommitted: false,
+        isPayed: false,
+        isRejected: false,
       },
-    );
+    });
+
+    assert.ok(result.id);
+    assert.strictEqual(result.mail, "user@example.com");
   });
 });


### PR DESCRIPTION
Match the existing admin update path so create never hard-fails on checkout rules; informational availability stays on validate endpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Admin manual booking creation no longer fails due to checkout-rule checks, including capacity and overlapping bookings.
  * Availability information remains accessible through validation checks.

* **Tests**
  * Updated booking creation coverage to confirm successful manual bookings return the expected booking ID and email.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->