### PR TITLE
Feat/customfield show in mail

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 ### Added
 
 - Custom field definitions support `usageOptions.showInMail` (checkout fields only, enforced on write): flagged fields render as `Label: Wert` lines in the booking-details block of all booking mails; empty values show as "nicht angegeben"
+- Mail-visible custom field values render type-aware via `CustomFieldService.formatValueForDisplay`: booleans as "Ja"/"Nein", selects as the option caption (raw value if the option was deleted), numbers as strings
 
 ### Fixed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 - Custom field definitions support `usageOptions.showInMail` (checkout fields only, enforced on write): flagged fields render as `Label: Wert` lines in the booking-details block of all booking mails; empty values show as "nicht angegeben"
 - Mail-visible custom field values render type-aware via `CustomFieldService.formatValueForDisplay`: booleans as "Ja"/"Nein", selects as the option caption (raw value if the option was deleted), numbers as strings
+- Migration `25-08-2026-customfield-show-in-mail` backfills `usageOptions.showInMail: false` on existing custom field definitions (instance, tenant, bookable) so all fields stay opt-in
 
 ### Fixed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 ## [Unreleased]
 
+### Added
+
+- Custom field definitions support `usageOptions.showInMail` (checkout fields only, enforced on write): flagged fields render as `Label: Wert` lines in the booking-details block of all booking mails; empty values show as "nicht angegeben"
+
 ### Fixed
 
 - Admin booking update no longer applies the assignee's bookable booking discounts when recomputing prices (same as manual create; Admin-entered list prices from `priceCategories` are kept)

--- a/migrations/scripts/25-08-2026-customfield-show-in-mail.js
+++ b/migrations/scripts/25-08-2026-customfield-show-in-mail.js
@@ -1,0 +1,99 @@
+/**
+ * Adds the new usageOptions field `showInMail` to existing custom field
+ * definitions on all three levels (Instance, Tenant, Bookable).
+ *
+ * - showInMail: false (custom field values are opt-in for booking mails,
+ *   so existing tenants see no behavior change).
+ */
+
+function migrateDefinitions(definitions = []) {
+  let changed = false;
+
+  for (const def of definitions) {
+    if (!def.usageOptions) {
+      def.usageOptions = {};
+    }
+
+    if (def.usageOptions.showInMail === undefined) {
+      def.usageOptions.showInMail = false;
+      changed = true;
+    }
+  }
+
+  return changed;
+}
+
+module.exports = {
+  name: "25-08-2026-customfield-show-in-mail",
+
+  migrateDefinitions,
+
+  up: async function (mongoose) {
+    const Instance = mongoose.model("Instance");
+    const Tenant = mongoose.model("Tenant");
+    const Bookable = mongoose.model("Bookable");
+
+    const instances = await Instance.find({
+      bookableCustomFields: { $exists: true, $ne: [] },
+    });
+    for (const instance of instances) {
+      if (migrateDefinitions(instance.bookableCustomFields)) {
+        instance.markModified("bookableCustomFields");
+        await instance.save();
+      }
+    }
+
+    const tenants = await Tenant.find({
+      bookableCustomFields: { $exists: true, $ne: [] },
+    });
+    for (const tenant of tenants) {
+      if (migrateDefinitions(tenant.bookableCustomFields)) {
+        tenant.markModified("bookableCustomFields");
+        await tenant.save();
+      }
+    }
+
+    const bookables = await Bookable.find({
+      customFieldDefinitions: { $exists: true, $ne: [] },
+    });
+    for (const bookable of bookables) {
+      if (migrateDefinitions(bookable.customFieldDefinitions)) {
+        bookable.markModified("customFieldDefinitions");
+        await bookable.save();
+      }
+    }
+  },
+
+  down: async function (mongoose) {
+    const Instance = mongoose.model("Instance");
+    const Tenant = mongoose.model("Tenant");
+    const Bookable = mongoose.model("Bookable");
+
+    await Instance.updateMany(
+      {},
+      {
+        $unset: {
+          "bookableCustomFields.$[].usageOptions.showInMail": "",
+        },
+      },
+    );
+
+    await Tenant.updateMany(
+      {},
+      {
+        $unset: {
+          "bookableCustomFields.$[].usageOptions.showInMail": "",
+        },
+      },
+    );
+
+    await Bookable.updateMany(
+      {},
+      {
+        $unset: {
+          "customFieldDefinitions.$[].usageOptions.showInMail": "",
+        },
+      },
+    );
+  },
+};

--- a/src/commons/mail-service/mail-data.service.js
+++ b/src/commons/mail-service/mail-data.service.js
@@ -3,6 +3,9 @@ const { BookableManager } = require("../data-managers/bookable-manager");
 const EventManager = require("../data-managers/event-manager");
 const TenantManager = require("../data-managers/tenant-manager");
 const QRCode = require("qrcode");
+const {
+  CustomFieldService,
+} = require("../services/custom-field/custom-field-service");
 const { renderSnippet } = require("./templates/template-loader");
 const Formatters = require("../utilities/formatters");
 
@@ -110,12 +113,10 @@ class MailDataService {
       .filter((field) => field.usageOptions?.showInMail === true)
       .map((field) => ({
         caption: field.caption,
-        displayValue:
-          field.value === null ||
-          field.value === undefined ||
-          field.value === ""
-            ? null
-            : String(field.value),
+        displayValue: CustomFieldService.formatValueForDisplay(
+          field,
+          field.value,
+        ),
       }));
 
     return renderSnippet("booking-details", {

--- a/src/commons/mail-service/mail-data.service.js
+++ b/src/commons/mail-service/mail-data.service.js
@@ -104,11 +104,26 @@ class MailDataService {
       tenant.mailBookingPeriodFormat,
     );
 
+    // Order follows the merge order of the definitions (instance → tenant →
+    // bookable); a null displayValue renders as "nicht angegeben".
+    const mailCustomFields = (booking.customFields || [])
+      .filter((field) => field.usageOptions?.showInMail === true)
+      .map((field) => ({
+        caption: field.caption,
+        displayValue:
+          field.value === null ||
+          field.value === undefined ||
+          field.value === ""
+            ? null
+            : String(field.value),
+      }));
+
     return renderSnippet("booking-details", {
       booking,
       bookingItems,
       coupon,
       bookingPeriod,
+      mailCustomFields,
     });
   }
 

--- a/src/commons/mail-service/templates/snippets/booking-details.hbs
+++ b/src/commons/mail-service/templates/snippets/booking-details.hbs
@@ -8,6 +8,10 @@
   <br> {{booking.comment}}
 {{else}} {{/gt}}
 
+{{#each mailCustomFields}}
+  <br><strong>{{caption}}:</strong>
+  {{#if displayValue}}{{displayValue}}{{else}}<em>nicht angegeben</em>{{/if}}
+{{/each}}
 {{#if bookingPeriod}}
   <br><strong>Buchungszeitraum:</strong> {{bookingPeriod}}
 {{/if}}

--- a/src/commons/schemas/customFieldDefinition.js
+++ b/src/commons/schemas/customFieldDefinition.js
@@ -40,6 +40,11 @@ const usageOptionsSchema = new Schema(
       enum: ["none", "badge", "belowDescription", "moreInfo"],
       default: "none",
     },
+
+    // Whether the value entered during checkout is shown in the booking-details
+    // block of all booking mails. Only meaningful for context "checkout";
+    // normalizeUsageOptions clears it otherwise.
+    showInMail: { type: Boolean, default: false },
   },
   { _id: false },
 );

--- a/src/commons/services/custom-field/custom-field-service.js
+++ b/src/commons/services/custom-field/custom-field-service.js
@@ -4,6 +4,7 @@ class CustomFieldService {
    * detail-display settings stay consistent.
    * - A field is only filterable when it has a catalogFilterType.
    * - When not filterable, catalog filter settings are cleared.
+   * - showInMail only exists on checkout fields; it is cleared otherwise.
    * @param {Object} definition Custom field definition
    * @returns {Object} The (mutated) definition
    */
@@ -31,6 +32,9 @@ class CustomFieldService {
     if (!allowedDetailPositions.includes(usage.detailDisplayPosition)) {
       usage.detailDisplayPosition = "none";
     }
+
+    usage.showInMail =
+      usage.context === "checkout" && usage.showInMail === true;
 
     return definition;
   }

--- a/src/commons/services/custom-field/custom-field-service.js
+++ b/src/commons/services/custom-field/custom-field-service.js
@@ -125,6 +125,45 @@ class CustomFieldService {
     }));
   }
 
+  /**
+   * Raw value of a select option, which may be a plain string or a
+   * {caption, value} object.
+   * @param {string|Object} option
+   * @returns {*}
+   */
+  static optionValue(option) {
+    return typeof option === "string" ? option : option.value;
+  }
+
+  /**
+   * Format a resolved custom field value for human-readable display.
+   * Returns null when the value counts as "not filled in".
+   * @param {Object} definition Custom field definition
+   * @param {*} value Raw value entered during checkout
+   * @returns {string|null}
+   */
+  static formatValueForDisplay(definition, value) {
+    if (value === null || value === undefined || value === "") {
+      return null;
+    }
+
+    switch (definition?.inputType) {
+      case "boolean":
+        return value === true ? "Ja" : "Nein";
+      case "select": {
+        const option = (definition.options || []).find(
+          (o) => this.optionValue(o) === value,
+        );
+        if (option === undefined || typeof option === "string") {
+          return String(value);
+        }
+        return option.caption != null ? String(option.caption) : String(value);
+      }
+      default:
+        return String(value);
+    }
+  }
+
   static validateValues(mergedDefinitions, customFieldValues = []) {
     const errors = [];
     const defMap = new Map(mergedDefinitions.map((d) => [d.id, d]));
@@ -150,9 +189,7 @@ class CustomFieldService {
       }
 
       if (def.inputType === "select" && value != null) {
-        const validValues = def.options.map((o) =>
-          typeof o === "string" ? o : o.value,
-        );
+        const validValues = def.options.map((o) => this.optionValue(o));
         if (!validValues.includes(value)) {
           errors.push(`${def.caption}: invalid option "${value}"`);
         }

--- a/tests/custom-field-mail-visibility.test.js
+++ b/tests/custom-field-mail-visibility.test.js
@@ -59,6 +59,106 @@ describe("CustomFieldService.normalizeUsageOptions (showInMail)", () => {
   });
 });
 
+describe("CustomFieldService.formatValueForDisplay", () => {
+  it("returns null for empty values regardless of inputType", () => {
+    for (const inputType of [
+      "string",
+      "text",
+      "numeric",
+      "boolean",
+      "select",
+    ]) {
+      for (const value of [null, undefined, ""]) {
+        const result = CustomFieldService.formatValueForDisplay(
+          checkoutField({ inputType }),
+          value,
+        );
+
+        assert.strictEqual(result, null);
+      }
+    }
+  });
+
+  it("formats boolean values as Ja/Nein", () => {
+    const definition = checkoutField({ inputType: "boolean" });
+
+    assert.strictEqual(
+      CustomFieldService.formatValueForDisplay(definition, true),
+      "Ja",
+    );
+    assert.strictEqual(
+      CustomFieldService.formatValueForDisplay(definition, false),
+      "Nein",
+    );
+  });
+
+  it("formats select values as the caption of the matching option", () => {
+    const definition = checkoutField({
+      inputType: "select",
+      options: [
+        { value: "opt-a", caption: "Option A" },
+        { value: "opt-b", caption: "Option B" },
+      ],
+    });
+
+    assert.strictEqual(
+      CustomFieldService.formatValueForDisplay(definition, "opt-b"),
+      "Option B",
+    );
+  });
+
+  it("keeps plain string select options as-is", () => {
+    const definition = checkoutField({
+      inputType: "select",
+      options: ["Klein", "Groß"],
+    });
+
+    assert.strictEqual(
+      CustomFieldService.formatValueForDisplay(definition, "Groß"),
+      "Groß",
+    );
+  });
+
+  it("falls back to the raw value when the select option was deleted", () => {
+    const definition = checkoutField({
+      inputType: "select",
+      options: [{ value: "opt-a", caption: "Option A" }],
+    });
+
+    assert.strictEqual(
+      CustomFieldService.formatValueForDisplay(definition, "opt-gone"),
+      "opt-gone",
+    );
+  });
+
+  it("formats numeric values as strings, keeping 0 visible", () => {
+    const definition = checkoutField({ inputType: "numeric" });
+
+    assert.strictEqual(
+      CustomFieldService.formatValueForDisplay(definition, 0),
+      "0",
+    );
+    assert.strictEqual(
+      CustomFieldService.formatValueForDisplay(definition, 12.5),
+      "12.5",
+    );
+  });
+
+  it("passes string and text values through unchanged", () => {
+    for (const inputType of ["string", "text"]) {
+      const definition = checkoutField({ inputType });
+
+      assert.strictEqual(
+        CustomFieldService.formatValueForDisplay(
+          definition,
+          "Zeile 1\nZeile 2",
+        ),
+        "Zeile 1\nZeile 2",
+      );
+    }
+  });
+});
+
 describe("MailDataService.generateBookingDetails (mailCustomFields)", () => {
   afterEach(() => {
     sinon.restore();
@@ -102,6 +202,37 @@ describe("MailDataService.generateBookingDetails (mailCustomFields)", () => {
     assert.ok(html.includes("4 Erwachsene"));
     assert.ok(!html.includes("Internes Feld"));
     assert.ok(!html.includes("geheim"));
+  });
+
+  it("renders boolean and select values human-readable", async () => {
+    stubBooking([
+      {
+        ...checkoutField({
+          id: "field-bool",
+          caption: "Barrierefrei",
+          inputType: "boolean",
+        }),
+        value: false,
+        hasValue: true,
+      },
+      {
+        ...checkoutField({
+          id: "field-select",
+          caption: "Raumgröße",
+          inputType: "select",
+          options: [{ value: "l", caption: "Großer Saal" }],
+        }),
+        value: "l",
+        hasValue: true,
+      },
+    ]);
+
+    const html = await MailDataService.generateBookingDetails("B-1", "tenant");
+
+    assert.ok(html.includes("<strong>Barrierefrei:</strong>"));
+    assert.ok(html.includes("Nein"));
+    assert.ok(html.includes("Großer Saal"));
+    assert.ok(!html.includes("nicht angegeben"));
   });
 
   it("renders flagged fields without a value as nicht angegeben", async () => {

--- a/tests/custom-field-mail-visibility.test.js
+++ b/tests/custom-field-mail-visibility.test.js
@@ -1,0 +1,186 @@
+const assert = require("assert");
+const sinon = require("sinon");
+const {
+  CustomFieldService,
+} = require("../src/commons/services/custom-field/custom-field-service");
+const BookingManager = require("../src/commons/data-managers/booking-manager");
+const {
+  BookableManager,
+} = require("../src/commons/data-managers/bookable-manager");
+const TenantManager = require("../src/commons/data-managers/tenant-manager");
+const MailDataService = require("../src/commons/mail-service/mail-data.service");
+// Registers the Handlebars helpers/partials the booking-details snippet uses.
+require("../src/commons/mail-service/mail-service");
+const {
+  renderSnippet,
+} = require("../src/commons/mail-service/templates/template-loader");
+
+function checkoutField(overrides = {}) {
+  return {
+    id: "field-a",
+    caption: "Anzahl Personen",
+    inputType: "string",
+    usageOptions: { context: "checkout", showInMail: true },
+    ...overrides,
+  };
+}
+
+describe("CustomFieldService.normalizeUsageOptions (showInMail)", () => {
+  it("keeps showInMail on checkout fields", () => {
+    const definition = checkoutField();
+
+    CustomFieldService.normalizeUsageOptions(definition);
+
+    assert.strictEqual(definition.usageOptions.showInMail, true);
+  });
+
+  it("clears showInMail on non-checkout fields", () => {
+    for (const context of ["catalog", "none"]) {
+      const definition = checkoutField({
+        usageOptions: { context, showInMail: true },
+      });
+
+      CustomFieldService.normalizeUsageOptions(definition);
+
+      assert.strictEqual(definition.usageOptions.showInMail, false);
+    }
+  });
+
+  it("coerces missing or non-boolean showInMail to false", () => {
+    for (const showInMail of [undefined, null, "true", 1]) {
+      const definition = checkoutField({
+        usageOptions: { context: "checkout", showInMail },
+      });
+
+      CustomFieldService.normalizeUsageOptions(definition);
+
+      assert.strictEqual(definition.usageOptions.showInMail, false);
+    }
+  });
+});
+
+describe("MailDataService.generateBookingDetails (mailCustomFields)", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  function stubBooking(customFields) {
+    sinon.stub(BookingManager, "getBooking").resolves({
+      id: "B-1",
+      priceEur: 10,
+      comment: "",
+      bookableItems: [],
+      timeBegin: null,
+      timeEnd: null,
+      customFields,
+    });
+    sinon.stub(TenantManager, "getTenant").resolves({});
+    sinon.stub(BookableManager, "getBookables").resolves([]);
+  }
+
+  it("renders only fields flagged with showInMail", async () => {
+    stubBooking([
+      {
+        ...checkoutField({ id: "field-a", caption: "Anzahl Personen" }),
+        value: "4 Erwachsene",
+        hasValue: true,
+      },
+      {
+        ...checkoutField({
+          id: "field-b",
+          caption: "Internes Feld",
+          usageOptions: { context: "checkout", showInMail: false },
+        }),
+        value: "geheim",
+        hasValue: true,
+      },
+    ]);
+
+    const html = await MailDataService.generateBookingDetails("B-1", "tenant");
+
+    assert.ok(html.includes("<strong>Anzahl Personen:</strong>"));
+    assert.ok(html.includes("4 Erwachsene"));
+    assert.ok(!html.includes("Internes Feld"));
+    assert.ok(!html.includes("geheim"));
+  });
+
+  it("renders flagged fields without a value as nicht angegeben", async () => {
+    stubBooking([{ ...checkoutField(), value: null, hasValue: false }]);
+
+    const html = await MailDataService.generateBookingDetails("B-1", "tenant");
+
+    assert.ok(html.includes("<strong>Anzahl Personen:</strong>"));
+    assert.ok(html.includes("<em>nicht angegeben</em>"));
+  });
+
+  it("renders unchanged when the booking has no custom fields", async () => {
+    stubBooking(undefined);
+
+    const html = await MailDataService.generateBookingDetails("B-1", "tenant");
+
+    assert.ok(!html.includes("nicht angegeben"));
+    assert.ok(!html.includes("<strong>Anzahl Personen:</strong>"));
+  });
+});
+
+describe("booking-details snippet (mailCustomFields)", () => {
+  const baseContext = {
+    booking: {
+      id: "B-1",
+      priceEur: 12.5,
+      comment: "Bitte klingeln",
+    },
+    bookingItems: [],
+    coupon: null,
+    bookingPeriod: "01.01.2026 10:00 - 12:00",
+  };
+
+  it("renders filled fields as Label: Wert after the booking comment", () => {
+    const html = renderSnippet("booking-details", {
+      ...baseContext,
+      mailCustomFields: [
+        { caption: "Anzahl Personen", displayValue: "4 Erwachsene" },
+      ],
+    });
+
+    assert.ok(html.includes("<strong>Anzahl Personen:</strong>"));
+    assert.ok(html.includes("4 Erwachsene"));
+    const commentIndex = html.indexOf("Hinweise zur Buchung");
+    const fieldIndex = html.indexOf("Anzahl Personen");
+    const periodIndex = html.indexOf("Buchungszeitraum");
+    assert.ok(commentIndex < fieldIndex && fieldIndex < periodIndex);
+  });
+
+  it("escapes user-entered values", () => {
+    const html = renderSnippet("booking-details", {
+      ...baseContext,
+      mailCustomFields: [
+        { caption: "Kommentar", displayValue: "<script>alert(1)</script>" },
+      ],
+    });
+
+    assert.ok(!html.includes("<script>"));
+    assert.ok(html.includes("&lt;script&gt;"));
+  });
+
+  it("renders empty values as italic nicht angegeben", () => {
+    const html = renderSnippet("booking-details", {
+      ...baseContext,
+      mailCustomFields: [{ caption: "Anzahl Personen", displayValue: null }],
+    });
+
+    assert.ok(html.includes("<strong>Anzahl Personen:</strong>"));
+    assert.ok(html.includes("<em>nicht angegeben</em>"));
+  });
+
+  it("renders byte-identical to a context without mailCustomFields", () => {
+    const withoutKey = renderSnippet("booking-details", baseContext);
+    const withEmptyList = renderSnippet("booking-details", {
+      ...baseContext,
+      mailCustomFields: [],
+    });
+
+    assert.strictEqual(withEmptyList, withoutKey);
+    assert.ok(!withoutKey.includes("nicht angegeben"));
+  });
+});

--- a/tests/customfield-show-in-mail-migration.test.js
+++ b/tests/customfield-show-in-mail-migration.test.js
@@ -1,0 +1,149 @@
+const assert = require("assert");
+const sinon = require("sinon");
+const migration = require("../migrations/scripts/25-08-2026-customfield-show-in-mail");
+
+describe("25-08-2026-customfield-show-in-mail migration", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("migrateDefinitions", () => {
+    it("backfills showInMail: false where the flag is missing", () => {
+      const definitions = [
+        { id: "a", usageOptions: { context: "checkout" } },
+        { id: "b", usageOptions: { context: "catalog" } },
+      ];
+
+      const changed = migration.migrateDefinitions(definitions);
+
+      assert.strictEqual(changed, true);
+      assert.strictEqual(definitions[0].usageOptions.showInMail, false);
+      assert.strictEqual(definitions[1].usageOptions.showInMail, false);
+    });
+
+    it("creates usageOptions when it is missing entirely", () => {
+      const definitions = [{ id: "a" }];
+
+      const changed = migration.migrateDefinitions(definitions);
+
+      assert.strictEqual(changed, true);
+      assert.strictEqual(definitions[0].usageOptions.showInMail, false);
+    });
+
+    it("does not overwrite an existing showInMail value", () => {
+      const definitions = [
+        { id: "a", usageOptions: { context: "checkout", showInMail: true } },
+        { id: "b", usageOptions: { context: "checkout", showInMail: false } },
+      ];
+
+      const changed = migration.migrateDefinitions(definitions);
+
+      assert.strictEqual(changed, false);
+      assert.strictEqual(definitions[0].usageOptions.showInMail, true);
+      assert.strictEqual(definitions[1].usageOptions.showInMail, false);
+    });
+
+    it("handles undefined and empty definition lists", () => {
+      assert.strictEqual(migration.migrateDefinitions(undefined), false);
+      assert.strictEqual(migration.migrateDefinitions([]), false);
+    });
+  });
+
+  describe("up", () => {
+    function fakeDoc(fieldName, definitions) {
+      return {
+        [fieldName]: definitions,
+        markModified: sinon.spy(),
+        save: sinon.stub().resolves(),
+      };
+    }
+
+    it("backfills instance, tenant and bookable definitions and saves only changed docs", async () => {
+      const instance = fakeDoc("bookableCustomFields", [
+        { id: "i1", usageOptions: { context: "checkout" } },
+      ]);
+      const tenantChanged = fakeDoc("bookableCustomFields", [
+        { id: "t1", usageOptions: {} },
+      ]);
+      const tenantUnchanged = fakeDoc("bookableCustomFields", [
+        { id: "t2", usageOptions: { showInMail: true } },
+      ]);
+      const bookable = fakeDoc("customFieldDefinitions", [{ id: "b1" }]);
+
+      const models = {
+        Instance: { find: sinon.stub().resolves([instance]) },
+        Tenant: {
+          find: sinon.stub().resolves([tenantChanged, tenantUnchanged]),
+        },
+        Bookable: { find: sinon.stub().resolves([bookable]) },
+      };
+      const mongoose = { model: (name) => models[name] };
+
+      await migration.up(mongoose);
+
+      assert.strictEqual(
+        instance.bookableCustomFields[0].usageOptions.showInMail,
+        false,
+      );
+      assert.ok(instance.markModified.calledWith("bookableCustomFields"));
+      assert.ok(instance.save.calledOnce);
+
+      assert.strictEqual(
+        tenantChanged.bookableCustomFields[0].usageOptions.showInMail,
+        false,
+      );
+      assert.ok(tenantChanged.save.calledOnce);
+
+      assert.strictEqual(
+        tenantUnchanged.bookableCustomFields[0].usageOptions.showInMail,
+        true,
+      );
+      assert.ok(tenantUnchanged.save.notCalled);
+
+      assert.strictEqual(
+        bookable.customFieldDefinitions[0].usageOptions.showInMail,
+        false,
+      );
+      assert.ok(bookable.markModified.calledWith("customFieldDefinitions"));
+      assert.ok(bookable.save.calledOnce);
+    });
+  });
+
+  describe("down", () => {
+    it("unsets showInMail on all three levels", async () => {
+      const models = {
+        Instance: { updateMany: sinon.stub().resolves() },
+        Tenant: { updateMany: sinon.stub().resolves() },
+        Bookable: { updateMany: sinon.stub().resolves() },
+      };
+      const mongoose = { model: (name) => models[name] };
+
+      await migration.down(mongoose);
+
+      assert.deepStrictEqual(models.Instance.updateMany.firstCall.args, [
+        {},
+        {
+          $unset: {
+            "bookableCustomFields.$[].usageOptions.showInMail": "",
+          },
+        },
+      ]);
+      assert.deepStrictEqual(models.Tenant.updateMany.firstCall.args, [
+        {},
+        {
+          $unset: {
+            "bookableCustomFields.$[].usageOptions.showInMail": "",
+          },
+        },
+      ]);
+      assert.deepStrictEqual(models.Bookable.updateMany.firstCall.args, [
+        {},
+        {
+          $unset: {
+            "customFieldDefinitions.$[].usageOptions.showInMail": "",
+          },
+        },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Checkout custom fields can now be optionally included in booking confirmation emails.
  - Values are displayed in a readable format, including selections and boolean fields.
  - Fields without a value are shown as “not specified.”
  - Existing custom fields default to hidden in emails.

- **Bug Fixes**
  - Prevented email visibility settings from applying outside checkout fields.

- **Tests**
  - Added coverage for visibility, formatting, rendering, escaping, and data migration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->