### PR TITLE
Type the result-bearing methods of the access provider seam

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 ### Changed
 
-- Access provider seam typed: `open`/`unlatch` answer an `OpenOutcome` (`{ state: "opened" | "pending", openProcessId }`), `getStatus` a `LockStatus` (`{ open, locked, doorOpen }`, each `true`/`false`/`null`), `close` nothing, and the new interface method `getOpenProgress(accessPoint, openProcessId)` (capability `getOpenProgress`, iFBS) an `OpenProgress`. `AccessService` no longer sniffs provider dialects and branches on `capabilities` only; the audit log stores the typed outcome instead of the raw provider answer. `open`/`unlatch` throw only `AccessOpenError` (`configuration` | `temporary`) at every provider now, so the access endpoints answer `openFailure` for NUKI and iFBS failures too instead of HTTP 500. HTTP response shapes are unchanged; a failed iFBS poll at `/open-status` now reports `open: null`, `confirmed: null` (unknown) instead of `false`. iFBS lockers no longer declare `close` - the iFBS API has no command for it and the call always failed
+- Access provider seam typed: `open`/`unlatch` answer an `OpenOutcome`, `getStatus` a `LockStatus`, `close` nothing, and the new `getOpenProgress` (capability `getOpenProgress`, iFBS) an `OpenProgress`; the audit log stores these instead of the raw provider answer. `open`/`unlatch` throw only `AccessOpenError` at every provider now, so NUKI and iFBS failures reach the client as `openFailure` instead of HTTP 500. HTTP shapes are unchanged; a failed iFBS poll at `/open-status` reports `open`/`confirmed` as `null` (unknown) instead of `false`, and iFBS lockers no longer declare `close` (the API has no command for it)
 
 ### Added
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 ## [Unreleased]
 
+### Changed
+
+- Access provider seam typed: `open`/`unlatch` answer an `OpenOutcome` (`{ state: "opened" | "pending", openProcessId }`), `getStatus` a `LockStatus` (`{ open, locked, doorOpen }`, each `true`/`false`/`null`), `close` nothing, and the new interface method `getOpenProgress(accessPoint, openProcessId)` (capability `getOpenProgress`, iFBS) an `OpenProgress`. `AccessService` no longer sniffs provider dialects and branches on `capabilities` only; the audit log stores the typed outcome instead of the raw provider answer. `open`/`unlatch` throw only `AccessOpenError` (`configuration` | `temporary`) at every provider now, so the access endpoints answer `openFailure` for NUKI and iFBS failures too instead of HTTP 500. HTTP response shapes are unchanged; a failed iFBS poll at `/open-status` now reports `open: null`, `confirmed: null` (unknown) instead of `false`. iFBS lockers no longer declare `close` - the iFBS API has no command for it and the call always failed
+
 ### Added
 
 - Access provider contract test against NUKI, Salto KS, iFBS and an in-memory test provider, plus characterization tests that pin today's provider dialects. Access providers accept an injected API client (`{ client }`) for tests; production behaviour is unchanged

--- a/src/commons/services/access/access-point-projection.js
+++ b/src/commons/services/access/access-point-projection.js
@@ -12,7 +12,7 @@ require("./providers/register-access-providers");
  *
  * `unlatch` is deliberately absent: pulling the latch is decided behind
  * `open`, per lock, so a client never picks that action itself.
- * `getOpenStatus` likewise: a client polls exactly when the open answer
+ * `getOpenProgress` likewise: a client polls exactly when the open answer
  * carries an `openProcessId`, so that answer already says it.
  */
 const UI_CAPABILITIES = Object.freeze(["open", "close", "getStatus"]);

--- a/src/commons/services/access/access-service.js
+++ b/src/commons/services/access/access-service.js
@@ -1,5 +1,6 @@
 const bunyan = require("bunyan");
 const { getAccessProvider } = require("./providers/access-provider-registry");
+const AccessProvider = require("./providers/access-provider");
 const BookingManager = require("../../data-managers/booking-manager");
 const { BookableManager } = require("../../data-managers/bookable-manager");
 const AccessPointManager = require("../../data-managers/access-point-manager");
@@ -20,13 +21,6 @@ const {
 const logger = bunyan.createLogger({
   name: "access-service.js",
   level: process.env.LOG_LEVEL,
-});
-
-/** A lock nobody could read: unknown on every count. */
-const UNKNOWN_LOCK_STATUS = Object.freeze({
-  open: null,
-  locked: null,
-  doorOpen: null,
 });
 
 class AccessService {
@@ -372,7 +366,7 @@ class AccessService {
       logger.warn(
         `Could not read access point ${accessPoint.id} after closing it: ${err.message}`,
       );
-      return this._toStatusResponse(UNKNOWN_LOCK_STATUS, null);
+      return this._toStatusResponse(AccessProvider.unknownLockStatus, null);
     }
   }
 
@@ -515,7 +509,7 @@ class AccessService {
         ? { open: true, locked: false, doorOpen: null }
         : progress.confirmed === false
           ? { open: false, locked: null, doorOpen: null }
-          : UNKNOWN_LOCK_STATUS;
+          : AccessProvider.unknownLockStatus;
 
     return {
       ...this._toStatusResponse(lockStatus, statusSource),

--- a/src/commons/services/access/access-service.js
+++ b/src/commons/services/access/access-service.js
@@ -22,6 +22,13 @@ const logger = bunyan.createLogger({
   level: process.env.LOG_LEVEL,
 });
 
+/** A lock nobody could read: unknown on every count. */
+const UNKNOWN_LOCK_STATUS = Object.freeze({
+  open: null,
+  locked: null,
+  doorOpen: null,
+});
+
 class AccessService {
   /**
    * Opens an access point linked to a booking.
@@ -161,7 +168,7 @@ class AccessService {
 
     try {
       const provider = getAccessProvider(accessPoint.provider);
-      const result = await provider[action](accessPoint, bookingContext);
+      const outcome = await provider[action](accessPoint, bookingContext);
 
       await this._log({
         tenantId: tenant,
@@ -171,16 +178,18 @@ class AccessService {
         action,
         result: "success",
         payload: {
-          ...result,
+          ...outcome,
           validatedEvidence: evidenceOutcome.validatedEvidence,
         },
         channel,
         accessRole: eligibility.accessRole,
         evidenceBypassed: evidenceOutcome.bypassed,
       });
+      // The outcome says by itself whether polling is called for: a
+      // pending open names its process, an opened door names none.
       return {
         success: true,
-        data: { openProcessId: this._toOpenProcessId(result) },
+        data: { openProcessId: outcome.openProcessId },
       };
     } catch (err) {
       await this._log({
@@ -313,7 +322,7 @@ class AccessService {
 
     try {
       const provider = getAccessProvider(accessPoint.provider);
-      const result = await provider.close(accessPoint, bookingContext);
+      await provider.close(accessPoint, bookingContext);
 
       await this._log({
         tenantId: tenant,
@@ -322,7 +331,6 @@ class AccessService {
         bookingId,
         action: "close",
         result: "success",
-        payload: result,
       });
       return this._readStatusAfterClose(provider, accessPoint, bookingContext);
     } catch (err) {
@@ -364,7 +372,7 @@ class AccessService {
       logger.warn(
         `Could not read access point ${accessPoint.id} after closing it: ${err.message}`,
       );
-      return this._toStatusResponse({}, null);
+      return this._toStatusResponse(UNKNOWN_LOCK_STATUS, null);
     }
   }
 
@@ -373,11 +381,16 @@ class AccessService {
    * one, the last event the door reported otherwise, and the lock's own state
    * as the last resort. `statusSource` says which of the three answered.
    *
+   * The provider is asked for the progress of a process only where it
+   * declares `getOpenProgress` - a process id at a provider that opens
+   * synchronously is nothing to poll.
+   *
    * @param {string} tenant Tenant ID
    * @param {string} bookingId Booking ID
    * @param {string} accessPointId Access point ID
    * @param {string|null} openProcessId The process an open answered with
-   * @returns {Promise<Object>} The status of the open attempt
+   * @returns {Promise<Object>} The status of the open attempt, as of
+   *   {@link _toOpenStatusResponse}
    */
   static async getOpenStatus(tenant, bookingId, accessPointId, openProcessId) {
     const { accessPoint, bookingContext } = await this._resolve(
@@ -386,23 +399,37 @@ class AccessService {
       accessPointId,
     );
     const provider = getAccessProvider(accessPoint.provider);
-    let status;
+    const canReportProgress =
+      provider.constructor.capabilities.includes("getOpenProgress");
+    let payload;
+    let response;
 
-    let statusSource;
-
-    if (typeof provider.getOpenStatus === "function" && openProcessId) {
-      status = await provider.getOpenStatus(tenant, openProcessId);
-      statusSource = "open_process";
+    if (openProcessId && canReportProgress) {
+      const progress = await provider.getOpenProgress(
+        accessPoint,
+        openProcessId,
+      );
+      payload = progress;
+      response = this._toOpenStatusResponse(progress, "open_process");
     } else if (bookingContext.lastEvent) {
-      status = {
-        confirmed: bookingContext.lastEvent.success === true,
-        confirmedAt: bookingContext.lastEvent.timestamp || null,
-        event: bookingContext.lastEvent,
+      const { lastEvent } = bookingContext;
+      const progress = {
+        confirmed: lastEvent.success === true,
+        confirmedAt: lastEvent.timestamp || null,
+        errorCode: null,
+        errorMessage: null,
       };
-      statusSource = "last_event";
+      payload = { ...progress, event: lastEvent };
+      response = this._toOpenStatusResponse(progress, "last_event");
     } else {
-      status = await provider.getStatus(accessPoint, bookingContext);
-      statusSource = "provider_status";
+      const lockStatus = await provider.getStatus(accessPoint, bookingContext);
+      payload = lockStatus;
+      response = {
+        ...this._toStatusResponse(lockStatus, "provider_status"),
+        confirmed: null,
+        errorCode: null,
+        errorMessage: null,
+      };
     }
 
     await this._log({
@@ -411,11 +438,11 @@ class AccessService {
       bookingId,
       action: "status",
       result: "success",
-      payload: status,
+      payload,
       actor: { source: "system" },
     });
 
-    return this._toOpenStatusResponse(status, statusSource);
+    return response;
   }
 
   /**
@@ -434,7 +461,7 @@ class AccessService {
     );
 
     const provider = getAccessProvider(accessPoint.provider);
-    const status = await provider.getStatus(accessPoint, bookingContext);
+    const lockStatus = await provider.getStatus(accessPoint, bookingContext);
 
     await this._log({
       tenantId: tenant,
@@ -442,115 +469,60 @@ class AccessService {
       bookingId,
       action: "status",
       result: "success",
-      payload: status,
+      payload: lockStatus,
       actor: { source: "system" },
     });
 
-    return this._toStatusResponse(status, "provider_status");
+    return this._toStatusResponse(lockStatus, "provider_status");
   }
 
   /**
    * @private
-   * A provider answer as the API hands it out: the named fields and nothing
-   * else. The raw answer stays in the audit log - as long as provider keys
-   * slip through, a client can branch on them again, which is exactly what
-   * these endpoints are meant to end.
+   * A lock status as the API hands it out: the three fields of the
+   * provider's LockStatus and where the answer came from. The adapters
+   * answer in this shape already - there is nothing to read out of them.
    *
    * `null` carries meaning and is not `false`: it says the provider does not
    * report this.
    *
-   * @param {Object} [status={}] The provider's answer
-   * @param {string|null} [statusSource=null] Where the answer came from
+   * @param {import("./providers/access-provider").LockStatus} lockStatus
+   *   The provider's answer
+   * @param {string|null} statusSource Where the answer came from
    * @returns {{ open: boolean|null, locked: boolean|null,
    *   doorOpen: boolean|null, statusSource: string|null }} The status
    */
-  static _toStatusResponse(status = {}, statusSource = null) {
-    const open = this._resolveOpen(status);
-
-    return {
-      open,
-      locked: this._resolveLocked(status, open),
-      doorOpen: typeof status.doorOpen === "boolean" ? status.doorOpen : null,
-      statusSource,
-    };
+  static _toStatusResponse(lockStatus, statusSource) {
+    return { ...lockStatus, statusSource };
   }
 
   /**
    * @private
-   * The status of an open attempt: the fields of {@link _toStatusResponse}
-   * plus what only an attempt can say - whether it was confirmed, and how it
-   * failed if it did.
+   * The status of an open attempt, read off its progress: a confirmed open
+   * is an open, unlocked door; one not confirmed is not open, and whether
+   * the lock is thrown is unknown; a progress the provider could not tell
+   * is unknown on every count. The door itself is never reported by a
+   * process - only a sensor can.
    *
-   * @param {Object} [status={}] The provider's answer
-   * @param {string|null} [statusSource=null] Where the answer came from
-   * @returns {Object} The status of the open attempt
+   * @param {import("./providers/access-provider").OpenProgress} progress
+   *   How far the attempt has come
+   * @param {string|null} statusSource Where the answer came from
+   * @returns {Object} The fields of {@link _toStatusResponse} plus
+   *   `confirmed`, `errorCode` and `errorMessage`
    */
-  static _toOpenStatusResponse(status = {}, statusSource = null) {
+  static _toOpenStatusResponse(progress, statusSource) {
+    const lockStatus =
+      progress.confirmed === true
+        ? { open: true, locked: false, doorOpen: null }
+        : progress.confirmed === false
+          ? { open: false, locked: null, doorOpen: null }
+          : UNKNOWN_LOCK_STATUS;
+
     return {
-      ...this._toStatusResponse(status, statusSource),
-      confirmed:
-        typeof status.confirmed === "boolean" ? status.confirmed : null,
-      errorCode:
-        typeof status.errorCode === "string" ||
-        typeof status.errorCode === "number"
-          ? status.errorCode
-          : null,
-      errorMessage:
-        typeof status.errorMessage === "string" ? status.errorMessage : null,
+      ...this._toStatusResponse(lockStatus, statusSource),
+      confirmed: progress.confirmed,
+      errorCode: progress.errorCode,
+      errorMessage: progress.errorMessage,
     };
-  }
-
-  /**
-   * @private
-   * The process id an open answered with, if the provider started one. `null`
-   * means the door is already dealt with, a value means there is something to
-   * poll - so the answer says by itself whether polling is called for.
-   *
-   * @param {Object} [result={}] The provider's answer to an open
-   * @returns {string|null} The open process id
-   */
-  static _toOpenProcessId(result = {}) {
-    const openProcessId = result?.openProcessId;
-
-    return openProcessId === null || openProcessId === undefined
-      ? null
-      : String(openProcessId);
-  }
-
-  static _resolveOpen(status) {
-    if (typeof status.open === "boolean") {
-      return status.open;
-    }
-
-    if (typeof status.confirmed === "boolean") {
-      return status.confirmed;
-    }
-
-    if (status.state === "open" || status.state === "unlocked") {
-      return true;
-    }
-
-    if (status.state === "closed" || status.state === "locked") {
-      return false;
-    }
-
-    return null;
-  }
-
-  static _resolveLocked(status, open) {
-    if (typeof status.locked === "boolean") {
-      return status.locked;
-    }
-
-    if (status.state === "closed" || status.state === "locked") {
-      return true;
-    }
-
-    if (open === true) {
-      return false;
-    }
-
-    return null;
   }
 
   /**

--- a/src/commons/services/access/providers/access-provider.js
+++ b/src/commons/services/access/providers/access-provider.js
@@ -95,6 +95,16 @@
  * @property {Object} payload The event as it came in
  */
 
+const { AccessOpenError } = require("../../../../errors/AccessOpenError");
+const { NotFoundError } = require("../../../../errors/BaseError");
+
+/** A lock nobody could read: unknown on every count. */
+const UNKNOWN_LOCK_STATUS = Object.freeze({
+  open: null,
+  locked: null,
+  doorOpen: null,
+});
+
 class AccessProvider {
   /**
    * @param {Object} [options]
@@ -104,6 +114,41 @@ class AccessProvider {
    */
   constructor({ client = null } = {}) {
     this._client = client;
+  }
+
+  /**
+   * The LockStatus of a lock the provider knows nothing about.
+   *
+   * @returns {LockStatus}
+   */
+  static get unknownLockStatus() {
+    return UNKNOWN_LOCK_STATUS;
+  }
+
+  /**
+   * @protected
+   * The tenant's API client for an open attempt, whose failures are the
+   * guest's to see as a failure class: a tenant without an active
+   * application of this provider - the adapter's `_getClient` throws a
+   * `NotFoundError` for it - is a configuration failure, a tenant that
+   * cannot be read right now a temporary one.
+   *
+   * @param {string} tenant Tenant the access point belongs to
+   * @returns {Promise<Object>} The client `_getClient` builds
+   * @throws {AccessOpenError}
+   */
+  async _getClientForOpen(tenant) {
+    try {
+      return await this._getClient(tenant);
+    } catch (err) {
+      throw err instanceof NotFoundError
+        ? AccessOpenError.configuration(
+            `${this.constructor.name} is not set up for tenant '${tenant}': ${err.message}`,
+          )
+        : AccessOpenError.temporary(
+            `${this.constructor.name} could not read the application of tenant '${tenant}': ${err.message}`,
+          );
+    }
   }
 
   /**
@@ -168,10 +213,13 @@ class AccessProvider {
    * How far a pending open has come - only providers whose open answers
    * `pending` declare this.
    *
-   * @param {Object} accessPoint The access point that was opened
+   * @param {Object} accessPoint The access point that was opened; carries
+   *   `tenantId`, which is how the provider finds the tenant here - there
+   *   is no booking context on a poll
    * @param {string} openProcessId The process the open answered with
    * @returns {Promise<OpenProgress>} The progress; a failed poll is answered,
    *   not thrown, with `confirmed: null` and the provider's reason
+   * @throws {Error} Nothing of its own - a failed poll is an answer
    */
   async getOpenProgress(accessPoint, openProcessId) {
     throw new Error(
@@ -314,6 +362,8 @@ class AccessProvider {
    * @param {Object} _headers The request headers carrying the signature
    * @param {string|null} _secret The shared secret of the subscription
    * @returns {boolean} Whether the signature holds
+   * @throws {Error} Nothing of its own - a signature that does not hold is
+   *   `false`, not an error
    */
   verifyWebhookSignature(_rawPayload, _headers, _secret) {
     throw new Error(

--- a/src/commons/services/access/providers/access-provider.js
+++ b/src/commons/services/access/providers/access-provider.js
@@ -1,3 +1,100 @@
+/**
+ * The seam `AccessService` talks to a locking system through. Every adapter
+ * - NUKI, Salto KS, iFBS - extends this class, declares the methods it can
+ * honour in `capabilities`, and answers the result-bearing ones in the
+ * closed shapes declared below. The service branches on `capabilities`
+ * only, never on what an adapter happens to have as a method, and it never
+ * sees a raw provider answer: what an adapter cannot say in these shapes it
+ * does not say.
+ *
+ * `tests/access-provider-contract.test.js` runs every adapter against this
+ * contract.
+ */
+
+/**
+ * What an open did. A provider that opens synchronously answers `opened`
+ * with no process; one that only starts the open - iFBS hands the command
+ * to the box and confirms later - answers `pending` with the process to
+ * poll through {@link AccessProvider#getOpenProgress}.
+ *
+ * Invariant: `state === "pending"` exactly when `openProcessId !== null`.
+ *
+ * @typedef {Object} OpenOutcome
+ * @property {"opened"|"pending"} state
+ * @property {string|null} openProcessId
+ */
+
+/**
+ * The state of the lock as far as the provider knows it. `null` means the
+ * provider does not report this - not `false`. Nothing else: battery,
+ * alarms and usage windows are provider detail that stays behind the seam.
+ *
+ * @typedef {Object} LockStatus
+ * @property {boolean|null} open Whether the lock grants access right now
+ * @property {boolean|null} locked Whether the bolt is thrown
+ * @property {boolean|null} doorOpen Whether the door itself stands open,
+ *   where a sensor can tell
+ */
+
+/**
+ * How far a pending open has come. `confirmed` is `null` when the poll
+ * itself failed and the provider cannot say; `errorCode` and `errorMessage`
+ * then carry the provider's own reason.
+ *
+ * @typedef {Object} OpenProgress
+ * @property {boolean|null} confirmed
+ * @property {string|null} confirmedAt
+ * @property {string|number|null} errorCode
+ * @property {string|null} errorMessage
+ */
+
+/**
+ * The booking an access point is operated for, as `AccessService` resolves
+ * it. Adapters read what they need from it and write nothing back.
+ *
+ * @typedef {Object} BookingContext
+ * @property {string} tenant
+ * @property {string} bookingId
+ * @property {number} timeBegin
+ * @property {number} timeEnd
+ * @property {number} [accessFrom] Start of the access window, buffer included
+ * @property {number} [accessTo] End of the access window, buffer included
+ * @property {Object} [booking] The booking itself
+ * @property {string} [externalBookingId] The provider's own id of the
+ *   booking, where the provider - iFBS - books on its side
+ * @property {string} [pin] A PIN the caller chose for the grant
+ * @property {string|null} [authorizationId] The grant to revoke
+ */
+
+/**
+ * An access point as the provider lists it - the shape the sync stores.
+ *
+ * @typedef {Object} ListedAccessPoint
+ * @property {string} id
+ * @property {"door"|"locker"} type
+ * @property {string} provider
+ * @property {string} externalId
+ * @property {string|null} locationId
+ * @property {string} label
+ * @property {string[]} capabilities The point's own capabilities, e.g.
+ *   `remote`, `authorization`
+ * @property {string[]} supportedModes The access point modes the lock
+ *   really supports
+ * @property {Object} metadata The provider's own record of the lock
+ */
+
+/**
+ * A webhook event as the provider reports it, normalized to what the
+ * service routes on.
+ *
+ * @typedef {Object} WebhookEvent
+ * @property {string} provider
+ * @property {string} externalId
+ * @property {string|null} eventType
+ * @property {number|string} timestamp
+ * @property {Object} payload The event as it came in
+ */
+
 class AccessProvider {
   /**
    * @param {Object} [options]
@@ -9,41 +106,138 @@ class AccessProvider {
     this._client = client;
   }
 
+  /**
+   * Opens the access point for the booking: pulls the latch where the lock
+   * has one, releases the lock where it has not, hands the command to the
+   * box where the provider is a locker system.
+   *
+   * @param {Object} accessPoint The access point to open
+   * @param {BookingContext} bookingContext The booking it is opened for
+   * @returns {Promise<OpenOutcome>} What the open did
+   * @throws {AccessOpenError} Only ever this: `configuration` when the
+   *   tenant, the lock or its setup are not as they should be, `temporary`
+   *   for everything the provider or the network did not manage this time
+   */
   async open(accessPoint, bookingContext) {
     throw new Error(`open() is not supported by ${this.constructor.name}`);
   }
 
+  /**
+   * Locks the access point again. Answers nothing: the state after a close
+   * is what the lock says it is, and the service reads it through
+   * {@link AccessProvider#getStatus}.
+   *
+   * @param {Object} accessPoint The access point to close
+   * @param {BookingContext} bookingContext The booking it is closed for
+   * @returns {Promise<void>}
+   * @throws {Error} The provider's own error when the close did not go
+   *   through
+   */
   async close(accessPoint, bookingContext) {
     throw new Error(`close() is not supported by ${this.constructor.name}`);
   }
 
+  /**
+   * Pulls the latch so the door physically opens, instead of only releasing
+   * the lock. Where a lock can pull its latch, {@link AccessProvider#open}
+   * does so by itself; this is the older way to the same end.
+   *
+   * @param {Object} accessPoint The access point to unlatch
+   * @param {BookingContext} bookingContext The booking it is unlatched for
+   * @returns {Promise<OpenOutcome>} What the unlatch did
+   * @throws {AccessOpenError} As of {@link AccessProvider#open}
+   */
   async unlatch(accessPoint, bookingContext) {
     throw new Error(`unlatch() is not supported by ${this.constructor.name}`);
   }
 
+  /**
+   * The state of the lock right now.
+   *
+   * @param {Object} accessPoint The access point to read
+   * @param {BookingContext} bookingContext The booking it is read for
+   * @returns {Promise<LockStatus>} The state, `null` for whatever the
+   *   provider does not report
+   * @throws {Error} The provider's own error when the lock cannot be read
+   */
   async getStatus(accessPoint, bookingContext) {
     throw new Error(`getStatus() is not supported by ${this.constructor.name}`);
   }
 
+  /**
+   * How far a pending open has come - only providers whose open answers
+   * `pending` declare this.
+   *
+   * @param {Object} accessPoint The access point that was opened
+   * @param {string} openProcessId The process the open answered with
+   * @returns {Promise<OpenProgress>} The progress; a failed poll is answered,
+   *   not thrown, with `confirmed: null` and the provider's reason
+   */
+  async getOpenProgress(accessPoint, openProcessId) {
+    throw new Error(
+      `getOpenProgress() is not supported by ${this.constructor.name}`,
+    );
+  }
+
+  /**
+   * Grants the booking an authorization at the lock - a keypad code, a
+   * guest with a PIN - for its access window.
+   *
+   * @param {Object} accessPoint The access point to grant access to
+   * @param {BookingContext} bookingContext The booking that gets access;
+   *   `pin` is used when it brings one
+   * @returns {Promise<Object>} The grant, with at least `authorizationId`
+   *   and the `pin` the person at the door types
+   * @throws {Error} The provider's own error; the service rethrows it and
+   *   the provisioning job tries again
+   */
   async grantAuthorization(accessPoint, bookingContext) {
     throw new Error(
       `grantAuthorization() is not supported by ${this.constructor.name}`,
     );
   }
 
+  /**
+   * Takes the authorization back. A grant the provider no longer has is
+   * nothing to do, not a failure.
+   *
+   * @param {Object} accessPoint The access point the grant was made for
+   * @param {BookingContext} bookingContext The booking, with the
+   *   `authorizationId` to revoke
+   * @returns {Promise<Object>} The revocation
+   * @throws {Error} The provider's own error when the revoke did not go
+   *   through
+   */
   async revokeAuthorization(accessPoint, bookingContext) {
     throw new Error(
       `revokeAuthorization() is not supported by ${this.constructor.name}`,
     );
   }
 
+  /**
+   * Every access point the provider has for the tenant.
+   *
+   * @param {string} tenant Tenant to list for
+   * @returns {Promise<ListedAccessPoint[]>} The access points
+   * @throws {Error} The provider's own error when the listing fails
+   */
   async listAccessPoints(tenant) {
     throw new Error(
       `listAccessPoints() is not supported by ${this.constructor.name}`,
     );
   }
 
-  async getSupportedModes() {
+  /**
+   * The access point modes the lock really supports right now, as
+   * {@link AccessProvider#listAccessPoints} would list them.
+   *
+   * @param {Object} accessPoint The access point to ask about
+   * @param {string} tenant Tenant the access point belongs to
+   * @returns {Promise<string[]|null>} The modes, or `null` when the provider
+   *   does not list the access point
+   * @throws {Error} The provider's own error when the lock cannot be read
+   */
+  async getSupportedModes(accessPoint, tenant) {
     throw new Error(
       `getSupportedModes() is not supported by ${this.constructor.name}`,
     );
@@ -59,6 +253,7 @@ class AccessProvider {
    * @param {string} _tenant Tenant the access point belongs to
    * @returns {Promise<Object|null>} A `location` in the shape of
    *   `accessPoint.location`, or `null` when the provider knows no location
+   * @throws {Error} The provider's own error when the lock cannot be read
    */
   async getLocation(_accessPoint, _tenant) {
     throw new Error(
@@ -66,30 +261,72 @@ class AccessProvider {
     );
   }
 
+  /**
+   * Subscribes the tenant's account to events at the given URL.
+   *
+   * @param {string} tenant Tenant to subscribe for
+   * @param {string} callbackUrl Where the provider is to send events
+   * @returns {Promise<Object>} The provider's subscription record, whose
+   *   `id` is what {@link AccessProvider#unregisterWebhook} takes
+   * @throws {Error} The provider's own error when subscribing fails
+   */
   async registerWebhook(tenant, callbackUrl) {
     throw new Error(
       `registerWebhook() is not supported by ${this.constructor.name}`,
     );
   }
 
-  async unregisterWebhook(tenant) {
+  /**
+   * Ends a subscription. Without an id there is nothing to end.
+   *
+   * @param {string} tenant Tenant the subscription belongs to
+   * @param {string|null} id The subscription as
+   *   {@link AccessProvider#registerWebhook} answered it
+   * @returns {Promise<Object>} The provider's answer
+   * @throws {Error} The provider's own error when unsubscribing fails
+   */
+  async unregisterWebhook(tenant, id) {
     throw new Error(
       `unregisterWebhook() is not supported by ${this.constructor.name}`,
     );
   }
 
+  /**
+   * Reads an incoming event into the shape the service routes on.
+   *
+   * @param {string|Object} _rawPayload The request body, raw or parsed
+   * @param {Object} _headers The request headers
+   * @returns {WebhookEvent} The event
+   * @throws {SyntaxError} A raw body that is not JSON
+   */
   parseWebhook(_rawPayload, _headers) {
     throw new Error(
       `parseWebhook() is not supported by ${this.constructor.name}`,
     );
   }
 
+  /**
+   * Whether an incoming event really comes from the provider. Without a
+   * secret configured there is nothing to check against, and the event
+   * passes.
+   *
+   * @param {string|Object} _rawPayload The request body, raw or parsed
+   * @param {Object} _headers The request headers carrying the signature
+   * @param {string|null} _secret The shared secret of the subscription
+   * @returns {boolean} Whether the signature holds
+   */
   verifyWebhookSignature(_rawPayload, _headers, _secret) {
     throw new Error(
       `verifyWebhookSignature() is not supported by ${this.constructor.name}`,
     );
   }
 
+  /**
+   * The methods this provider honours. The service asks nothing it does not
+   * find here.
+   *
+   * @returns {string[]}
+   */
   static get capabilities() {
     return [];
   }

--- a/src/commons/services/access/providers/ifbs-access-provider.js
+++ b/src/commons/services/access/providers/ifbs-access-provider.js
@@ -2,6 +2,8 @@ const AccessProvider = require("./access-provider");
 const TenantManager = require("../../../data-managers/tenant-manager");
 const { createClient } = require("../../locker/clients/locker-client-registry");
 const IfbsApiError = require("../../locker/clients/ifbs-api-error");
+const { AccessOpenError } = require("../../../../errors/AccessOpenError");
+const { NotFoundError } = require("../../../../errors/BaseError");
 
 const APP_TYPE = "locker";
 
@@ -9,6 +11,8 @@ class IfbsAccessProvider extends AccessProvider {
   /**
    * Creates an iFBS API client for the given tenant.
    * @private
+   * @throws {NotFoundError} `ifbs_application_not_found` when the tenant
+   *   has no active iFBS application
    */
   async _getClient(tenant) {
     if (this._client) {
@@ -16,136 +20,137 @@ class IfbsAccessProvider extends AccessProvider {
     }
 
     const tenantData = await TenantManager.getTenant(tenant);
-    const rawApp = tenantData.applications.find(
+    const rawApp = tenantData?.applications?.find(
       (a) => a.type === APP_TYPE && a.id === "ifbs" && a.active,
     );
 
     if (!rawApp) {
-      throw new Error(
-        `No active locker application 'ifbs' found for tenant '${tenant}'`,
-      );
+      throw new NotFoundError("ifbs_application_not_found", { tenant });
     }
 
     return createClient(rawApp);
   }
 
+  /**
+   * @private
+   * The client for an open attempt, whose failures are the guest's to see
+   * as a failure class: no active iFBS application is a configuration
+   * failure, a tenant that cannot be read right now a temporary one.
+   *
+   * @param {string} tenant Tenant the locker belongs to
+   * @returns {Promise<Object>} The tenant's iFBS API client
+   * @throws {AccessOpenError}
+   */
+  async _getClientForOpen(tenant) {
+    try {
+      return await this._getClient(tenant);
+    } catch (err) {
+      throw err instanceof NotFoundError
+        ? AccessOpenError.configuration(
+            `No active locker application 'ifbs' found for tenant '${tenant}'`,
+          )
+        : AccessOpenError.temporary(
+            `iFBS application of tenant '${tenant}' could not be read: ${err.message}`,
+          );
+    }
+  }
+
+  /**
+   * Hands the open command to the box. iFBS confirms the open later, so the
+   * outcome is always `pending` with the `OpenBox_ID` to poll through
+   * {@link IfbsAccessProvider#getOpenProgress}.
+   *
+   * @param {Object} accessPoint The locker to open
+   * @param {Object} bookingContext The booking, with the iFBS
+   *   `externalBookingId` the box was booked under
+   * @returns {Promise<import("./access-provider").OpenOutcome>}
+   * @throws {AccessOpenError} `configuration` without an active iFBS
+   *   application; `temporary` for everything iFBS or the network did not
+   *   manage, an iFBS error number included - the box is booked either
+   *   way, so a refusal is nothing the admin can configure away
+   */
   async open(accessPoint, bookingContext) {
-    const client = await this._getClient(bookingContext.tenant);
-    const result = await client.openBox(bookingContext.externalBookingId);
-    return {
-      processId: result.Booking_ID,
-      openProcessId: result.OpenBox_ID,
-    };
-  }
+    const client = await this._getClientForOpen(bookingContext.tenant);
+    const bookingId = bookingContext.externalBookingId;
 
-  async close(accessPoint, bookingContext) {
-    const client = await this._getClient(bookingContext.tenant);
-    const result = await client.closeBox(bookingContext.externalBookingId);
-    return {
-      success: true,
-      state: "closed",
-      providerResponse: result,
-    };
-  }
-
-  async getStatus(accessPoint, bookingContext) {
-    const client = await this._getClient(bookingContext.tenant);
-    const usage = this._resolveUsageWindowStatus(bookingContext);
-
-    if (bookingContext.lastOpenBoxId) {
-      try {
-        const result = await client.monitorOpenBox(
-          bookingContext.lastOpenBoxId,
-        );
-
-        return {
-          ...this._mapOpenBoxStatus(result, { includeReceived: true }),
-          bookingId: bookingContext.externalBookingId,
-          usageState: usage.usageState,
-        };
-      } catch (err) {
-        if (!this._isOpenBoxProcessNotFound(err)) {
-          throw err;
-        }
-      }
+    let result;
+    try {
+      result = await client.openBox(bookingId);
+    } catch (err) {
+      throw err instanceof IfbsApiError
+        ? AccessOpenError.temporary(
+            `iFBS refused to open the box of booking '${bookingId}' (${err.errNo}): ${err.errMsg}`,
+          )
+        : AccessOpenError.temporary(
+            `iFBS open of booking '${bookingId}' failed: ${err.message}`,
+          );
     }
 
-    return usage;
+    return { state: "pending", openProcessId: String(result.OpenBox_ID) };
   }
 
-  async getOpenStatus(tenant, openBoxId) {
-    const client = await this._getClient(tenant);
+  /**
+   * What iFBS knows about the box: only whether the last open process it
+   * has for the booking was confirmed. iFBS confirms lock activation, not
+   * whether the door is physically open, and without a known process it
+   * knows nothing at all.
+   *
+   * @param {Object} accessPoint The locker to read
+   * @param {Object} bookingContext The booking, with `lastOpenBoxId` where
+   *   an open process is known
+   * @returns {Promise<import("./access-provider").LockStatus>}
+   */
+  async getStatus(accessPoint, bookingContext) {
+    const unknown = { open: null, locked: null, doorOpen: null };
+
+    if (!bookingContext.lastOpenBoxId) {
+      return unknown;
+    }
+
+    const client = await this._getClient(bookingContext.tenant);
 
     try {
-      const result = await client.waitForOpenBox(openBoxId, 30);
-      return this._mapOpenBoxStatus(result);
+      const result = await client.monitorOpenBox(bookingContext.lastOpenBoxId);
+
+      return result.BoxControlConfirmed === "true"
+        ? { open: true, locked: false, doorOpen: null }
+        : unknown;
+    } catch (err) {
+      if (this._isOpenBoxProcessNotFound(err)) {
+        return unknown;
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Waits up to 30 seconds for the box to confirm the open. A poll that
+   * fails - the process is unknown to iFBS, the API is unreachable - is
+   * answered with `confirmed: null` and the reason, never thrown: the person
+   * at the box keeps polling, and the reason is theirs to see.
+   *
+   * @param {Object} accessPoint The locker that was opened
+   * @param {string} openProcessId The `OpenBox_ID` the open answered with
+   * @returns {Promise<import("./access-provider").OpenProgress>}
+   */
+  async getOpenProgress(accessPoint, openProcessId) {
+    try {
+      const client = await this._getClient(accessPoint.tenantId);
+      const result = await client.waitForOpenBox(openProcessId, 30);
+      return {
+        confirmed: result.BoxControlConfirmed === "true",
+        confirmedAt: result.BoxControlConfirmedDateTime || null,
+        errorCode: null,
+        errorMessage: null,
+      };
     } catch (err) {
       return {
-        ...this._mapOpenBoxStatus({
-          OpenBox_ID: openBoxId,
-          BoxControlConfirmed: "false",
-        }),
+        confirmed: null,
+        confirmedAt: null,
         errorCode: err instanceof IfbsApiError ? err.errNo : null,
         errorMessage: err instanceof IfbsApiError ? err.errMsg : err.message,
       };
     }
-  }
-
-  /**
-   * Maps iFBS monitorOpenBox / waitForOpenBox fields to access status.
-   * The API confirms lock activation only — not whether the door is physically open.
-   * @private
-   */
-  _mapOpenBoxStatus(result, { includeReceived = false } = {}) {
-    const confirmed = result.BoxControlConfirmed === "true";
-    const received = result.BoxControlReceived === "true";
-
-    const status = {
-      openProcessId: result.OpenBox_ID ?? null,
-      confirmed,
-      confirmedAt: result.BoxControlConfirmedDateTime || null,
-      open: confirmed ? true : null,
-      state: confirmed ? "open" : received ? "opening" : "pending",
-    };
-
-    if (includeReceived) {
-      status.boxControlReceived = received;
-      status.receivedAt = result.BoxControlReceivedDateTime || null;
-    }
-
-    if (result.WaitTime != null) {
-      status.waitTime = result.WaitTime;
-    }
-
-    return status;
-  }
-
-  /**
-   * Derives booking usage window state when no OpenBox process is available.
-   * @private
-   */
-  _resolveUsageWindowStatus(bookingContext) {
-    const now = Date.now();
-    const accessFrom = bookingContext.accessFrom ?? bookingContext.timeBegin;
-    const accessTo = bookingContext.accessTo ?? bookingContext.timeEnd;
-
-    let usageState = "active";
-    if (accessFrom != null && now < accessFrom) {
-      usageState = "upcoming";
-    } else if (accessTo != null && now > accessTo) {
-      usageState = "expired";
-    }
-
-    return {
-      bookingId: bookingContext.externalBookingId,
-      usageState,
-      accessFrom,
-      accessTo,
-      open: null,
-      locked: null,
-      doorOpen: null,
-      state: usageState,
-    };
   }
 
   /** @private */
@@ -154,7 +159,9 @@ class IfbsAccessProvider extends AccessProvider {
   }
 
   static get capabilities() {
-    return ["open", "close", "getStatus", "getOpenStatus"];
+    // No close: iFBS has no command to close a box - the door of a locker
+    // is shut by hand.
+    return ["open", "getStatus", "getOpenProgress"];
   }
 }
 

--- a/src/commons/services/access/providers/ifbs-access-provider.js
+++ b/src/commons/services/access/providers/ifbs-access-provider.js
@@ -32,30 +32,6 @@ class IfbsAccessProvider extends AccessProvider {
   }
 
   /**
-   * @private
-   * The client for an open attempt, whose failures are the guest's to see
-   * as a failure class: no active iFBS application is a configuration
-   * failure, a tenant that cannot be read right now a temporary one.
-   *
-   * @param {string} tenant Tenant the locker belongs to
-   * @returns {Promise<Object>} The tenant's iFBS API client
-   * @throws {AccessOpenError}
-   */
-  async _getClientForOpen(tenant) {
-    try {
-      return await this._getClient(tenant);
-    } catch (err) {
-      throw err instanceof NotFoundError
-        ? AccessOpenError.configuration(
-            `No active locker application 'ifbs' found for tenant '${tenant}'`,
-          )
-        : AccessOpenError.temporary(
-            `iFBS application of tenant '${tenant}' could not be read: ${err.message}`,
-          );
-    }
-  }
-
-  /**
    * Hands the open command to the box. iFBS confirms the open later, so the
    * outcome is always `pending` with the `OpenBox_ID` to poll through
    * {@link IfbsAccessProvider#getOpenProgress}.
@@ -86,6 +62,12 @@ class IfbsAccessProvider extends AccessProvider {
           );
     }
 
+    if (result.OpenBox_ID == null) {
+      throw AccessOpenError.temporary(
+        `iFBS answered the open of booking '${bookingId}' without an OpenBox_ID`,
+      );
+    }
+
     return { state: "pending", openProcessId: String(result.OpenBox_ID) };
   }
 
@@ -101,7 +83,7 @@ class IfbsAccessProvider extends AccessProvider {
    * @returns {Promise<import("./access-provider").LockStatus>}
    */
   async getStatus(accessPoint, bookingContext) {
-    const unknown = { open: null, locked: null, doorOpen: null };
+    const unknown = AccessProvider.unknownLockStatus;
 
     if (!bookingContext.lastOpenBoxId) {
       return unknown;

--- a/src/commons/services/access/providers/nuki-access-provider.js
+++ b/src/commons/services/access/providers/nuki-access-provider.js
@@ -46,30 +46,6 @@ class NukiAccessProvider extends AccessProvider {
   }
 
   /**
-   * @private
-   * The client for an open attempt, whose failures are the guest's to see
-   * as a failure class: no active Nuki application is a configuration
-   * failure, a tenant that cannot be read right now a temporary one.
-   *
-   * @param {string} tenant Tenant the door belongs to
-   * @returns {Promise<Object>} The tenant's Nuki API client
-   * @throws {AccessOpenError}
-   */
-  async _getClientForOpen(tenant) {
-    try {
-      return await this._getClient(tenant);
-    } catch (err) {
-      throw err instanceof NotFoundError
-        ? AccessOpenError.configuration(
-            `No active access application '${PROVIDER_ID}' found for tenant '${tenant}'`,
-          )
-        : AccessOpenError.temporary(
-            `Nuki application of tenant '${tenant}' could not be read: ${err.message}`,
-          );
-    }
-  }
-
-  /**
    * Opens the access point: pulls the latch where the lock has one, releases
    * the lock where it has not. For the person at the door that is the
    * difference between "the door is open" and "it is unlocked, now push".

--- a/src/commons/services/access/providers/nuki-access-provider.js
+++ b/src/commons/services/access/providers/nuki-access-provider.js
@@ -7,6 +7,8 @@ const { NukiApiClient, NUKI_ACTIONS } = require("../clients/nuki-api-client");
 const {
   deriveSupportedModes,
 } = require("../../../entities/access/access-point");
+const { AccessOpenError } = require("../../../../errors/AccessOpenError");
+const { NotFoundError } = require("../../../../errors/BaseError");
 
 require("../clients");
 
@@ -19,6 +21,13 @@ const logger = bunyan.createLogger({
 });
 
 class NukiAccessProvider extends AccessProvider {
+  /**
+   * @private
+   * @param {string} tenant Tenant the client acts for
+   * @returns {Promise<Object>} The tenant's Nuki API client
+   * @throws {NotFoundError} `nuki_application_not_found` when the tenant
+   *   has no active Nuki application
+   */
   async _getClient(tenant) {
     if (this._client) {
       return this._client;
@@ -30,12 +39,34 @@ class NukiAccessProvider extends AccessProvider {
     );
 
     if (!rawApp) {
-      throw new Error(
-        `No active access application '${PROVIDER_ID}' found for tenant '${tenant}'`,
-      );
+      throw new NotFoundError("nuki_application_not_found", { tenant });
     }
 
     return createClient(rawApp);
+  }
+
+  /**
+   * @private
+   * The client for an open attempt, whose failures are the guest's to see
+   * as a failure class: no active Nuki application is a configuration
+   * failure, a tenant that cannot be read right now a temporary one.
+   *
+   * @param {string} tenant Tenant the door belongs to
+   * @returns {Promise<Object>} The tenant's Nuki API client
+   * @throws {AccessOpenError}
+   */
+  async _getClientForOpen(tenant) {
+    try {
+      return await this._getClient(tenant);
+    } catch (err) {
+      throw err instanceof NotFoundError
+        ? AccessOpenError.configuration(
+            `No active access application '${PROVIDER_ID}' found for tenant '${tenant}'`,
+          )
+        : AccessOpenError.temporary(
+            `Nuki application of tenant '${tenant}' could not be read: ${err.message}`,
+          );
+    }
   }
 
   /**
@@ -49,25 +80,20 @@ class NukiAccessProvider extends AccessProvider {
    * cannot pull its latch is asked to unlock right away, so nobody waits out a
    * failed action in front of the door.
    *
+   * Nuki carries the action out before it answers, so the outcome is
+   * always `opened` and there is no process to poll.
+   *
    * @param {Object} accessPoint The access point to open
    * @param {Object} bookingContext The booking the door is opened for
-   * @returns {Promise<Object>} The provider's answer to the action
+   * @returns {Promise<import("./access-provider").OpenOutcome>}
    */
   async open(accessPoint, bookingContext) {
-    const client = await this._getClient(bookingContext.tenant);
+    const client = await this._getClientForOpen(bookingContext.tenant);
     const action = (await this._hasLatch(client, accessPoint))
       ? NUKI_ACTIONS.UNLATCH
       : NUKI_ACTIONS.UNLOCK;
-    const providerResponse = await client.executeAction(
-      accessPoint.externalId,
-      action,
-    );
 
-    return {
-      success: true,
-      state: "open",
-      providerResponse,
-    };
+    return this._executeOpenAction(client, accessPoint, action);
   }
 
   /**
@@ -98,38 +124,84 @@ class NukiAccessProvider extends AccessProvider {
 
   async close(accessPoint, bookingContext) {
     const client = await this._getClient(bookingContext.tenant);
-    const providerResponse = await client.executeAction(
-      accessPoint.externalId,
-      NUKI_ACTIONS.LOCK,
-    );
-
-    return {
-      success: true,
-      state: "closed",
-      providerResponse,
-    };
+    await client.executeAction(accessPoint.externalId, NUKI_ACTIONS.LOCK);
   }
 
-  // Pulls the latch so the door physically opens, instead of only releasing
-  // the lock (unlock). Requires a Nuki actor that is mounted on a door with a
-  // latch (i.e. not an Opener/Box).
+  /**
+   * Pulls the latch so the door physically opens, instead of only releasing
+   * the lock (unlock). Requires a Nuki actor that is mounted on a door with
+   * a latch (i.e. not an Opener/Box).
+   *
+   * @param {Object} accessPoint The access point to unlatch
+   * @param {Object} bookingContext The booking the door is unlatched for
+   * @returns {Promise<import("./access-provider").OpenOutcome>}
+   */
   async unlatch(accessPoint, bookingContext) {
-    const client = await this._getClient(bookingContext.tenant);
-    const providerResponse = await client.executeAction(
-      accessPoint.externalId,
-      NUKI_ACTIONS.UNLATCH,
-    );
+    const client = await this._getClientForOpen(bookingContext.tenant);
 
-    return {
-      success: true,
-      state: "open",
-      providerResponse,
-    };
+    return this._executeOpenAction(client, accessPoint, NUKI_ACTIONS.UNLATCH);
   }
 
+  /**
+   * @private
+   * Sends the action that opens the door and turns whatever Nuki answers
+   * into the failure class the guest may see: a smartlock Nuki does not
+   * know or a token it refuses are configuration, everything else - the
+   * lock offline, Nuki down, the network - is temporary.
+   *
+   * @param {Object} client The tenant's Nuki API client
+   * @param {Object} accessPoint The access point being opened
+   * @param {number} action The Nuki action to send
+   * @returns {Promise<import("./access-provider").OpenOutcome>}
+   * @throws {AccessOpenError}
+   */
+  async _executeOpenAction(client, accessPoint, action) {
+    try {
+      await client.executeAction(accessPoint.externalId, action);
+    } catch (err) {
+      throw this._mapOpenError(err, accessPoint);
+    }
+
+    return { state: "opened", openProcessId: null };
+  }
+
+  /** @private */
+  _mapOpenError(err, accessPoint) {
+    const status = err?.response?.status;
+    const detail = err.message || String(err);
+
+    if (status === 404) {
+      return AccessOpenError.configuration(
+        `Nuki does not know smartlock '${accessPoint.externalId}': ${detail}`,
+      );
+    }
+
+    if (status === 401 || status === 403) {
+      return AccessOpenError.configuration(
+        `Nuki refused the action on smartlock '${accessPoint.externalId}' - check the API token: ${detail}`,
+      );
+    }
+
+    return AccessOpenError.temporary(
+      `Nuki open of smartlock '${accessPoint.externalId}' failed: ${detail}`,
+    );
+  }
+
+  /**
+   * The lock's state as the Nuki Web API reports it, reduced to the three
+   * questions of a LockStatus: `open` is whether the lock currently grants
+   * access (unlocked, unlatched, lock'n'go), `locked` whether the bolt is
+   * thrown, `doorOpen` what the door sensor says where there is one.
+   *
+   * @param {Object} accessPoint The access point to read
+   * @param {Object} bookingContext The booking it is read for
+   * @returns {Promise<import("./access-provider").LockStatus>}
+   */
   async getStatus(accessPoint, bookingContext) {
     const client = await this._getClient(bookingContext.tenant);
-    return client.getSmartlockState(accessPoint.externalId);
+    const state = await client.getSmartlockState(accessPoint.externalId);
+
+    return { open: state.open, locked: state.locked, doorOpen: state.doorOpen };
   }
 
   async grantAuthorization(accessPoint, bookingContext) {
@@ -242,13 +314,13 @@ class NukiAccessProvider extends AccessProvider {
     return client.registerNotification(callbackUrl);
   }
 
-  async unregisterWebhook(tenant, notificationId) {
-    if (!notificationId) {
+  async unregisterWebhook(tenant, id) {
+    if (!id) {
       return { success: true, skipped: true, reason: "missing notificationId" };
     }
 
     const client = await this._getClient(tenant);
-    return client.unregisterNotification(notificationId);
+    return client.unregisterNotification(id);
   }
 
   parseWebhook(rawPayload, _headers = {}) {

--- a/src/commons/services/access/providers/salto-ks-access-provider.js
+++ b/src/commons/services/access/providers/salto-ks-access-provider.js
@@ -8,6 +8,7 @@ const {
 const SaltoKsIqActivationService = require("../salto-ks-iq-activation-service");
 const { AccessPointMode } = require("../../../entities/access/access-point");
 const { AccessOpenError } = require("../../../../errors/AccessOpenError");
+const { NotFoundError } = require("../../../../errors/BaseError");
 
 require("../clients");
 
@@ -47,6 +48,12 @@ class SaltoKsAccessProvider extends AccessProvider {
    * from the caller - and at most one OTP is spent per attempt: a rejection
    * is booked and reported, not retried with a fresh computation.
    *
+   * Salto opens the lock before it answers, so the outcome is always
+   * `opened` and there is no process to poll.
+   *
+   * @param {Object} accessPoint The access point to open
+   * @param {Object} bookingContext The booking the door is opened for
+   * @returns {Promise<import("./access-provider").OpenOutcome>}
    * @throws {AccessOpenError} With the failure class the guest may see;
    *   the message carries the Salto detail for the audit log.
    */
@@ -54,6 +61,27 @@ class SaltoKsAccessProvider extends AccessProvider {
     const tenant = bookingContext.tenant;
     const lockId = String(accessPoint.externalId);
 
+    try {
+      return await this._open(tenant, lockId);
+    } catch (err) {
+      if (err instanceof AccessOpenError) {
+        throw err;
+      }
+      throw this._mapClientError(err, tenant, lockId);
+    }
+  }
+
+  /**
+   * @private
+   * The open attempt itself; every failure of it is classified by the
+   * caller. Only the locking call has a mapping of its own, because only
+   * there an OTP can be rejected and has to be booked on the IQ.
+   *
+   * @param {string} tenant Tenant the lock belongs to
+   * @param {string} lockId The Salto id of the lock
+   * @returns {Promise<import("./access-provider").OpenOutcome>}
+   */
+  async _open(tenant, lockId) {
     // A lock whose IQ is already known can be refused - backoff after
     // otp_blocked, missing activation - without any Salto call (§4/§7 of the
     // spec). When this passes, the attempt continues on live data.
@@ -105,9 +133,8 @@ class SaltoKsAccessProvider extends AccessProvider {
       ? await SaltoKsIqActivationService.resolveOtpForOpen(tenant, iq)
       : { otp: null };
 
-    let providerResponse;
     try {
-      providerResponse = await client.openLock(lockId, { otp });
+      await client.openLock(lockId, { otp });
     } catch (err) {
       throw await this._mapOpenError(err, tenant, iq);
     }
@@ -116,11 +143,7 @@ class SaltoKsAccessProvider extends AccessProvider {
       await SaltoKsIqActivationService.recordOpenSuccess(tenant, iq.id);
     }
 
-    return {
-      success: true,
-      state: "open",
-      providerResponse,
-    };
+    return { state: "opened", openProcessId: null };
   }
 
   /**
@@ -155,6 +178,43 @@ class SaltoKsAccessProvider extends AccessProvider {
     return AccessOpenError.temporary(`Salto KS open failed: ${detail}`);
   }
 
+  /**
+   * @private
+   * Everything that fails on the way to the locking call - reading the
+   * tenant's application, listing locks and IQs - as the failure class the
+   * guest may see: no Salto application and a refused system user are
+   * configuration, the rest is temporary.
+   */
+  _mapClientError(err, tenant, lockId) {
+    const detail = err.message || String(err);
+
+    if (err instanceof NotFoundError) {
+      return AccessOpenError.configuration(
+        `No active Salto KS application found for tenant '${tenant}': ${detail}`,
+      );
+    }
+
+    if (classifySaltoError(err) === "forbidden") {
+      return AccessOpenError.configuration(
+        `Salto KS refused to read lock '${lockId}' - check the system user's rights: ${detail}`,
+      );
+    }
+
+    return AccessOpenError.temporary(
+      `Salto KS could not be read for lock '${lockId}': ${detail}`,
+    );
+  }
+
+  /**
+   * The lock's state from the site's lock listing: `locked_state` is the
+   * only thing Salto says about the bolt, and it says nothing about the
+   * door itself. A lock Salto does not list, or lists without a state, is
+   * unknown on every count.
+   *
+   * @param {Object} accessPoint The access point to read
+   * @param {Object} bookingContext The booking it is read for
+   * @returns {Promise<import("./access-provider").LockStatus>}
+   */
   async getStatus(accessPoint, bookingContext) {
     const client = await this._getClient(bookingContext.tenant);
     const locks = await client.getLocks();
@@ -165,22 +225,15 @@ class SaltoKsAccessProvider extends AccessProvider {
 
     const lockedState = lock?.locked_state ?? null;
 
-    return {
-      lockId: String(accessPoint.externalId),
-      name: lock?.customer_reference || "",
-      online: lock?.online ?? null,
-      state:
-        lockedState === "locked"
-          ? "locked"
-          : lockedState === "unlocked"
-            ? "unlocked"
-            : null,
-      lockedState,
-      batteryLevel: lock?.battery_level ?? null,
-      batteryCritical: lock?.battery_level === "critical" ? true : null,
-      leftOpenAlarm: lock?.left_open_alarm ?? null,
-      intrusionAlarm: lock?.intrusion_alarm ?? null,
-    };
+    if (lockedState === "locked") {
+      return { open: false, locked: true, doorOpen: null };
+    }
+
+    if (lockedState === "unlocked") {
+      return { open: true, locked: false, doorOpen: null };
+    }
+
+    return { open: null, locked: null, doorOpen: null };
   }
 
   async grantAuthorization(accessPoint, bookingContext) {
@@ -389,16 +442,16 @@ class SaltoKsAccessProvider extends AccessProvider {
     return client.subscribeNotifications(callbackUrl);
   }
 
-  async unregisterWebhook(tenant, subscriptionId) {
-    if (!subscriptionId) {
+  async unregisterWebhook(tenant, id) {
+    if (!id) {
       return { success: true, skipped: true, reason: "missing subscriptionId" };
     }
 
     const client = await this._getClient(tenant);
-    return client.unsubscribeNotifications(subscriptionId);
+    return client.unsubscribeNotifications(id);
   }
 
-  parseWebhook(rawPayload) {
+  parseWebhook(rawPayload, _headers = {}) {
     const payload =
       typeof rawPayload === "string" ? JSON.parse(rawPayload) : rawPayload;
 

--- a/src/commons/services/access/providers/salto-ks-access-provider.js
+++ b/src/commons/services/access/providers/salto-ks-access-provider.js
@@ -62,7 +62,7 @@ class SaltoKsAccessProvider extends AccessProvider {
     const lockId = String(accessPoint.externalId);
 
     try {
-      return await this._open(tenant, lockId);
+      return await this._attemptOpen(tenant, lockId);
     } catch (err) {
       if (err instanceof AccessOpenError) {
         throw err;
@@ -81,7 +81,7 @@ class SaltoKsAccessProvider extends AccessProvider {
    * @param {string} lockId The Salto id of the lock
    * @returns {Promise<import("./access-provider").OpenOutcome>}
    */
-  async _open(tenant, lockId) {
+  async _attemptOpen(tenant, lockId) {
     // A lock whose IQ is already known can be refused - backoff after
     // otp_blocked, missing activation - without any Salto call (§4/§7 of the
     // spec). When this passes, the attempt continues on live data.
@@ -233,7 +233,7 @@ class SaltoKsAccessProvider extends AccessProvider {
       return { open: true, locked: false, doorOpen: null };
     }
 
-    return { open: null, locked: null, doorOpen: null };
+    return AccessProvider.unknownLockStatus;
   }
 
   async grantAuthorization(accessPoint, bookingContext) {

--- a/tests/access-open.test.js
+++ b/tests/access-open.test.js
@@ -6,6 +6,7 @@ const {
   ACCESS_BLOCKING_REASONS,
 } = require("../src/commons/services/access/access-blocking-reasons");
 const AccessLogService = require("../src/commons/services/access/access-log-service");
+const AccessProvider = require("../src/commons/services/access/providers/access-provider");
 const AccessController = require("../src/platform/api/controllers/access-controller");
 const BookingManager = require("../src/commons/data-managers/booking-manager");
 const AccessPointManager = require("../src/commons/data-managers/access-point-manager");
@@ -22,21 +23,20 @@ const { ForbiddenError } = require("../src/errors/BaseError");
 const MINUTE = 60 * 1000;
 const TEST_PROVIDER = "test-open-provider";
 
-let providerOpen = async () => ({});
-let providerUnlatch = async () => ({ success: true, state: "open" });
+let providerOpen = async () => ({ state: "opened", openProcessId: null });
+let providerUnlatch = async () => ({ state: "opened", openProcessId: null });
 let providerStatus = async () => ({
-  state: "locked",
-  providerResponse: { raw: true },
+  open: false,
+  locked: true,
+  doorOpen: null,
 });
 
-class TestOpenProvider {
+class TestOpenProvider extends AccessProvider {
   async open(accessPoint, context) {
     return providerOpen(accessPoint, context);
   }
 
-  async close() {
-    return { success: true, state: "closed", providerResponse: { raw: true } };
-  }
+  async close() {}
 
   async unlatch(accessPoint, context) {
     return providerUnlatch(accessPoint, context);
@@ -44,6 +44,10 @@ class TestOpenProvider {
 
   async getStatus(accessPoint, context) {
     return providerStatus(accessPoint, context);
+  }
+
+  static get capabilities() {
+    return ["open", "close", "unlatch", "getStatus"];
   }
 }
 
@@ -152,7 +156,7 @@ describe("AccessService.open", () => {
     sandbox = sinon.createSandbox();
     providerOpen = sandbox
       .stub()
-      .resolves({ processId: 42, openProcessId: 99 });
+      .resolves({ state: "pending", openProcessId: "99" });
     sandbox.stub(AccessLogService, "log").resolves();
     sandbox.stub(PermissionsService, "_isOwner").returns(true);
   });
@@ -186,7 +190,7 @@ describe("AccessService.open", () => {
   it("answers an open that is already done with no process to poll", async () => {
     const booking = createBooking();
     stubResolvedDoor(sandbox, booking);
-    providerOpen.resolves({ success: true, state: "open" });
+    providerOpen.resolves({ state: "opened", openProcessId: null });
 
     const outcome = await AccessService.open(
       "tenant-1",
@@ -208,8 +212,8 @@ describe("AccessService.open", () => {
     await AccessService.open("tenant-1", "booking-1", "door-1", "user-1");
 
     expect(AccessLogService.log.firstCall.args[0].payload).to.include({
-      processId: 42,
-      openProcessId: 99,
+      state: "pending",
+      openProcessId: "99",
     });
   });
 
@@ -593,10 +597,10 @@ describe("AccessService close, unlatch and status with validation rules", () => 
     sandbox = sinon.createSandbox();
     providerUnlatch = sandbox
       .stub()
-      .resolves({ success: true, state: "open", openProcessId: "77" });
+      .resolves({ state: "pending", openProcessId: "77" });
     providerStatus = sandbox
       .stub()
-      .resolves({ state: "locked", providerResponse: { raw: true } });
+      .resolves({ open: false, locked: true, doorOpen: null });
     sandbox.stub(AccessLogService, "log").resolves();
     // Ownership is left to the data: the booking is assigned to "user-1".
     stubResolvedDoor(sandbox, createBooking(), {
@@ -641,7 +645,9 @@ describe("AccessService close, unlatch and status with validation rules", () => 
   });
 
   it("does not claim the lock turned before the lock says so", async () => {
-    providerStatus = sandbox.stub().resolves({ state: "unlocked" });
+    providerStatus = sandbox
+      .stub()
+      .resolves({ open: true, locked: false, doorOpen: null });
 
     const result = await AccessService.close(
       "tenant-1",
@@ -775,9 +781,10 @@ describe("AccessService close, unlatch and status with validation rules", () => 
   it("keeps the provider's own status answer in the audit log", async () => {
     await AccessService.getStatus("tenant-1", "booking-1", "door-1");
 
-    expect(AccessLogService.log.firstCall.args[0].payload).to.deep.include({
-      state: "locked",
-      providerResponse: { raw: true },
+    expect(AccessLogService.log.firstCall.args[0].payload).to.deep.equal({
+      open: false,
+      locked: true,
+      doorOpen: null,
     });
   });
 

--- a/tests/access-provider-contract.test.js
+++ b/tests/access-provider-contract.test.js
@@ -6,7 +6,6 @@
  *
  * Cases the Provider-Outcomes spec promises but which only hold after the
  * seam is typed are `it.skip` with the ticket that makes them true:
- * (2) OpenOutcome, LockStatus, OpenProgress and the error contract;
  * (3) Grant and Revocation. The spec lives with the effort's map, not in
  * the repo.
  */
@@ -79,10 +78,7 @@ function parameterNames(fn) {
  * Each implementation carries `today`: the facts about its dialect that the
  * active cases pin as they are now, and that the typed seam changes. They
  * choose between `it` and `it.skip` per implementation until then.
- *   openNamesProcess  the open answer carries an open process to poll
- *   mapsClientErrors  a broken client ends in an AccessOpenError
  *   revokeIdempotent  a second revoke of the same grant does not throw
- *   arityDrift        capabilities whose parameter count differs from the base
  */
 const IMPLEMENTATIONS = [
   {
@@ -109,10 +105,7 @@ const IMPLEMENTATIONS = [
       return new NukiAccessProvider({ client: brokenNukiApiClient() });
     },
     today: {
-      openNamesProcess: false,
-      mapsClientErrors: false,
       revokeIdempotent: false,
-      arityDrift: ["getSupportedModes", "unregisterWebhook"],
     },
   },
   {
@@ -142,10 +135,7 @@ const IMPLEMENTATIONS = [
       return new SaltoKsAccessProvider({ client: brokenSaltoKsApiClient() });
     },
     today: {
-      openNamesProcess: false,
-      mapsClientErrors: false,
       revokeIdempotent: false,
-      arityDrift: ["getSupportedModes", "unregisterWebhook", "parseWebhook"],
     },
   },
   {
@@ -170,10 +160,7 @@ const IMPLEMENTATIONS = [
       return new IfbsAccessProvider({ client: brokenIfbsApiClient() });
     },
     today: {
-      openNamesProcess: true,
-      mapsClientErrors: false,
       revokeIdempotent: false,
-      arityDrift: [],
     },
   },
   {
@@ -202,12 +189,7 @@ const IMPLEMENTATIONS = [
       return new InMemoryAccessProvider({ broken: true });
     },
     today: {
-      openNamesProcess: false,
-      mapsClientErrors: true,
       revokeIdempotent: true,
-      // The base class is what drifts here: it declares `getSupportedModes()`
-      // without the parameters every adapter takes.
-      arityDrift: ["getSupportedModes"],
     },
   },
 ];
@@ -244,19 +226,7 @@ for (const implementation of IMPLEMENTATIONS) {
       }
     });
 
-    it("drifts from the base class in parameter count exactly where it does today", function () {
-      const base = AccessProvider.prototype;
-      const drift = capabilities.filter(
-        (capability) =>
-          typeof base[capability] === "function" &&
-          parameterNames(base[capability]).length !==
-            parameterNames(provider[capability]).length,
-      );
-
-      assert.deepStrictEqual(drift, today.arityDrift);
-    });
-
-    it.skip("agrees with the base class in the parameter list of every capability (2)", function () {
+    it("agrees with the base class in the parameter list of every capability", function () {
       const base = AccessProvider.prototype;
       for (const capability of capabilities) {
         assert.deepStrictEqual(
@@ -310,27 +280,7 @@ for (const implementation of IMPLEMENTATIONS) {
       },
     );
 
-    when("open")("opens and answers with a plain object", async function () {
-      const outcome = await provider.open(accessPoint, bookingContext);
-
-      assert.strictEqual(typeof outcome, "object");
-      assert.notStrictEqual(outcome, null);
-    });
-
-    when("open")(
-      "names an open process only where the provider opens asynchronously",
-      async function () {
-        const outcome = await provider.open(accessPoint, bookingContext);
-
-        if (today.openNamesProcess) {
-          assert.ok(outcome.openProcessId != null);
-        } else {
-          assert.strictEqual(outcome.openProcessId ?? null, null);
-        }
-      },
-    );
-
-    it.skip("answers an open with an OpenOutcome (2)", async function () {
+    when("open")("answers an open with an OpenOutcome", async function () {
       const outcome = await provider.open(accessPoint, bookingContext);
 
       assert.deepStrictEqual(Object.keys(outcome).sort(), [
@@ -342,40 +292,78 @@ for (const implementation of IMPLEMENTATIONS) {
         outcome.state === "pending",
         outcome.openProcessId !== null,
       );
-    });
-
-    when("getStatus")("reads the status without throwing", async function () {
-      const status = await provider.getStatus(accessPoint, bookingContext);
-
-      assert.strictEqual(typeof status, "object");
-    });
-
-    it.skip("answers the status as a LockStatus of booleans or null (2)", async function () {
-      const status = await provider.getStatus(accessPoint, bookingContext);
-
-      assert.deepStrictEqual(Object.keys(status).sort(), [
-        "doorOpen",
-        "locked",
-        "open",
-      ]);
-      for (const value of Object.values(status)) {
-        assert.ok(value === null || typeof value === "boolean");
+      if (outcome.openProcessId !== null) {
+        assert.strictEqual(typeof outcome.openProcessId, "string");
       }
     });
 
-    it.skip("answers the progress of an open process as an OpenProgress (2)", async function () {
-      const outcome = await provider.open(accessPoint, bookingContext);
-      const progress = await provider.getOpenProgress(
-        accessPoint,
-        outcome.openProcessId,
-      );
+    when("unlatch")(
+      "answers an unlatch with an OpenOutcome",
+      async function () {
+        const outcome = await provider.unlatch(accessPoint, bookingContext);
 
-      assert.deepStrictEqual(Object.keys(progress).sort(), [
-        "confirmed",
-        "confirmedAt",
-        "errorCode",
-        "errorMessage",
-      ]);
+        assert.deepStrictEqual(Object.keys(outcome).sort(), [
+          "openProcessId",
+          "state",
+        ]);
+        assert.strictEqual(
+          outcome.state === "pending",
+          outcome.openProcessId !== null,
+        );
+      },
+    );
+
+    when("getStatus")(
+      "answers the status as a LockStatus of booleans or null",
+      async function () {
+        const status = await provider.getStatus(accessPoint, bookingContext);
+
+        assert.deepStrictEqual(Object.keys(status).sort(), [
+          "doorOpen",
+          "locked",
+          "open",
+        ]);
+        for (const value of Object.values(status)) {
+          assert.ok(value === null || typeof value === "boolean");
+        }
+      },
+    );
+
+    when("getOpenProgress")(
+      "answers the progress of an open process as an OpenProgress",
+      async function () {
+        const outcome = await provider.open(accessPoint, bookingContext);
+        const progress = await provider.getOpenProgress(
+          accessPoint,
+          outcome.openProcessId,
+        );
+
+        assert.deepStrictEqual(Object.keys(progress).sort(), [
+          "confirmed",
+          "confirmedAt",
+          "errorCode",
+          "errorMessage",
+        ]);
+        assert.ok([true, false, null].includes(progress.confirmed));
+      },
+    );
+
+    when("getOpenProgress")(
+      "answers a failed poll with the reason instead of throwing",
+      async function () {
+        const broken = implementation.createBroken();
+
+        const progress = await broken.getOpenProgress(accessPoint, "1");
+
+        assert.strictEqual(progress.confirmed, null);
+        assert.strictEqual(typeof progress.errorMessage, "string");
+      },
+    );
+
+    when("close")("closes and answers nothing", async function () {
+      const answer = await provider.close(accessPoint, bookingContext);
+
+      assert.strictEqual(answer, undefined);
     });
 
     when("grantAuthorization")(
@@ -462,18 +450,36 @@ for (const implementation of IMPLEMENTATIONS) {
       assert.ok([true, false, null].includes(revocation.principalRemoved));
     });
 
-    (declares("open") && today.mapsClientErrors ? it : it.skip)(
-      "fails an open on a broken client with an AccessOpenError, never a raw error (2)",
+    when("open")(
+      "fails an open on a broken client with an AccessOpenError, never a raw error",
       async function () {
         const broken = implementation.createBroken();
 
         await assert.rejects(
           () => broken.open(accessPoint, bookingContext),
           (error) => {
-            assert.ok(error instanceof AccessOpenError);
+            assert.ok(
+              error instanceof AccessOpenError,
+              `expected an AccessOpenError, got ${error.constructor.name}: ${error.message}`,
+            );
             assert.ok(
               ["configuration", "temporary"].includes(error.failureClass),
             );
+            return true;
+          },
+        );
+      },
+    );
+
+    when("unlatch")(
+      "fails an unlatch on a broken client with an AccessOpenError, never a raw error",
+      async function () {
+        const broken = implementation.createBroken();
+
+        await assert.rejects(
+          () => broken.unlatch(accessPoint, bookingContext),
+          (error) => {
+            assert.ok(error instanceof AccessOpenError);
             return true;
           },
         );

--- a/tests/access-provider-dialects.test.js
+++ b/tests/access-provider-dialects.test.js
@@ -168,6 +168,10 @@ describe("access provider dialects: the adapters as they answer", () => {
       provider = new NukiAccessProvider({ client: clients.nuki });
     });
 
+    afterEach(() => {
+      sinon.restore();
+    });
+
     it("answers an open as opened, with no process to poll", async () => {
       const outcome = await provider.open(NUKI_DOOR, doorContext());
 
@@ -288,15 +292,11 @@ describe("access provider dialects: the adapters as they answer", () => {
       sinon.stub(TenantManager, "getTenant").resolves(tenantWithSaltoApp());
       const unconfigured = new NukiAccessProvider();
 
-      try {
-        await rejectsOpen(
-          unconfigured.open(NUKI_DOOR, doorContext()),
-          "configuration",
-          "No active access application 'nuki'",
-        );
-      } finally {
-        sinon.restore();
-      }
+      await rejectsOpen(
+        unconfigured.open(NUKI_DOOR, doorContext()),
+        "configuration",
+        "nuki_application_not_found",
+      );
     });
   });
 

--- a/tests/access-provider-dialects.test.js
+++ b/tests/access-provider-dialects.test.js
@@ -1,11 +1,13 @@
 /**
- * Characterization of the access provider seam as it is today: the three
- * dialects NUKI, Salto KS and iFBS answer in, and what `AccessService` makes
- * of them - the sniffing in `_resolveOpen`/`_resolveLocked`, the fields that
- * land in `accessInfo`, how revoke failures are treated. Nothing here is the
- * target contract; every expectation is the observed behaviour, pinned so
- * that typing the seam (Provider-Outcomes tickets 2 and 3) changes it on
- * purpose, never by accident.
+ * Characterization of the access provider seam: how NUKI, Salto KS and iFBS
+ * answer, and what `AccessService` makes of it. The result-bearing methods
+ * - open, unlatch, close, getStatus, getOpenProgress - answer in the typed
+ * shapes of `access-provider.js` and every open failure is an
+ * `AccessOpenError` (Provider-Outcomes ticket 2); the expectations on those
+ * are the contract. Grants and revocations still answer in each provider's
+ * own dialect, and what lands in `accessInfo` follows it - those
+ * expectations are the observed behaviour, pinned so that ticket 3 changes
+ * it on purpose, never by accident.
  *
  * The adapters run for real over fake API clients that replace only the
  * HTTP transport (`tests/helpers/fake-*-api-client.js`). The target contract
@@ -48,6 +50,7 @@ const { AccessOpenError } = require("../src/errors/AccessOpenError");
 const {
   FakeNukiApiClient,
   brokenNukiApiClient,
+  nukiHttpError,
 } = require("./helpers/fake-nuki-api-client");
 const {
   FakeSaltoKsApiClient,
@@ -132,6 +135,16 @@ function rejects(promise, ErrorClass, message) {
   });
 }
 
+/** Asserts a rejection with an AccessOpenError of the given failure class. */
+function rejectsOpen(promise, failureClass, message = "") {
+  return assert.rejects(promise, (error) => {
+    expect(error).to.be.instanceOf(AccessOpenError);
+    expect(error.failureClass).to.equal(failureClass);
+    expect(error.message).to.include(message);
+    return true;
+  });
+}
+
 /** Asserts a rejection with a client error the adapter did not map. */
 function rejectsRaw(promise, check) {
   return assert.rejects(promise, (error) => {
@@ -141,7 +154,7 @@ function rejectsRaw(promise, check) {
   });
 }
 
-describe("access provider dialects: the adapters as they answer today", () => {
+describe("access provider dialects: the adapters as they answer", () => {
   let clients;
 
   beforeEach(() => {
@@ -155,44 +168,37 @@ describe("access provider dialects: the adapters as they answer today", () => {
       provider = new NukiAccessProvider({ client: clients.nuki });
     });
 
-    it("answers an open with a fixed success and the raw provider response", async () => {
+    it("answers an open as opened, with no process to poll", async () => {
       const outcome = await provider.open(NUKI_DOOR, doorContext());
 
-      expect(outcome).to.deep.equal({
-        success: true,
-        state: "open",
-        providerResponse: "",
-      });
+      expect(outcome).to.deep.equal({ state: "opened", openProcessId: null });
       expect(clients.nuki.actions).to.deep.equal([
         { smartlockId: "1001", action: NUKI_ACTIONS.UNLATCH },
       ]);
     });
 
-    it("answers the status as the client's own smartlock state, unmapped", async () => {
+    it("answers the status as a LockStatus read off the smartlock state", async () => {
       const status = await provider.getStatus(NUKI_DOOR, doorContext());
 
-      expect(Object.keys(status).sort()).to.deep.equal([
-        "batteryCharge",
-        "batteryCharging",
-        "batteryCritical",
-        "doorOpen",
-        "doorSensorState",
-        "doorStateCode",
-        "lockState",
-        "lockStateCode",
-        "locked",
-        "name",
-        "open",
-        "providerResponse",
-        "serverState",
-        "smartlockId",
-        "state",
-      ]);
-      expect(status).to.include({
-        smartlockId: "1001",
-        locked: true,
+      expect(status).to.deep.equal({
         open: false,
-        lockState: "locked",
+        locked: true,
+        doorOpen: null,
+      });
+    });
+
+    it("answers a smartlock without a state as unknown on every count", async () => {
+      provider = new NukiAccessProvider({
+        client: new FakeNukiApiClient({
+          smartlocks: [nukiSmartlock({ state: undefined })],
+        }),
+      });
+
+      const status = await provider.getStatus(NUKI_DOOR, doorContext());
+
+      expect(status).to.deep.equal({
+        open: null,
+        locked: null,
         doorOpen: null,
       });
     });
@@ -256,12 +262,41 @@ describe("access provider dialects: the adapters as they answer today", () => {
       );
     });
 
-    it("lets a broken client's error escape raw from an open", async () => {
+    it("maps a broken client to a temporary AccessOpenError on an open", async () => {
       const broken = new NukiAccessProvider({ client: brokenNukiApiClient() });
 
-      await rejectsRaw(broken.open(NUKI_DOOR, doorContext()), (err) =>
-        expect(err.response.status).to.equal(500),
+      await rejectsOpen(broken.open(NUKI_DOOR, doorContext()), "temporary");
+    });
+
+    it("maps a smartlock Nuki does not know to a configuration AccessOpenError", async () => {
+      await rejectsOpen(
+        provider.open({ ...NUKI_DOOR, externalId: "9999" }, doorContext()),
+        "configuration",
+        "does not know smartlock '9999'",
       );
+    });
+
+    it("maps a refused token to a configuration AccessOpenError", async () => {
+      const broken = new NukiAccessProvider({
+        client: brokenNukiApiClient(nukiHttpError(401)),
+      });
+
+      await rejectsOpen(broken.open(NUKI_DOOR, doorContext()), "configuration");
+    });
+
+    it("maps a missing Nuki application to a configuration AccessOpenError", async () => {
+      sinon.stub(TenantManager, "getTenant").resolves(tenantWithSaltoApp());
+      const unconfigured = new NukiAccessProvider();
+
+      try {
+        await rejectsOpen(
+          unconfigured.open(NUKI_DOOR, doorContext()),
+          "configuration",
+          "No active access application 'nuki'",
+        );
+      } finally {
+        sinon.restore();
+      }
     });
   });
 
@@ -352,29 +387,47 @@ describe("access provider dialects: the adapters as they answer today", () => {
       provider = new SaltoKsAccessProvider({ client: clients["salto-ks"] });
     });
 
-    it("answers an open with a fixed success and the raw provider response", async () => {
+    it("answers an open as opened, with no process to poll", async () => {
       const outcome = await provider.open(SALTO_DOOR, doorContext());
 
-      expect(outcome).to.deep.equal({
-        success: true,
-        state: "open",
-        providerResponse: saltoLock({ locked_state: "unlocked" }),
-      });
+      expect(outcome).to.deep.equal({ state: "opened", openProcessId: null });
+      // An IQ without OTP: the lock is opened without one.
+      expect(clients["salto-ks"].openings).to.deep.equal([
+        { lockId: SALTO_LOCK_ID, otp: undefined },
+      ]);
     });
 
-    it("answers the status as a rich object with a locked/unlocked/null state", async () => {
-      const status = await provider.getStatus(SALTO_DOOR, doorContext());
+    const lockedStates = [
+      { lockedState: "locked", expected: { open: false, locked: true } },
+      { lockedState: "unlocked", expected: { open: true, locked: false } },
+      { lockedState: undefined, expected: { open: null, locked: null } },
+    ];
+
+    for (const { lockedState, expected } of lockedStates) {
+      it(`answers a lock in locked_state '${lockedState}' as a LockStatus`, async () => {
+        provider = new SaltoKsAccessProvider({
+          client: new FakeSaltoKsApiClient({
+            locks: [saltoLock({ locked_state: lockedState })],
+            iqs: [saltoIq()],
+          }),
+        });
+
+        const status = await provider.getStatus(SALTO_DOOR, doorContext());
+
+        expect(status).to.deep.equal({ ...expected, doorOpen: null });
+      });
+    }
+
+    it("answers a lock Salto does not list as unknown on every count", async () => {
+      const status = await provider.getStatus(
+        { ...SALTO_DOOR, externalId: "no-such-lock" },
+        doorContext(),
+      );
 
       expect(status).to.deep.equal({
-        lockId: SALTO_LOCK_ID,
-        name: "Tür 01",
-        online: true,
-        state: "locked",
-        lockedState: "locked",
-        batteryLevel: null,
-        batteryCritical: null,
-        leftOpenAlarm: null,
-        intrusionAlarm: null,
+        open: null,
+        locked: null,
+        doorOpen: null,
       });
     });
 
@@ -497,13 +550,35 @@ describe("access provider dialects: the adapters as they answer today", () => {
       }
     });
 
-    it("lets a client failure before the open call escape raw", async () => {
+    it("maps a client failure before the open call to a temporary AccessOpenError", async () => {
       const broken = new SaltoKsAccessProvider({
         client: brokenSaltoKsApiClient(),
       });
 
-      await rejectsRaw(broken.open(SALTO_DOOR, doorContext()), (err) =>
-        expect(err.response.status).to.equal(500),
+      await rejectsOpen(broken.open(SALTO_DOOR, doorContext()), "temporary");
+    });
+
+    it("maps a refused lock listing to a configuration AccessOpenError", async () => {
+      const broken = new SaltoKsAccessProvider({
+        client: brokenSaltoKsApiClient(
+          saltoHttpError(403, { Message: "Forbidden" }),
+        ),
+      });
+
+      await rejectsOpen(
+        broken.open(SALTO_DOOR, doorContext()),
+        "configuration",
+      );
+    });
+
+    it("maps a lock Salto does not list to a configuration AccessOpenError", async () => {
+      await rejectsOpen(
+        provider.open(
+          { ...SALTO_DOOR, externalId: "no-such-lock" },
+          doorContext(),
+        ),
+        "configuration",
+        "does not list lock",
       );
     });
 
@@ -536,26 +611,23 @@ describe("access provider dialects: the adapters as they answer today", () => {
       provider = new IfbsAccessProvider({ client: clients.ifbs });
     });
 
-    it("answers an open with the booking and open-box process ids only", async () => {
+    it("answers an open as pending, with the open-box process to poll", async () => {
       const outcome = await provider.open(IFBS_LOCKER, lockerContext());
 
-      expect(outcome).to.deep.equal({
-        processId: "booking-17",
-        openProcessId: "1",
-      });
+      expect(outcome).to.deep.equal({ state: "pending", openProcessId: "1" });
     });
 
-    it("cannot close: the client has no closeBox, although close is a declared capability", async () => {
-      expect(IfbsAccessProvider.capabilities).to.include("close");
+    it("declares no close: iFBS has no command to close a box", async () => {
+      expect(IfbsAccessProvider.capabilities).not.to.include("close");
 
       await rejects(
         provider.close(IFBS_LOCKER, lockerContext()),
-        TypeError,
-        "client.closeBox is not a function",
+        Error,
+        "close() is not supported by",
       );
     });
 
-    it("answers the status of a known open process as a mapped open-box status", async () => {
+    it("answers a confirmed open process as open and unlocked", async () => {
       await provider.open(IFBS_LOCKER, lockerContext());
       clients.ifbs.confirm("1");
 
@@ -565,75 +637,130 @@ describe("access provider dialects: the adapters as they answer today", () => {
       });
 
       expect(status).to.deep.equal({
-        openProcessId: "1",
-        confirmed: true,
-        confirmedAt: "2026-09-02 10:00:02",
         open: true,
-        state: "open",
-        boxControlReceived: true,
-        receivedAt: "2026-09-02 10:00:00",
-        bookingId: "booking-17",
-        usageState: "active",
+        locked: false,
+        doorOpen: null,
       });
     });
 
-    it("answers the status without a known process as the usage window", async () => {
-      const context = lockerContext();
+    it("answers an open process the box has not confirmed as unknown", async () => {
+      await provider.open(IFBS_LOCKER, lockerContext());
 
-      const status = await provider.getStatus(IFBS_LOCKER, context);
+      const status = await provider.getStatus(IFBS_LOCKER, {
+        ...lockerContext(),
+        lastOpenBoxId: "1",
+      });
 
       expect(status).to.deep.equal({
-        bookingId: "booking-17",
-        usageState: "active",
-        accessFrom: context.accessFrom,
-        accessTo: context.accessTo,
         open: null,
         locked: null,
         doorOpen: null,
-        state: "active",
       });
     });
 
-    it("answers the progress of an open process off the interface, via getOpenStatus(tenant, id)", async () => {
-      await provider.open(IFBS_LOCKER, lockerContext());
+    it("answers an open process iFBS no longer knows as unknown", async () => {
+      const status = await provider.getStatus(IFBS_LOCKER, {
+        ...lockerContext(),
+        lastOpenBoxId: "99",
+      });
 
-      const progress = await provider.getOpenStatus(TENANT, "1");
+      expect(status).to.deep.equal({
+        open: null,
+        locked: null,
+        doorOpen: null,
+      });
+    });
+
+    it("answers the status without a known process as unknown, without asking iFBS", async () => {
+      const broken = new IfbsAccessProvider({ client: brokenIfbsApiClient() });
+
+      const status = await broken.getStatus(IFBS_LOCKER, lockerContext());
+
+      expect(status).to.deep.equal({
+        open: null,
+        locked: null,
+        doorOpen: null,
+      });
+    });
+
+    it("answers the progress of an open process as an OpenProgress", async () => {
+      const outcome = await provider.open(IFBS_LOCKER, lockerContext());
+
+      const progress = await provider.getOpenProgress(
+        IFBS_LOCKER,
+        outcome.openProcessId,
+      );
 
       expect(progress).to.deep.equal({
-        openProcessId: "1",
         confirmed: true,
         confirmedAt: "2026-09-02 10:00:02",
-        open: true,
-        state: "open",
-        waitTime: 2,
+        errorCode: null,
+        errorMessage: null,
       });
     });
 
-    it("answers a failed poll with the iFBS error number and message", async () => {
-      const progress = await provider.getOpenStatus(TENANT, "99");
+    it("answers a box that has not confirmed yet as not confirmed", async () => {
+      clients.ifbs.confirmsOnWait = false;
+      const outcome = await provider.open(IFBS_LOCKER, lockerContext());
+
+      const progress = await provider.getOpenProgress(
+        IFBS_LOCKER,
+        outcome.openProcessId,
+      );
 
       expect(progress).to.deep.equal({
-        openProcessId: "99",
         confirmed: false,
         confirmedAt: null,
-        open: null,
-        state: "pending",
+        errorCode: null,
+        errorMessage: null,
+      });
+    });
+
+    it("answers a failed poll with confirmed unknown and the iFBS error number and message", async () => {
+      const progress = await provider.getOpenProgress(IFBS_LOCKER, "99");
+
+      expect(progress).to.deep.equal({
+        confirmed: null,
+        confirmedAt: null,
         errorCode: ERR_NO_WAIT_PROCESS_NOT_FOUND,
         errorMessage: "OpenBox process not found",
       });
     });
 
-    it("lets a broken client's error escape raw from an open", async () => {
+    it("answers an unreachable API on a poll as confirmed unknown, with the network error", async () => {
       const broken = new IfbsAccessProvider({ client: brokenIfbsApiClient() });
 
-      await rejectsRaw(broken.open(IFBS_LOCKER, lockerContext()), (err) =>
-        expect(err.code).to.equal("ECONNREFUSED"),
+      const progress = await broken.getOpenProgress(IFBS_LOCKER, "1");
+
+      expect(progress).to.deep.equal({
+        confirmed: null,
+        confirmedAt: null,
+        errorCode: null,
+        errorMessage: "connect ECONNREFUSED",
+      });
+    });
+
+    it("maps a broken client to a temporary AccessOpenError on an open", async () => {
+      const broken = new IfbsAccessProvider({ client: brokenIfbsApiClient() });
+
+      await rejectsOpen(
+        broken.open(IFBS_LOCKER, lockerContext()),
+        "temporary",
+        "ECONNREFUSED",
+      );
+    });
+
+    it("maps an iFBS refusal to a temporary AccessOpenError carrying the error number", async () => {
+      await rejectsOpen(
+        provider.open(IFBS_LOCKER, doorContext({ externalBookingId: "gone" })),
+        "temporary",
+        "(1701): Booking not found",
       );
     });
   });
 });
 
-describe("access provider dialects: what AccessService makes of them today", () => {
+describe("access provider dialects: what AccessService makes of them", () => {
   let sandbox;
   let clients;
 
@@ -753,7 +880,7 @@ describe("access provider dialects: what AccessService makes of them today", () 
   }
 
   describe("open", () => {
-    it("reads no open process out of a NUKI open and audits the raw answer", async () => {
+    it("answers a NUKI open with no process to poll and audits the outcome", async () => {
       stubBooking(createBooking(), [NUKI_DOOR]);
 
       const outcome = await AccessService.open(
@@ -768,14 +895,13 @@ describe("access provider dialects: what AccessService makes of them today", () 
         data: { openProcessId: null },
       });
       expect(loggedPayload("open").payload).to.deep.equal({
-        success: true,
-        state: "open",
-        providerResponse: "",
+        state: "opened",
+        openProcessId: null,
         validatedEvidence: [],
       });
     });
 
-    it("reads the open-box process out of an iFBS open, as a string", async () => {
+    it("answers an iFBS open with the open-box process to poll and audits the outcome", async () => {
       stubBooking(lockerBooking());
 
       const outcome = await AccessService.open(
@@ -790,13 +916,13 @@ describe("access provider dialects: what AccessService makes of them today", () 
         data: { openProcessId: "1" },
       });
       expect(loggedPayload("open").payload).to.deep.equal({
-        processId: "booking-17",
+        state: "pending",
         openProcessId: "1",
         validatedEvidence: [],
       });
     });
 
-    it("reads no open process out of a Salto open and audits the raw answer", async () => {
+    it("answers a Salto open with no process to poll and audits the outcome", async () => {
       stubBooking(createBooking(), [SALTO_DOOR]);
 
       const outcome = await AccessService.open(
@@ -810,13 +936,11 @@ describe("access provider dialects: what AccessService makes of them today", () 
         success: true,
         data: { openProcessId: null },
       });
-      expect(loggedPayload("open").payload).to.include({
-        success: true,
-        state: "open",
+      expect(loggedPayload("open").payload).to.deep.equal({
+        state: "opened",
+        openProcessId: null,
+        validatedEvidence: [],
       });
-      expect(loggedPayload("open").payload.providerResponse).to.deep.equal(
-        saltoLock({ locked_state: "unlocked" }),
-      );
     });
 
     it("opens through the in-memory provider like any other", async () => {
@@ -836,19 +960,19 @@ describe("access provider dialects: what AccessService makes of them today", () 
       expect(loggedPayload("open")).to.include({ result: "success" });
     });
 
-    it("rethrows a raw NUKI client error after auditing the failure", async () => {
+    it("rethrows NUKI's classified AccessOpenError after auditing the failure", async () => {
       clients.nuki = brokenNukiApiClient();
       registerFakeProviders();
       stubBooking(createBooking(), [NUKI_DOOR]);
 
-      await rejectsRaw(
+      await rejectsOpen(
         AccessService.open(TENANT, "booking-1", "door-1", "user-1"),
-        (err) => expect(err.response.status).to.equal(500),
+        "temporary",
       );
-      expect(loggedPayload("open")).to.include({
-        result: "failure",
-        errorMessage: "Request failed with status code 500",
-      });
+      expect(loggedPayload("open")).to.include({ result: "failure" });
+      expect(loggedPayload("open").errorMessage).to.include(
+        "Request failed with status code 500",
+      );
     });
 
     it("rethrows Salto's classified AccessOpenError after auditing the failure", async () => {
@@ -872,7 +996,7 @@ describe("access provider dialects: what AccessService makes of them today", () 
   });
 
   describe("getStatus", () => {
-    it("takes NUKI's booleans as they are", async () => {
+    it("answers NUKI's LockStatus with its source, and audits the LockStatus", async () => {
       stubBooking(createBooking(), [NUKI_DOOR]);
 
       const status = await AccessService.getStatus(
@@ -887,9 +1011,10 @@ describe("access provider dialects: what AccessService makes of them today", () 
         doorOpen: null,
         statusSource: "provider_status",
       });
-      expect(loggedPayload("status").payload).to.include({
-        lockState: "locked",
-        smartlockId: "1001",
+      expect(loggedPayload("status").payload).to.deep.equal({
+        open: false,
+        locked: true,
+        doorOpen: null,
       });
     });
 
@@ -921,7 +1046,7 @@ describe("access provider dialects: what AccessService makes of them today", () 
     ];
 
     for (const { lockedState, expected } of saltoStates) {
-      it(`sniffs Salto's state '${lockedState}' into open/locked`, async () => {
+      it(`answers Salto's locked_state '${lockedState}' as the adapter maps it`, async () => {
         clients = createClients({
           saltoLocks: [saltoLock({ locked_state: lockedState })],
         });
@@ -953,9 +1078,10 @@ describe("access provider dialects: what AccessService makes of them today", () 
         doorOpen: null,
         statusSource: "provider_status",
       });
-      expect(loggedPayload("status").payload).to.include({
-        usageState: "active",
-        state: "active",
+      expect(loggedPayload("status").payload).to.deep.equal({
+        open: null,
+        locked: null,
+        doorOpen: null,
       });
     });
 
@@ -993,7 +1119,7 @@ describe("access provider dialects: what AccessService makes of them today", () 
   });
 
   describe("getOpenStatus", () => {
-    it("polls the iFBS open process when the provider has getOpenStatus", async () => {
+    it("polls the iFBS open process where the provider declares getOpenProgress", async () => {
       stubBooking(lockerBooking());
       await clients.ifbs.openBox("booking-17");
 
@@ -1015,7 +1141,7 @@ describe("access provider dialects: what AccessService makes of them today", () 
       });
     });
 
-    it("reports a failed iFBS poll as not open, with the error", async () => {
+    it("reports a failed iFBS poll as unknown, with the error", async () => {
       stubBooking(lockerBooking());
 
       const status = await AccessService.getOpenStatus(
@@ -1026,17 +1152,17 @@ describe("access provider dialects: what AccessService makes of them today", () 
       );
 
       expect(status).to.deep.equal({
-        open: false,
+        open: null,
         locked: null,
         doorOpen: null,
         statusSource: "open_process",
-        confirmed: false,
+        confirmed: null,
         errorCode: ERR_NO_WAIT_PROCESS_NOT_FOUND,
         errorMessage: "OpenBox process not found",
       });
     });
 
-    it("ignores an open process id where the provider has no getOpenStatus", async () => {
+    it("ignores an open process id where the provider declares no getOpenProgress", async () => {
       stubBooking(createBooking(), [NUKI_DOOR]);
 
       const status = await AccessService.getOpenStatus(
@@ -1116,46 +1242,42 @@ describe("access provider dialects: what AccessService makes of them today", () 
     });
   });
 
-  describe("the status sniffing in _resolveOpen/_resolveLocked", () => {
-    // Ticket 2 deletes both helpers together with this table; until then it
-    // is the complete word on how a provider answer becomes open/locked.
-    const answers = [
-      { given: { open: true, locked: false }, open: true, locked: false },
-      { given: { open: false, locked: true }, open: false, locked: true },
-      { given: { open: true }, open: true, locked: false },
-      { given: { open: false }, open: false, locked: null },
-      { given: { confirmed: true }, open: true, locked: false },
-      { given: { confirmed: false }, open: false, locked: null },
-      { given: { state: "open" }, open: true, locked: false },
-      { given: { state: "unlocked" }, open: true, locked: false },
-      { given: { state: "closed" }, open: false, locked: true },
-      { given: { state: "locked" }, open: false, locked: true },
-      { given: { state: "active" }, open: null, locked: null },
-      { given: { locked: true }, open: null, locked: true },
-      { given: { open: true, state: "locked" }, open: true, locked: true },
-      { given: {}, open: null, locked: null },
-    ];
+  describe("the projection of an open's progress onto the status endpoint", () => {
+    it("reports an iFBS open the box has not confirmed yet as not open, unknown whether locked", async () => {
+      clients.ifbs.confirmsOnWait = false;
+      stubBooking(lockerBooking());
+      await clients.ifbs.openBox("booking-17");
 
-    for (const { given, open, locked } of answers) {
-      it(`reads ${JSON.stringify(given)} as open ${open}, locked ${locked}`, () => {
-        expect(
-          AccessService._toStatusResponse(given, "provider_status"),
-        ).to.deep.equal({
-          open,
-          locked,
-          doorOpen: null,
-          statusSource: "provider_status",
-        });
+      const status = await AccessService.getOpenStatus(
+        TENANT,
+        "booking-1",
+        "7",
+        "1",
+      );
+
+      expect(status).to.deep.equal({
+        open: false,
+        locked: null,
+        doorOpen: null,
+        statusSource: "open_process",
+        confirmed: false,
+        errorCode: null,
+        errorMessage: null,
       });
-    }
+    });
 
-    it("takes doorOpen only as a boolean", () => {
-      expect(
-        AccessService._toStatusResponse({ doorOpen: "open" }).doorOpen,
-      ).to.equal(null);
-      expect(
-        AccessService._toStatusResponse({ doorOpen: true }).doorOpen,
-      ).to.equal(true);
+    it("audits the OpenProgress of a polled process, and the event behind a last-event answer", async () => {
+      stubBooking(lockerBooking());
+      await clients.ifbs.openBox("booking-17");
+
+      await AccessService.getOpenStatus(TENANT, "booking-1", "7", "1");
+
+      expect(loggedPayload("status").payload).to.deep.equal({
+        confirmed: true,
+        confirmedAt: "2026-09-02 10:00:02",
+        errorCode: null,
+        errorMessage: null,
+      });
     });
   });
 
@@ -1196,13 +1318,13 @@ describe("access provider dialects: what AccessService makes of them today", () 
       expect(loggedPayload("close")).to.include({ result: "failure" });
     });
 
-    it("fails on an iFBS locker with a TypeError, although iFBS declares close", async () => {
+    it("fails on an iFBS locker, which declares no close", async () => {
       stubBooking(lockerBooking());
 
       await rejects(
         AccessService.close(TENANT, "booking-1", "7", "user-1"),
-        TypeError,
-        "client.closeBox is not a function",
+        Error,
+        "close() is not supported by",
       );
       expect(loggedPayload("close")).to.include({ result: "failure" });
     });

--- a/tests/access-service.test.js
+++ b/tests/access-service.test.js
@@ -247,7 +247,7 @@ describe("AccessService locker access window", () => {
       label: "",
       mode: "remote",
       validationRuleTypes: [],
-      capabilities: ["open", "close", "getStatus"],
+      capabilities: ["open", "getStatus"],
       externalBookingId: "ifbs-booking-99",
       isProvisioned: true,
       accessBuffer: { beforeMs: 0, afterMs: 0 },

--- a/tests/helpers/in-memory-access-provider.js
+++ b/tests/helpers/in-memory-access-provider.js
@@ -56,7 +56,7 @@ class InMemoryAccessProvider extends AccessProvider {
       externalId: String(accessPoint.externalId),
       action: "open",
     });
-    return { success: true, state: "open", openProcessId: null };
+    return { state: "opened", openProcessId: null };
   }
 
   async unlatch(accessPoint, bookingContext) {
@@ -70,7 +70,6 @@ class InMemoryAccessProvider extends AccessProvider {
       externalId: String(accessPoint.externalId),
       action: "close",
     });
-    return { success: true, state: "closed" };
   }
 
   async getStatus(accessPoint, _bookingContext) {

--- a/tests/ifbs-access-provider.test.js
+++ b/tests/ifbs-access-provider.test.js
@@ -1,3 +1,4 @@
+const assert = require("assert");
 const { expect } = require("chai");
 const sinon = require("sinon");
 
@@ -18,6 +19,8 @@ describe("IfbsAccessProvider.getStatus", () => {
     accessTo: 2_000,
   };
 
+  const unknown = { open: null, locked: null, doorOpen: null };
+
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     provider = new IfbsAccessProvider();
@@ -32,24 +35,14 @@ describe("IfbsAccessProvider.getStatus", () => {
     sandbox.restore();
   });
 
-  it("returns usage window status when no open process is known", async () => {
-    sandbox.useFakeTimers({ now: 1_500 });
-
+  it("knows nothing without an open process, and does not ask iFBS", async () => {
     const status = await provider.getStatus({}, bookingContext);
 
-    expect(status).to.deep.include({
-      bookingId: "booking-17",
-      usageState: "active",
-      state: "active",
-      open: null,
-      locked: null,
-      doorOpen: null,
-    });
+    expect(status).to.deep.equal(unknown);
     expect(client.monitorOpenBox.called).to.equal(false);
   });
 
-  it("polls monitorOpenBox when lastOpenBoxId is present", async () => {
-    sandbox.useFakeTimers({ now: 1_500 });
+  it("polls monitorOpenBox when lastOpenBoxId is present and answers a confirmed open as open", async () => {
     client.monitorOpenBox.resolves({
       OpenBox_ID: "9",
       BoxControlReceived: "true",
@@ -65,20 +58,25 @@ describe("IfbsAccessProvider.getStatus", () => {
 
     expect(client.monitorOpenBox.calledOnce).to.equal(true);
     expect(client.monitorOpenBox.firstCall.args).to.deep.equal(["9"]);
-    expect(status).to.deep.include({
-      openProcessId: "9",
-      confirmed: true,
-      confirmedAt: "2018-11-21 13:42:40",
-      boxControlReceived: true,
-      receivedAt: "2018-11-21 13:42:38",
-      open: true,
-      state: "open",
-      usageState: "active",
-    });
+    expect(status).to.deep.equal({ open: true, locked: false, doorOpen: null });
   });
 
-  it("falls back to usage window when the open process no longer exists", async () => {
-    sandbox.useFakeTimers({ now: 3_000 });
+  it("answers an open process the box has not confirmed as unknown", async () => {
+    client.monitorOpenBox.resolves({
+      OpenBox_ID: "9",
+      BoxControlReceived: "true",
+      BoxControlConfirmed: "false",
+    });
+
+    const status = await provider.getStatus(
+      {},
+      { ...bookingContext, lastOpenBoxId: "9" },
+    );
+
+    expect(status).to.deep.equal(unknown);
+  });
+
+  it("answers unknown when the open process no longer exists", async () => {
     client.monitorOpenBox.rejects(
       new IfbsApiError("monitorOpenBox.php", {
         ErrNo: 1802,
@@ -91,10 +89,20 @@ describe("IfbsAccessProvider.getStatus", () => {
       { ...bookingContext, lastOpenBoxId: "9" },
     );
 
-    expect(status).to.deep.include({
-      bookingId: "booking-17",
-      usageState: "expired",
-      state: "expired",
-    });
+    expect(status).to.deep.equal(unknown);
+  });
+
+  it("lets any other iFBS failure through", async () => {
+    client.monitorOpenBox.rejects(
+      new IfbsApiError("monitorOpenBox.php", {
+        ErrNo: 1000,
+        ErrMsg: "Internal error",
+      }),
+    );
+
+    await assert.rejects(
+      provider.getStatus({}, { ...bookingContext, lastOpenBoxId: "9" }),
+      IfbsApiError,
+    );
   });
 });

--- a/tests/nuki-open-latch.test.js
+++ b/tests/nuki-open-latch.test.js
@@ -82,7 +82,7 @@ describe("Nuki open pulls the latch where the lock has one", () => {
     expect(
       client.executeAction.calledOnceWithExactly("lock-1", NUKI_ACTIONS.UNLOCK),
     ).to.be.true;
-    expect(result.success).to.be.true;
+    expect(result).to.deep.equal({ state: "opened", openProcessId: null });
   });
 
   it("sends one action and never a second one after it", async () => {

--- a/tests/salto-ks-remote-open.test.js
+++ b/tests/salto-ks-remote-open.test.js
@@ -121,7 +121,7 @@ describe("SaltoKsAccessProvider.open", () => {
         IQ_ID,
       ),
     ).to.be.true;
-    expect(result.success).to.be.true;
+    expect(result).to.deep.equal({ state: "opened", openProcessId: null });
   });
 
   it("never takes an OTP from the caller", async () => {


### PR DESCRIPTION
Provider-Outcomes ticket (2): [OpenOutcome, LockStatus, OpenProgress und Fehlervertrag am Seam](https://app.notion.com/p/3cf1e90322a6813fa043d3bf82f5cc76). Follows #247 (ticket 1); ticket (3) - Grant, Revocation, migration, cleanup job - stays out of scope, so `grantAuthorization`/`revokeAuthorization` and `accessInfo` are untouched.

## What changes

- `access-provider.js` declares `OpenOutcome`, `LockStatus` and `OpenProgress` as JSDoc typedefs, documents every method with `@param`/`@returns`/`@throws`, adds `getOpenProgress(accessPoint, openProcessId)` to the interface, and aligns its parameter lists with the adapters (`getSupportedModes(accessPoint, tenant)`, `unregisterWebhook(tenant, id)`, Salto `parseWebhook(rawPayload, headers)`).
- NUKI, Salto KS and iFBS answer `open`/`unlatch` with an `OpenOutcome` (invariant `pending ⇔ openProcessId`), `getStatus` with a `LockStatus` of booleans or `null`, and `close` with nothing. iFBS implements `getOpenProgress` and declares the capability; Salto and NUKI map their own states.
- `AccessService` branches on `capabilities` only, never on `typeof`. `_resolveOpen`, `_resolveLocked` and `_toOpenProcessId` are gone, `_toStatusResponse` is `{...lockStatus, statusSource}`, the `lastEvent` fallback stays, and the audit log stores the typed outcome instead of the raw provider answer.
- Error contract: `open`/`unlatch` throw only `AccessOpenError`. NUKI and iFBS now map a missing application, an unknown lock and a refused token to `configuration` and every other client failure to `temporary`; Salto maps the failures before its locking call as well. NUKI and iFBS failures therefore reach the client as `openFailure` instead of HTTP 500.
- The contract cases marked (2) in `tests/access-provider-contract.test.js` are active; `tests/access-provider-dialects.test.js` pins the new behaviour.

HTTP response shapes of the access endpoints are unchanged.

## Decisions to confirm

- **iFBS drops the `close` capability.** The client never had a `closeBox`, so the call always failed with a TypeError. The booking access-point listing for lockers now reports `["open", "getStatus"]`; a storefront that renders a close button from `capabilities` loses it for lockers.
- **A failed iFBS poll at `/open-status` reports `confirmed: null` and `open: null`** (unknown) instead of `false`. The ticket asked for `open: null`; `confirmed: null` follows from the `OpenProgress` typedef, where `null` means the poll itself failed.
- **NUKI and iFBS `_getClient` throw a `NotFoundError`** (`nuki_application_not_found`, `ifbs_application_not_found`) for a missing application on every method, matching what Salto already did. Controllers still render these as generic errors.

## Verification

- `npm test`: 1414 passing. The single failure, "returns a group preview with per-booking and aggregate amounts" in `tests/cancellation-booking-service.test.js`, fails identically on `version/4.3.x` and is unrelated.
- `npm run lint:check`: 0 errors (105 pre-existing warnings). `npm run format:check`: clean.
- Reviewed with `/code-review` (standards and spec axes); the findings are answered in the second commit.
