### PR TITLE
Keep admin-entered prices on booking update when discounts apply.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 ## [Unreleased]
 
+### Fixed
+
+- Admin booking update no longer applies the assignee's bookable booking discounts when recomputing prices (same as manual create; Admin-entered list prices from `priceCategories` are kept)
+
 ## [4.2.5] — 2026-08-10
 
 ### Fixed

--- a/src/commons/services/checkout/booking-service.js
+++ b/src/commons/services/checkout/booking-service.js
@@ -675,6 +675,9 @@ class BookingService {
         paymentMethod: updatedBooking.paymentMethod,
         attachments: oldBooking.attachments,
         lockerInfo: oldBooking.lockerInfo,
+        // Same as manual create: admin-entered list prices must not be overwritten
+        // by the assignee's (or admin's) bookingDiscounts.
+        bookWithoutDiscount: true,
         checkoutId,
         customFieldValues: updatedBooking.customFieldValues,
         cancellationPolicy: updatedBooking.cancellationPolicy,

--- a/tests/admin-booking-update-self-block.test.js
+++ b/tests/admin-booking-update-self-block.test.js
@@ -316,6 +316,51 @@ describe("BookingService.updateBooking — admin edit self-block & prices", () =
     assert.strictEqual(stored.vatIncludedEur, 3.8);
   });
 
+  it("does not apply assigned user's booking discount when admin edits priceCategories", async () => {
+    const assigneeId = "admin@stadt.de";
+    MembershipManager.getMembershipByTenantAndUserID.resolves({
+      userId: assigneeId,
+      roles: [],
+    });
+
+    const snapshot = bookableSnapshot({
+      priceCategories: priceCategories(20),
+      bookingDiscounts: {
+        users: [{ userId: assigneeId, discountPercent: 100 }],
+        roles: [],
+      },
+    });
+    concurrent = [
+      bookingRecord({
+        snapshot,
+        priceEur: 11.9,
+        vatIncludedEur: 1.9,
+        itemNet: 10,
+        itemGross: 11.9,
+      }),
+    ];
+    concurrent[0].assignedUserId = assigneeId;
+
+    const updated = bookingRecord({
+      snapshot,
+      priceEur: 11.9,
+      vatIncludedEur: 1.9,
+      itemNet: 10,
+      itemGross: 11.9,
+    });
+    updated.assignedUserId = assigneeId;
+
+    await BookingService.updateBooking(TENANT_ID, updated);
+    const stored = lastPreparedStore();
+
+    // Admin entered list price via priceCategories must win over bookingDiscounts
+    assert.strictEqual(stored.bookableItems[0].userPriceEur, 20);
+    assert.strictEqual(stored.bookableItems[0].userGrossPriceEur, 23.8);
+    assert.strictEqual(stored.bookableItems[0].regularPriceEur, 20);
+    assert.strictEqual(stored.priceEur, 23.8);
+    assert.strictEqual(stored.vatIncludedEur, 3.8);
+  });
+
   it("allows admin update even when a group sibling overlaps the same window", async () => {
     concurrent = [
       bookingRecord(),


### PR DESCRIPTION
Manual create already skipped bookable bookingDiscounts; update now does the same so priceCategory edits are not overwritten by the assignee discount.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Admin-edited booking prices now retain the entered `priceCategories` list prices during updates.
  - Booking discounts are no longer applied when administrators manually update bookings.
  - Recalculated net, gross, regular, total, and VAT prices now reflect the administrator’s entered values.

- **Documentation**
  - Added an Unreleased changelog entry describing the booking price update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->