### PR TITLE
Pin the booking lifecycle as it is today (BookingLifecycle 1/9)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -194,3 +194,49 @@ _Avoid_: Salto-User (unqualifiziert), Nutzer, Account
 **Widerruf (eines Grants)**:
 Das Zurücknehmen eines Grants beim Provider, mit der Auskunft, ob der externe Principal dabei entfernt wurde. Ein wiederholter Widerruf desselben Grants ist erlaubt und holt nur nach, was fehlt.
 _Avoid_: Revoke (als deutsches Nomen), Löschung, Deprovisionierung
+
+### Buchungslebenszyklus
+
+**Buchungszustand**:
+Der eine gespeicherte Wert, der sagt, wo eine Buchung in ihrem Leben steht: _angefragt_ (noch nicht bestätigt), _Zahlung offen_ (bestätigt, Preis größer null, unbezahlt), _bestätigt_ (bestätigt und bezahlt, oder bestätigt und kostenlos), _abgelehnt_ (aus „angefragt" heraus storniert) oder _storniert_ (aus „Zahlung offen" oder „bestätigt" heraus storniert). „Bezahlt, aber nicht bestätigt" gibt es nicht. Die drei Flags bestätigt/bezahlt/storniert sind Ableitungen des Zustands, nie seine Quelle.
+_Avoid_: isCommitted/isPayed/isRejected (als Sprechbegriffe — das sind die abgeleiteten Flags), Status-Key (das ist die Frontend-Übersetzung), Buchungsstatus (unqualifiziert)
+
+**Lebenszyklus-Übergang**:
+Ein benannter Wechsel des Buchungszustands mit seinen Effekten: Aufnahme, Bestätigung, Zahlung, Storno, Wiederherstellung, Änderung und Stornoanfrage. Welcher Übergang aus welchem Zustand erlaubt ist, steht in einer Tabelle; alles andere ist ein Fehler, keine stille Annahme. Ein Übergang gilt immer einer Buchung; eine Gruppenbuchung durchläuft ihre Übergänge als eigener Lebenszyklus über den Übergängen ihrer Mitglieder.
+_Avoid_: Aktion, Statuswechsel, Flag setzen, Übergang (unqualifiziert)
+
+**Effekt (eines Übergangs)**:
+Eine beobachtbare Nebenwirkung, die ein Lebenszyklus-Übergang auslöst: Vormerkung oder Grant an AccessPoints, ein Buchungsdokument, eine Mail, ein Workflow-Ereignis. Effekte gehören zum Übergang, nie zum Aufrufer; welche laufen und was bei ihrem Scheitern passiert, entscheidet allein der Lebenszyklus.
+_Avoid_: Side-Effect, Hook (das ist das Workflow-Ereignis bzw. die Stornoanfrage), Nachbearbeitung
+
+**Auslöser (eines Übergangs)**:
+Wer einen Lebenszyklus-Übergang veranlasst hat: _Buchender_, _Verwaltung_, _Zahlung_ (ein Zahlungsanbieter), _Workflow_ (eine Workflow-Aktion) oder _System_. Ein Wert am Übergang, der z.B. die Erstattungsregel des Stornos wählt und Workflow-Schleifen verhindert. Nicht zu verwechseln mit der Zugriffsrolle, die sich auf das Bedienen von AccessPoints bezieht.
+_Avoid_: Origin (Altname im Storno), skipWorkflow (das ist die Alt-Kodierung für „Auslöser Workflow"), Herkunft
+
+**Aufnahme (einer Buchung)**:
+Der erste Lebenszyklus-Übergang: eine vom Checkout gespeicherte Buchung wird in den Lebenszyklus aufgenommen, mit den Effekten des Zustands, in dem sie ankommt. Der Checkout entscheidet den Anfangszustand (angefragt, Zahlung offen oder bestätigt) und endet mit dem Speichern; bricht die Aufnahme ab, entsteht die Buchung nicht.
+_Avoid_: Create (als Übergangsname), Anlegen, Checkout (das ist der Vorgang davor)
+
+**Stornoanfrage**:
+Der vom Buchenden geäußerte Wunsch, eine Buchung zu stornieren, der erst mit seiner Bestätigung zum Storno wird. Ein offener Vorgang an einem Buchungszustand, kein eigener Zustand: die Buchung bleibt währenddessen gültig. Nur möglich, wenn die Stornierungsregel der Buchung sie zulässt.
+_Avoid_: Reject-Hook (das ist die Speicherform), Kündigung, Stornierung (das ist der Übergang danach)
+
+**Wiederherstellung (einer Buchung)**:
+Der Lebenszyklus-Übergang, der eine abgelehnte oder stornierte Buchung in den Zustand zurückholt, den sie vor dem Storno hatte, mit Preis und Positionen von damals; die Erstattung fällt weg, der Zugang wird neu gewährt. Der Zustand vor dem Storno wird beim Storno festgehalten.
+_Avoid_: Unreject, Reaktivierung, Rücknahme des Stornos (das ist die Handlung, nicht der Übergang)
+
+**Fehlerpolitik (eines Effekts)**:
+Was ein gescheiterter Effekt mit seinem Lebenszyklus-Übergang macht: _abbrechen_ (der Übergang findet nicht statt, schon Geschriebenes wird zurückgenommen) oder _protokollieren_ (der Übergang gilt, der Fehler steht im Ergebnis und im Log). Am Effekt festgelegt, für jeden Übergang gleich, nie vom Aufrufer gewählt. Nur das Speichern und die Vormerkung brechen ab; Zugang, Dokument und Mitteilungen werden protokolliert.
+_Avoid_: onFailure (als Sprechbegriff), Verschlucken, Rollback (das ist die Handlung beim Abbrechen, nicht die Politik), Retry (gibt es nicht)
+
+**Ausstellung (eines Buchungsdokuments)**:
+Der eine Vorgang, in dem ein Buchungsdokument entsteht: Nummer ziehen, erzeugen, ablegen und an alle zugehörigen Buchungen anhängen. Eine Dokumentnummer ohne Anhang gibt es nicht; eine Nummer, die durch einen Fehler beim Erzeugen verloren geht, ist eine erklärte Lücke, keine Doppelvergabe. Die Ausstellung versendet nichts — die Mail ist eine Mitteilung des Übergangs oder der Verwaltung.
+_Avoid_: Issuance (als deutsches Nomen), Erzeugen (das ist nur das Rendern), Belegerstellung (unqualifiziert)
+
+**Revision (eines Buchungsdokuments)**:
+Eine erneute Ausstellung eines Buchungsdokuments unter derselben Dokumentnummer, fortlaufend gezählt. Ein Nachdruck durch die Verwaltung ist eine Revision, keine Kopie: er entsteht als neues Medium mit derselben Nummer.
+_Avoid_: Nachdruck (als Modellbegriff — das ist die Handlung), Reprint, Belegkopie, Duplikat
+
+**Zahlungsaufforderung**:
+Die eine Mitteilung, mit der der Mandant den Buchenden zur Zahlung einer Buchung in „Zahlung offen" auffordert. Ihre Form bestimmt der Zahlungsanbieter des Mandanten: ein Zahlungslink, eine ausgestellte Rechnung oder die Ankündigung einer später erstellten Rechnung. Eine Mitteilung, kein Zustand: scheitert sie, bleibt die Buchung in „Zahlung offen".
+_Avoid_: paymentRequest (als Sprechbegriff), Rechnungsversand (das ist nur eine der drei Formen), Zahlungserinnerung (das gibt es nicht)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,7 @@ Releases are tagged `v4.x.x` from branch `version/4.x`.
 
 ### Added
 
+- Booking lifecycle, step 1 of 9: characterization tests over HTTP (`supertest`, new dev dependency) pin every state change of a booking and a group booking as it is today - admission, commit, pay, reject, cancellation request, the admin PUT and the reprint endpoints - each as a table of its effects at the seam. The known defects are pinned as today's behaviour and name the ticket that turns them. No production code changed
 - Access provider contract test against NUKI, Salto KS, iFBS and an in-memory test provider, plus characterization tests that pin today's provider dialects. Access providers accept an injected API client (`{ client }`) for tests; production behaviour is unchanged
 
 - Manual price per bookable item: `bookableItems[].manualPriceEur` (net, per unit) on the admin booking API (`PUT /api/:tenant/bookings`). Under the `ADMIN_MANUAL` checkout policy it replaces the price that categories or external providers would yield — VAT, amount and coupons apply as before — and it stays on the stored item until the admin clears it (`null`), so moving the booking never silently reprices it. A self-service checkout that carries the field has it stripped (on copies — the caller's items are left untouched), so it can never reach a stored booking. Until now the Admin UI could only express an entered price by rewriting one price category of the item, which silently missed whenever that category did not match the booking date

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -5,7 +5,7 @@
 - **Runner:** Mocha (`npm test`)
 - **Assertions:** Node `assert` or Chai
 - **Mocking:** Sinon (`sinon.stub`, `sinon.spy`)
-- **HTTP tests:** chai-http (where used)
+- **HTTP tests:** supertest against the real routers on a bare express app (see `tests/helpers/booking-lifecycle-harness.js`); chai-http is still installed but unused
 
 ## Location
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,8 @@
         "mocha": "^10.2.0",
         "nodemon": "^3.0.2",
         "prettier": "3.2.5",
-        "semver": "^7.5.0"
+        "semver": "^7.5.0",
+        "supertest": "^7.2.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1213,6 +1214,19 @@
         "sparse-bitfield": "^3.0.3"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -1243,6 +1257,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@pkgr/core": {
@@ -1882,6 +1906,35 @@
         "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.1",
         "set-function-length": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2569,6 +2622,20 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -2603,6 +2670,24 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-get-iterator": {
       "version": "1.1.3",
       "license": "MIT",
@@ -2619,6 +2704,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/escalade": {
@@ -3167,12 +3279,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.0",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -3273,16 +3389,40 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.2",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob": {
@@ -3333,10 +3473,12 @@
       }
     },
     "node_modules/gopd": {
-      "version": "1.0.1",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3387,18 +3529,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-proto": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3408,10 +3542,12 @@
       }
     },
     "node_modules/has-tostringtag": {
-      "version": "1.0.0",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "license": "MIT",
       "dependencies": {
-        "has-symbols": "^1.0.2"
+        "has-symbols": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3421,7 +3557,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.0",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4241,6 +4379,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/md5": {
       "version": "2.3.0",
       "license": "BSD-3-Clause",
@@ -4794,8 +4941,13 @@
       "license": "MIT"
     },
     "node_modules/object-inspect": {
-      "version": "1.13.1",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5351,10 +5503,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.11.2",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.4"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -5762,12 +5917,72 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.4",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5961,6 +6176,108 @@
       },
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/supertest/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/supertest/node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
+    "node_modules/supertest/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/supertest/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supertest/node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "mocha": "^10.2.0",
     "nodemon": "^3.0.2",
     "prettier": "3.2.5",
-    "semver": "^7.5.0"
+    "semver": "^7.5.0",
+    "supertest": "^7.2.2"
   }
 }

--- a/tests/booking-lifecycle-characterization.test.js
+++ b/tests/booking-lifecycle-characterization.test.js
@@ -1,0 +1,1211 @@
+/**
+ * Characterization of the booking lifecycle as it is today, seen through
+ * the HTTP form: every state change of a single booking - admission by the
+ * checkout, confirmation, payment (administration and payment webhook),
+ * cancellation, cancellation request, the admin PUT with its flag flips
+ * and the hidden reinstatement - plus the reprint endpoints and the
+ * workflow action that calls the same transitions.
+ *
+ * Written for the first ticket of the BookingLifecycle chain (Wayfinder,
+ * "BookingLifecycle (1): Charakterisierungstests ..."); the vocabulary of
+ * the states is the glossary in `CONTEXT.md`, "Buchungslebenszyklus". It
+ * pins, it does not judge: each case lists the effects at the seam as a
+ * table - store writes, access calls, documents, mails, workflow events -
+ * in the order they happen today. The known defects are pinned as today's
+ * behaviour and name the ticket of the chain that turns them; when that
+ * ticket lands, the expectation here changes with it and the changelog
+ * says so.
+ *
+ * The harness (`helpers/booking-lifecycle-harness.js`) runs the real
+ * routers, controllers, `BookingService` and checkout over an in-memory
+ * store; the seams record and, when told to, fail.
+ */
+
+const { expect } = require("chai");
+const sinon = require("sinon");
+
+const {
+  installHarness,
+  bookable,
+  checkoutBody,
+  adminForm,
+  stateOf,
+  TENANT,
+  ADMIN,
+  CUSTOMER,
+  TIME_BEGIN,
+  TIME_END,
+  DAY,
+} = require("./helpers/booking-lifecycle-harness");
+const {
+  BookingStatusAction,
+} = require("../src/commons/services/workflow/workflow-action");
+
+describe("booking lifecycle today: what each state change does at the seam", function () {
+  let h;
+
+  beforeEach(async function () {
+    h = await installHarness();
+  });
+
+  afterEach(async function () {
+    sinon.restore();
+    await h.close();
+  });
+
+  // --- the requests ------------------------------------------------------
+
+  const api = () => h.api();
+
+  /** A customer's checkout through the storefront (v2). */
+  async function checkout(bookableId, overrides) {
+    const res = await api()
+      .post(`/api/v2/${TENANT}/checkout`)
+      .set(h.as(CUSTOMER))
+      .send(checkoutBody(bookableId, overrides));
+    expect(res.status).to.equal(200);
+    return res.body;
+  }
+
+  const commit = (id) =>
+    api().get(`/api/${TENANT}/bookings/${id}/commit`).set(h.as(ADMIN));
+  const pay = (id, body = {}) =>
+    api().post(`/api/${TENANT}/bookings/${id}/pay`).set(h.as(ADMIN)).send(body);
+  const reject = (id, body = {}) =>
+    api()
+      .post(`/api/${TENANT}/bookings/${id}/reject`)
+      .set(h.as(ADMIN))
+      .send(body);
+  const requestReject = (id, body = {}) =>
+    api().post(`/api/${TENANT}/bookings/${id}/request-reject`).send(body);
+  const releaseHook = (id, hookId) =>
+    api()
+      .get(`/api/${TENANT}/bookings/${id}/hooks/${hookId}/release`)
+      .set(h.as(ADMIN));
+  const update = (id, changes) =>
+    api()
+      .put(`/api/${TENANT}/bookings`)
+      .set(h.as(ADMIN))
+      .send(adminForm(h.stored(id), changes));
+
+  /** A booking in a given state, with the rows of getting there forgotten. */
+  async function bookingIn(state) {
+    let id;
+    switch (state) {
+      case "requested":
+        id = (await checkout("room")).data.booking.id;
+        break;
+      case "payment_due":
+        id = (await checkout("auto-room")).data.booking.id;
+        break;
+      case "confirmed":
+        id = (await checkout("auto-room")).data.booking.id;
+        await pay(id);
+        break;
+      case "confirmed_free":
+        id = (await checkout("free-room")).data.booking.id;
+        break;
+      default:
+        throw new Error(`unknown state ${state}`);
+    }
+    expect(stateOf(h.stored(id))).to.equal(
+      state === "confirmed_free" ? "confirmed" : state,
+    );
+    h.clearEffects();
+    return id;
+  }
+
+  // -----------------------------------------------------------------------
+
+  describe("admission: the checkout stores the booking and runs the effects of its state", function () {
+    it("a self-service booking of a room to be confirmed arrives as requested", async function () {
+      const body = await checkout("room");
+
+      const { booking, payment } = body.data;
+      expect(payment).to.equal(null);
+      expect(stateOf(h.stored(booking.id))).to.equal("requested");
+      expect(h.stored(booking.id)).to.include({
+        assignedUserId: CUSTOMER,
+        priceEur: 40,
+        paymentProvider: "giroCockpit",
+      });
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 requested",
+        // Ticket 9: `onCreate` is the one event without `skipBookingStatus`.
+        "workflow.onCreate B1 without skipBookingStatus",
+        "access.hold B1",
+        "mail.sendBookingRequestConfirmation B1",
+        "mail.sendIncomingBooking B1",
+        "supervisor.notify B1",
+      ]);
+    });
+
+    it("a self-service booking of a room confirmed at once arrives as payment due and goes on to the payment link", async function () {
+      const body = await checkout("auto-room");
+
+      const { booking, payment } = body.data;
+      expect(payment).to.deep.equal({
+        provider: "giroCockpit",
+        data: { url: "https://pay.example.test" },
+      });
+      expect(stateOf(h.stored(booking.id))).to.equal("payment_due");
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 payment_due",
+        "workflow.onCreate B1 without skipBookingStatus",
+        "access.hold B1",
+        // Today a booking confirmation without receipt goes out here; the
+        // spec's payment request (part 2 §8 `admit`) is ticket 9.
+        "mail.sendBookingConfirmation B1",
+        "mail.sendIncomingBooking B1",
+        "supervisor.notify B1",
+        "access.refreshHolds B1",
+        "payment.createPayment B1",
+      ]);
+    });
+
+    it("a self-service booking of a free room confirmed at once arrives as confirmed and is granted", async function () {
+      const body = await checkout("free-room");
+
+      const { booking, payment } = body.data;
+      expect(payment).to.equal(null);
+      expect(stateOf(h.stored(booking.id))).to.equal("confirmed");
+      expect(h.stored(booking.id)).to.include({ priceEur: 0, isPayed: true });
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 confirmed",
+        "workflow.onCreate B1 without skipBookingStatus",
+        "access.hold B1",
+        "access.provision B1",
+        "mail.sendBookingConfirmation B1",
+        "mail.sendIncomingBooking B1",
+        "supervisor.notify B1",
+      ]);
+    });
+
+    it("the legacy checkout answers the booking itself and runs the same effects", async function () {
+      const res = await api()
+        .post(`/api/${TENANT}/checkout`)
+        .set(h.as(CUSTOMER))
+        .send(checkoutBody("room"));
+
+      expect(res.status).to.equal(200);
+      expect(res.body).to.include({ id: h.stored(res.body.id).id });
+      expect(stateOf(h.stored(res.body.id))).to.equal("requested");
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 requested",
+        "workflow.onCreate B1 without skipBookingStatus",
+        "access.hold B1",
+        "mail.sendBookingRequestConfirmation B1",
+        "mail.sendIncomingBooking B1",
+        "supervisor.notify B1",
+      ]);
+    });
+
+    it("a manual booking, confirmed and paid, is granted, receipted and confirmed by mail; the answer is the booking before the receipt", async function () {
+      const booking = await h.manualBooking("room", {
+        isCommitted: true,
+        isPayed: true,
+      });
+
+      expect(booking.attachments).to.deep.equal([]);
+      expect(booking.assignedUserId).to.equal(CUSTOMER);
+      const stored = h.stored(booking.id);
+      expect(stateOf(stored)).to.equal("confirmed");
+      expect(stored.attachments.map((att) => att.type)).to.deep.equal([
+        "receipt",
+      ]);
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 confirmed",
+        "workflow.onCreate B1 without skipBookingStatus",
+        "access.hold B1",
+        "access.provision B1",
+        "documents.receipt B1",
+        "store.save B1 confirmed [receipt]",
+        "mail.sendBookingConfirmation B1 [RE-1.pdf]",
+        "mail.sendIncomingBooking B1",
+        "supervisor.notify B1",
+      ]);
+    });
+
+    it("a manual booking, confirmed but unpaid, is held and confirmed by mail without a payment request", async function () {
+      const booking = await h.manualBooking("room", { isCommitted: true });
+
+      expect(stateOf(h.stored(booking.id))).to.equal("payment_due");
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 payment_due",
+        "workflow.onCreate B1 without skipBookingStatus",
+        "access.hold B1",
+        "mail.sendBookingConfirmation B1",
+        "mail.sendIncomingBooking B1",
+        "supervisor.notify B1",
+      ]);
+    });
+
+    it("a manual booking without flags arrives as requested", async function () {
+      const booking = await h.manualBooking("room");
+
+      expect(stateOf(h.stored(booking.id))).to.equal("requested");
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 requested",
+        "workflow.onCreate B1 without skipBookingStatus",
+        "access.hold B1",
+        "mail.sendBookingRequestConfirmation B1",
+        "mail.sendIncomingBooking B1",
+        "supervisor.notify B1",
+      ]);
+    });
+
+    it("a manual booking paid but unconfirmed is stored as such and treated as a request (ticket 9: 400 invalid_status)", async function () {
+      const booking = await h.manualBooking("room", { isPayed: true });
+
+      expect(stateOf(h.stored(booking.id))).to.equal("paid_unconfirmed");
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 paid_unconfirmed",
+        "workflow.onCreate B1 without skipBookingStatus",
+        "access.hold B1",
+        "mail.sendBookingRequestConfirmation B1",
+        "mail.sendIncomingBooking B1",
+        "supervisor.notify B1",
+      ]);
+    });
+
+    it("a hold that fails rolls the booking back: it never existed", async function () {
+      h.failing.add("access.hold");
+
+      const body = await checkout("room");
+
+      expect(body.success).to.equal(false);
+      expect(h.store.size).to.equal(0);
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 requested",
+        "workflow.onCreate B1 without skipBookingStatus",
+        "access.hold B1 FAILED",
+        "store.remove B1",
+      ]);
+    });
+
+    it("a mail that fails at admission is logged; the booking stands and the other mails go out", async function () {
+      h.failing.add("mail.sendBookingRequestConfirmation");
+
+      const body = await checkout("room");
+
+      expect(stateOf(h.stored(body.data.booking.id))).to.equal("requested");
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 requested",
+        "workflow.onCreate B1 without skipBookingStatus",
+        "access.hold B1",
+        "mail.sendBookingRequestConfirmation B1 FAILED",
+        "mail.sendIncomingBooking B1",
+        "supervisor.notify B1",
+      ]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+
+  describe("confirmation: GET /bookings/:id/commit", function () {
+    it("confirms a priced request, asks the payment provider for its payment request, and fires the workflow before the write", async function () {
+      const id = await bookingIn("requested");
+
+      const res = await commit(id);
+
+      expect(res.status).to.equal(200);
+      expect(res.body).to.deep.equal({ success: true, data: null, errors: [] });
+      expect(stateOf(h.stored(id))).to.equal("payment_due");
+      expect(h.takeEffects()).to.deep.equal([
+        "workflow.onCommit B1",
+        "store.save B1 payment_due",
+        "payment.paymentRequest B1",
+      ]);
+    });
+
+    it("confirms a free request, grants it and sends the free booking confirmation", async function () {
+      const { booking } = (await checkout("free-request-room")).data;
+      expect(stateOf(h.stored(booking.id))).to.equal("requested");
+      // A free request is stored paid: the checkout sets `isPayed` from the
+      // price, not from a payment (ticket 2 derives the flag from `status`).
+      expect(h.stored(booking.id)).to.include({ priceEur: 0, isPayed: true });
+      h.clearEffects();
+
+      const res = await commit(booking.id);
+
+      expect(res.status).to.equal(200);
+      expect(stateOf(h.stored(booking.id))).to.equal("confirmed");
+      expect(h.takeEffects()).to.deep.equal([
+        "workflow.onCommit B1",
+        "store.save B1 confirmed",
+        "access.provision B1",
+        "mail.sendFreeBookingConfirmation B1",
+      ]);
+    });
+
+    it("answers 500 for a confirmed booking when the tenant has no payment service: commitBooking returns undefined (ticket 5)", async function () {
+      const id = await bookingIn("requested");
+      h.payment.available = false;
+
+      const res = await commit(id);
+
+      expect(res.status).to.equal(500);
+      expect(res.text).to.equal("Could not commit booking");
+      expect(stateOf(h.stored(id))).to.equal("payment_due");
+      expect(h.takeEffects()).to.deep.equal([
+        "workflow.onCommit B1",
+        "store.save B1 payment_due",
+      ]);
+    });
+
+    it("never mails the organizer of a ticket booking on confirmation - the block reads `type` off the item, not off `_bookableUsed` (ticket 5)", async function () {
+      const booking = await h.manualBooking("ticket");
+      expect(booking.bookableItems[0]._bookableUsed.type).to.equal("ticket");
+      h.clearEffects();
+
+      const res = await commit(booking.id);
+
+      expect(res.status).to.equal(200);
+      expect(h.takeEffects()).to.deep.equal([
+        "workflow.onCommit B1",
+        "store.save B1 payment_due",
+        "payment.paymentRequest B1",
+      ]);
+
+      // The payment path reads `_bookableUsed` and does mail the organizer.
+      await pay(booking.id);
+      expect(h.takeEffects()).to.include("mail.sendNewBooking B1");
+    });
+
+    it("a grant that fails on a free confirmation restores the snapshot and answers 500 (ticket 5: recorded instead)", async function () {
+      const { booking } = (await checkout("free-request-room")).data;
+      h.clearEffects();
+      h.failing.add("access.provision");
+
+      const res = await commit(booking.id);
+
+      expect(res.status).to.equal(500);
+      expect(stateOf(h.stored(booking.id))).to.equal("requested");
+      expect(h.takeEffects()).to.deep.equal([
+        "workflow.onCommit B1",
+        "store.save B1 confirmed",
+        "access.provision B1 FAILED",
+        "store.save B1 requested",
+      ]);
+    });
+
+    it("a payment request that fails answers 500 for a booking that is confirmed (ticket 5: recorded instead)", async function () {
+      const id = await bookingIn("requested");
+      h.failing.add("payment.paymentRequest");
+
+      const res = await commit(id);
+
+      expect(res.status).to.equal(500);
+      expect(stateOf(h.stored(id))).to.equal("payment_due");
+      expect(h.takeEffects()).to.deep.equal([
+        "workflow.onCommit B1",
+        "store.save B1 payment_due",
+        "payment.paymentRequest B1 FAILED",
+      ]);
+    });
+
+    it("confirms a confirmed booking again, with a second payment request (ticket 5: 409 invalid_transition)", async function () {
+      const id = await bookingIn("payment_due");
+
+      const res = await commit(id);
+
+      expect(res.status).to.equal(200);
+      expect(h.takeEffects()).to.deep.equal([
+        "workflow.onCommit B1",
+        "store.save B1 payment_due",
+        "payment.paymentRequest B1",
+      ]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+
+  describe("payment: POST /bookings/:id/pay and the payment webhook", function () {
+    it("the administration marks a booking paid: state write, grant, receipt as a second write, confirmation with the receipt", async function () {
+      const id = await bookingIn("payment_due");
+
+      const res = await pay(id, {
+        paymentMethod: "CASH",
+        timePaid: 1700000000000,
+      });
+
+      expect(res.status).to.equal(200);
+      expect(res.body).to.deep.equal({ success: true, data: null, errors: [] });
+      expect(h.stored(id)).to.include({
+        isPayed: true,
+        paymentMethod: "CASH",
+        timePaid: 1700000000000,
+      });
+      expect(
+        h.stored(id).attachments.map((att) => att.receiptId),
+      ).to.deep.equal(["RE-1"]);
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 confirmed",
+        "workflow.onPay B1",
+        "access.provision B1",
+        "documents.receipt B1",
+        "store.save B1 confirmed [receipt]",
+        "mail.sendBookingConfirmation B1 [RE-1.pdf]",
+      ]);
+    });
+
+    it("the payment webhook runs the same transition with the provider's payment method", async function () {
+      const id = await bookingIn("payment_due");
+
+      const res = await h.webhook(`id=${id}`);
+
+      expect(res.status).to.equal(200);
+      // The method is the provider's word (the harness says CREDIT_CARD).
+      expect(h.stored(id)).to.include({
+        isPayed: true,
+        paymentMethod: "CREDIT_CARD",
+      });
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 confirmed",
+        "workflow.onPay B1",
+        "access.provision B1",
+        "documents.receipt B1",
+        "store.save B1 confirmed [receipt]",
+        "mail.sendBookingConfirmation B1 [RE-1.pdf]",
+      ]);
+    });
+
+    it("pays a request that was never confirmed: the flag is set, nothing is mailed (ticket 4: 409 invalid_transition)", async function () {
+      const id = await bookingIn("requested");
+
+      const res = await pay(id);
+
+      expect(res.status).to.equal(200);
+      expect(stateOf(h.stored(id))).to.equal("paid_unconfirmed");
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 paid_unconfirmed",
+        "workflow.onPay B1",
+        "access.provision B1",
+      ]);
+    });
+
+    it("pays a paid booking again and issues a second receipt (ticket 4: 409 invalid_transition)", async function () {
+      const id = await bookingIn("confirmed");
+
+      const res = await pay(id);
+
+      expect(res.status).to.equal(200);
+      expect(
+        h.stored(id).attachments.map((att) => att.receiptId),
+      ).to.deep.equal(["RE-1", "RE-2"]);
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 confirmed [receipt]",
+        "workflow.onPay B1",
+        "access.provision B1",
+        "documents.receipt B1",
+        "store.save B1 confirmed [receipt,receipt]",
+        "mail.sendBookingConfirmation B1 [RE-2.pdf]",
+      ]);
+    });
+
+    it("a grant that fails leaves the booking paid; receipt and mail follow", async function () {
+      const id = await bookingIn("payment_due");
+      h.failing.add("access.provision");
+
+      const res = await pay(id);
+
+      expect(res.status).to.equal(200);
+      expect(stateOf(h.stored(id))).to.equal("confirmed");
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 confirmed",
+        "workflow.onPay B1",
+        "access.provision B1 FAILED",
+        "documents.receipt B1",
+        "store.save B1 confirmed [receipt]",
+        "mail.sendBookingConfirmation B1 [RE-1.pdf]",
+      ]);
+    });
+
+    it("a receipt that fails answers 500 for a booking that is paid, without receipt or mail (ticket 4: recorded instead)", async function () {
+      const id = await bookingIn("payment_due");
+      h.failing.add("documents.receipt");
+
+      const res = await pay(id);
+
+      expect(res.status).to.equal(500);
+      expect(res.text).to.equal("Could not set booking as paid");
+      expect(stateOf(h.stored(id))).to.equal("confirmed");
+      expect(h.stored(id).attachments).to.deep.equal([]);
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 confirmed",
+        "workflow.onPay B1",
+        "access.provision B1",
+        "documents.receipt B1 FAILED",
+      ]);
+    });
+
+    it("a mail that fails after the receipt is logged; the answer is 200", async function () {
+      const id = await bookingIn("payment_due");
+      h.failing.add("mail.sendBookingConfirmation");
+
+      const res = await pay(id);
+
+      expect(res.status).to.equal(200);
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 confirmed",
+        "workflow.onPay B1",
+        "access.provision B1",
+        "documents.receipt B1",
+        "store.save B1 confirmed [receipt]",
+        "mail.sendBookingConfirmation B1 [RE-1.pdf] FAILED",
+      ]);
+    });
+
+    it("paying a free booking issues no receipt", async function () {
+      const id = await bookingIn("confirmed_free");
+
+      const res = await pay(id);
+
+      expect(res.status).to.equal(200);
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 confirmed",
+        "workflow.onPay B1",
+        "access.provision B1",
+        "mail.sendBookingConfirmation B1",
+      ]);
+    });
+
+    it("the receipt replaces the `mailAttach` documents in the confirmation instead of joining them (tickets 4, 8)", async function () {
+      // Unpaid, the document of the room goes out with the confirmation.
+      const unpaid = await checkout("room-with-doc");
+      expect(h.takeEffects()).to.include(
+        "mail.sendBookingConfirmation B1 [Hausordnung.pdf]",
+      );
+
+      // Paid at once, the receipt is all that goes out.
+      await h.manualBooking("room-with-doc", {
+        isCommitted: true,
+        isPayed: true,
+      });
+      expect(h.takeEffects()).to.include(
+        "mail.sendBookingConfirmation B2 [RE-1.pdf]",
+      );
+
+      // And the payment of the unpaid one carries the receipt alone.
+      await pay(unpaid.data.booking.id);
+      expect(h.takeEffects()).to.include(
+        "mail.sendBookingConfirmation B1 [RE-2.pdf]",
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+
+  describe("cancellation: POST /bookings/:id/reject", function () {
+    it("cancels a paid booking: the cancellation document is rendered first and rides in the state write, then revoke and the cancel mail", async function () {
+      const id = await bookingIn("confirmed");
+
+      const res = await reject(id, { reason: "Raum gesperrt" });
+
+      expect(res.status).to.equal(200);
+      expect(res.text).to.equal("OK");
+      const stored = h.stored(id);
+      expect(stateOf(stored)).to.equal("cancelled");
+      expect(stored.rejectionReason).to.equal("Raum gesperrt");
+      expect(stored.cancellationRefund).to.include({
+        origin: "admin",
+        cancelledByUserId: ADMIN,
+        originalAmountEur: 40,
+      });
+      expect(stored.attachments.map((att) => att.type)).to.deep.equal([
+        "receipt",
+        "cancellation",
+      ]);
+      expect(h.takeEffects()).to.deep.equal([
+        "documents.cancellation B1",
+        "store.save B1 cancelled [receipt,cancellation]",
+        "workflow.onReject B1",
+        "access.revoke B1",
+        "mail.sendBookingCancel B1 [ST-1.pdf]",
+      ]);
+    });
+
+    it("`skipCancellation` leaves the document out and mails without attachment", async function () {
+      const id = await bookingIn("confirmed");
+
+      const res = await reject(id, { reason: "", skipCancellation: true });
+
+      expect(res.status).to.equal(200);
+      expect(h.stored(id).attachments.map((att) => att.type)).to.deep.equal([
+        "receipt",
+      ]);
+      expect(h.stored(id).cancellationRefund).to.include({ origin: "admin" });
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 cancelled [receipt]",
+        "workflow.onReject B1",
+        "access.revoke B1",
+        "mail.sendBookingCancel B1",
+      ]);
+    });
+
+    it("rejects a priced request with a cancellation document and the rejection mail", async function () {
+      const id = await bookingIn("requested");
+
+      const res = await reject(id, { reason: "Kein Platz" });
+
+      expect(res.status).to.equal(200);
+      expect(stateOf(h.stored(id))).to.equal("rejected");
+      expect(h.takeEffects()).to.deep.equal([
+        "documents.cancellation B1",
+        "store.save B1 rejected [cancellation]",
+        "workflow.onReject B1",
+        "access.revoke B1",
+        "mail.sendBookingRejection B1 [ST-1.pdf]",
+      ]);
+    });
+
+    it("cancels a free booking without a document", async function () {
+      const id = await bookingIn("confirmed_free");
+
+      const res = await reject(id, { reason: "" });
+
+      expect(res.status).to.equal(200);
+      expect(stateOf(h.stored(id))).to.equal("cancelled");
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 cancelled",
+        "workflow.onReject B1",
+        "access.revoke B1",
+        "mail.sendBookingCancel B1",
+      ]);
+    });
+
+    it("an admin refund percentage overrides the tiers; an invalid one is a 400 before any effect", async function () {
+      const id = await bookingIn("confirmed");
+
+      const invalid = await reject(id, { refundPercentage: 150 });
+      expect(invalid.status).to.equal(400);
+      expect(invalid.text).to.equal("invalid_refund_percentage");
+      expect(h.takeEffects()).to.deep.equal([]);
+
+      const res = await reject(id, { refundPercentage: 50 });
+      expect(res.status).to.equal(200);
+      expect(h.stored(id).cancellationRefund).to.include({
+        appliedRefundPercentage: 50,
+        refundAmountEur: 20,
+        cancellationFeeEur: 20,
+        adminOverride: true,
+      });
+    });
+
+    it("cancels a cancelled booking again and issues a second cancellation document (ticket 6: 409 invalid_transition)", async function () {
+      const id = await bookingIn("confirmed");
+      await reject(id, { reason: "einmal" });
+      h.clearEffects();
+
+      const res = await reject(id, { reason: "zweimal" });
+
+      expect(res.status).to.equal(200);
+      expect(
+        h.stored(id).attachments.filter((att) => att.type === "cancellation"),
+      ).to.have.length(2);
+      expect(h.takeEffects()).to.deep.equal([
+        "documents.cancellation B1",
+        "store.save B1 cancelled [receipt,cancellation,cancellation]",
+        "workflow.onReject B1",
+        "access.revoke B1",
+        "mail.sendBookingCancel B1 [ST-2.pdf]",
+      ]);
+    });
+
+    it("a cancel mail that fails answers 500 for a booking that is cancelled (ticket 6: recorded instead)", async function () {
+      const id = await bookingIn("confirmed");
+      h.failing.add("mail.sendBookingCancel");
+
+      const res = await reject(id, { reason: "" });
+
+      expect(res.status).to.equal(500);
+      expect(res.text).to.equal("Could not reject booking");
+      expect(stateOf(h.stored(id))).to.equal("cancelled");
+      expect(h.takeEffects()).to.deep.equal([
+        "documents.cancellation B1",
+        "store.save B1 cancelled [receipt,cancellation]",
+        "workflow.onReject B1",
+        "access.revoke B1",
+        "mail.sendBookingCancel B1 [ST-1.pdf] FAILED",
+      ]);
+    });
+
+    it("a revoke that fails is logged; the mail goes out", async function () {
+      const id = await bookingIn("confirmed");
+      h.failing.add("access.revoke");
+
+      const res = await reject(id, { reason: "" });
+
+      expect(res.status).to.equal(200);
+      expect(h.takeEffects()).to.deep.equal([
+        "documents.cancellation B1",
+        "store.save B1 cancelled [receipt,cancellation]",
+        "workflow.onReject B1",
+        "access.revoke B1 FAILED",
+        "mail.sendBookingCancel B1 [ST-1.pdf]",
+      ]);
+    });
+
+    it("a cancellation document that fails leaves the booking untouched, 500 (ticket 6: the document follows the write)", async function () {
+      const id = await bookingIn("confirmed");
+      h.failing.add("documents.cancellation");
+
+      const res = await reject(id, { reason: "" });
+
+      expect(res.status).to.equal(500);
+      expect(stateOf(h.stored(id))).to.equal("confirmed");
+      expect(h.stored(id).cancellationRefund).to.equal(undefined);
+      expect(h.takeEffects()).to.deep.equal([
+        "documents.cancellation B1 FAILED",
+      ]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+
+  describe("cancellation request: POST /bookings/:id/request-reject and the hook release", function () {
+    it("stores a REJECT hook and mails the verification; the state stays", async function () {
+      const id = await bookingIn("confirmed");
+
+      const res = await requestReject(id, { reason: "Krank" });
+
+      expect(res.status).to.equal(201);
+      const stored = h.stored(id);
+      expect(stateOf(stored)).to.equal("confirmed");
+      expect(stored.hooks).to.have.length(1);
+      expect(stored.hooks[0]).to.include({ type: "REJECT" });
+      expect(stored.hooks[0].payload).to.deep.equal({ reason: "Krank" });
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 confirmed [receipt]",
+        "mail.sendVerifyBookingRejection B1",
+      ]);
+    });
+
+    it("keeps the bank details of the request, trimmed and upper-cased", async function () {
+      const id = await bookingIn("confirmed");
+
+      await requestReject(id, {
+        reason: "",
+        bankDetails: {
+          accountHolder: " Erika Muster ",
+          iban: "de12 3456",
+          bic: "abc",
+          bankName: "",
+        },
+      });
+
+      expect(h.stored(id).hooks[0].payload.bankDetails).to.deep.equal({
+        accountHolder: "Erika Muster",
+        bankName: "",
+        iban: "DE123456",
+        bic: "ABC",
+      });
+    });
+
+    it("refuses a booking whose policy is not user-cancellable, 403, without effect", async function () {
+      h.bookables["fixed-room"] = bookable({
+        id: "fixed-room",
+        title: "Fester Raum",
+        autoCommitBooking: true,
+        cancellationPolicy: { userCancellable: false, contactHint: "" },
+      });
+      const { booking } = (await checkout("fixed-room")).data;
+      h.clearEffects();
+
+      const res = await requestReject(booking.id, { reason: "" });
+
+      expect(res.status).to.equal(403);
+      expect(res.body).to.include({
+        code: "booking_user_cancellation_disabled",
+      });
+      expect(h.takeEffects()).to.deep.equal([]);
+    });
+
+    it("a verification mail that fails answers 500 for a hook that is stored (ticket 6: recorded instead)", async function () {
+      const id = await bookingIn("confirmed");
+      h.failing.add("mail.sendVerifyBookingRejection");
+
+      const res = await requestReject(id, { reason: "" });
+
+      // The service builds its `BaseError` with the params where the status
+      // code goes, so the controller finds no numeric status and answers
+      // its plain 500; the error code never reaches the client.
+      expect(res.status).to.equal(500);
+      expect(res.text).to.equal("Could not reject booking");
+      expect(h.stored(id).hooks).to.have.length(1);
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 confirmed [receipt]",
+        "mail.sendVerifyBookingRejection B1 FAILED",
+      ]);
+    });
+
+    it("releasing the hook cancels as the customer: the hook goes, the refund is the customer's, the cancel mail goes out", async function () {
+      const id = await bookingIn("confirmed");
+      await requestReject(id, { reason: "Krank" });
+      const [hook] = h.stored(id).hooks;
+      h.clearEffects();
+
+      const res = await releaseHook(id, hook.id);
+
+      expect(res.status).to.equal(200);
+      const stored = h.stored(id);
+      expect(stateOf(stored)).to.equal("cancelled");
+      expect(stored.hooks).to.deep.equal([]);
+      expect(stored.rejectionReason).to.equal("Krank");
+      expect(stored.cancellationRefund).to.include({ origin: "user" });
+      expect(h.takeEffects()).to.deep.equal([
+        "documents.cancellation B1",
+        "store.save B1 cancelled [receipt,cancellation]",
+        "workflow.onReject B1",
+        "access.revoke B1",
+        "mail.sendBookingCancel B1 [ST-1.pdf]",
+      ]);
+    });
+
+    it("releasing the hook of a request sends the cancel mail, not the rejection: a hook counts as cancellation", async function () {
+      const id = await bookingIn("requested");
+      await requestReject(id, { reason: "" });
+      const [hook] = h.stored(id).hooks;
+      h.clearEffects();
+
+      const res = await releaseHook(id, hook.id);
+
+      expect(res.status).to.equal(200);
+      expect(stateOf(h.stored(id))).to.equal("rejected");
+      expect(h.takeEffects()).to.deep.equal([
+        "documents.cancellation B1",
+        "store.save B1 rejected [cancellation]",
+        "workflow.onReject B1",
+        "access.revoke B1",
+        "mail.sendBookingCancel B1 [ST-1.pdf]",
+      ]);
+    });
+
+    it("an unknown hook is a 404 without effect", async function () {
+      const id = await bookingIn("confirmed");
+      await requestReject(id, { reason: "" });
+      h.clearEffects();
+
+      const res = await releaseHook(id, "no-such-hook");
+
+      expect(res.status).to.equal(404);
+      expect(h.takeEffects()).to.deep.equal([]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+
+  describe("the admin PUT: content changes, flag flips and the hidden reinstatement", function () {
+    it("moves a paid booking: one write, the access is updated, nothing is mailed", async function () {
+      const id = await bookingIn("confirmed");
+
+      const res = await update(id, {
+        timeBegin: TIME_BEGIN + DAY,
+        timeEnd: TIME_END + DAY,
+      });
+
+      expect(res.status).to.equal(201);
+      expect(res.body).to.include({ id, timeBegin: TIME_BEGIN + DAY });
+      const stored = h.stored(id);
+      expect(stateOf(stored)).to.equal("confirmed");
+      expect(stored.attachments.map((att) => att.type)).to.deep.equal([
+        "receipt",
+      ]);
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 confirmed [receipt]",
+        "access.update B1",
+      ]);
+    });
+
+    it("changes a request: the hold is taken back and made anew", async function () {
+      const id = await bookingIn("requested");
+
+      const res = await update(id, { comment: "Bitte Beamer" });
+
+      expect(res.status).to.equal(201);
+      expect(h.stored(id).comment).to.equal("Bitte Beamer");
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 requested",
+        "access.revoke B1",
+        "access.hold B1",
+      ]);
+    });
+
+    it("drops an open cancellation request: the form does not carry the hooks, the write does not keep them", async function () {
+      const id = await bookingIn("confirmed");
+      await requestReject(id, { reason: "" });
+      expect(h.stored(id).hooks).to.have.length(1);
+
+      await update(id, { comment: "geändert" });
+
+      expect(h.stored(id).hooks).to.deep.equal([]);
+    });
+
+    it("flipping isCommitted confirms after the content write, then holds anew", async function () {
+      const id = await bookingIn("requested");
+
+      const res = await update(id, { isCommitted: true });
+
+      expect(res.status).to.equal(201);
+      expect(stateOf(h.stored(id))).to.equal("payment_due");
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 payment_due",
+        "workflow.onCommit B1",
+        "store.save B1 payment_due",
+        "payment.paymentRequest B1",
+        "access.revoke B1",
+        "access.hold B1",
+      ]);
+    });
+
+    it("flipping isCommitted and isPayed at once confirms as if free, then pays: two grants, a free-booking mail and the receipt mail", async function () {
+      const id = await bookingIn("requested");
+
+      const res = await update(id, { isCommitted: true, isPayed: true });
+
+      expect(res.status).to.equal(201);
+      expect(stateOf(h.stored(id))).to.equal("confirmed");
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 confirmed",
+        "workflow.onCommit B1",
+        "store.save B1 confirmed",
+        "access.provision B1",
+        // The booking is paid when `commitBooking` reads it, so it goes the
+        // "no payment required" way of a free booking.
+        "mail.sendFreeBookingConfirmation B1",
+        "store.save B1 confirmed",
+        "workflow.onPay B1",
+        "access.provision B1",
+        "documents.receipt B1",
+        "store.save B1 confirmed [receipt]",
+        "mail.sendBookingConfirmation B1 [RE-1.pdf]",
+        "access.update B1",
+      ]);
+    });
+
+    it("flipping isRejected cancels as the system, with a full refund", async function () {
+      const id = await bookingIn("confirmed");
+
+      const res = await update(id, {
+        isRejected: true,
+        rejectionReason: "Doppelbuchung",
+      });
+
+      expect(res.status).to.equal(201);
+      const stored = h.stored(id);
+      expect(stateOf(stored)).to.equal("cancelled");
+      expect(stored.cancellationRefund).to.include({
+        origin: "system",
+        appliedRefundPercentage: 100,
+      });
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 cancelled [receipt]",
+        "documents.cancellation B1",
+        "store.save B1 cancelled [receipt,cancellation]",
+        "workflow.onReject B1",
+        "access.revoke B1",
+        "mail.sendBookingCancel B1 [ST-1.pdf]",
+      ]);
+    });
+
+    it("clearing isRejected reinstates: price and items of before, no refund, a new grant, no mail", async function () {
+      const id = await bookingIn("confirmed");
+      await reject(id, { reason: "Irrtum", refundPercentage: 50 });
+      expect(h.stored(id).cancellationRefund).to.include({
+        appliedRefundPercentage: 50,
+      });
+      h.clearEffects();
+
+      const res = await update(id, { isRejected: false });
+
+      expect(res.status).to.equal(201);
+      const stored = h.stored(id);
+      expect(stateOf(stored)).to.equal("confirmed");
+      expect(stored).to.include({ priceEur: 40, rejectionReason: "" });
+      expect(stored.cancellationRefund).to.equal(undefined);
+      expect(stored.attachments.map((att) => att.type)).to.deep.equal([
+        "receipt",
+        "cancellation",
+      ]);
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 confirmed [receipt,cancellation]",
+        "access.provision B1",
+      ]);
+    });
+
+    it("a failed flip restores the old booking but leaves the refund behind, and the mails are out (ticket 7)", async function () {
+      const id = await bookingIn("confirmed");
+      h.failing.add("mail.sendBookingCancel");
+
+      const res = await update(id, { isRejected: true });
+
+      // 500, but not the error handler's JSON: the service's `BaseError`
+      // carries its params where the status code goes, the handler fails
+      // on `res.status(...)`, and express answers its bare 500.
+      expect(res.status).to.equal(500);
+      expect(res.body).to.deep.equal({});
+      const stored = h.stored(id);
+      expect(stateOf(stored)).to.equal("confirmed");
+      expect(stored.cancellationRefund).to.include({ origin: "system" });
+      expect(stored.attachments.map((att) => att.type)).to.deep.equal([
+        "receipt",
+      ]);
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 cancelled [receipt]",
+        "documents.cancellation B1",
+        "store.save B1 cancelled [receipt,cancellation]",
+        "workflow.onReject B1",
+        "access.revoke B1",
+        "mail.sendBookingCancel B1 [ST-1.pdf] FAILED",
+        "store.save B1 confirmed [receipt]",
+      ]);
+    });
+
+    it("stores any flag combination: paid without confirmed is written as sent (ticket 7: 400 invalid_status_change)", async function () {
+      const id = await bookingIn("confirmed");
+
+      const res = await update(id, { isCommitted: false, isPayed: true });
+
+      expect(res.status).to.equal(201);
+      expect(stateOf(h.stored(id))).to.equal("paid_unconfirmed");
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 paid_unconfirmed [receipt]",
+        "access.revoke B1",
+        "access.hold B1",
+      ]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+
+  describe("reprint: POST /bookings/:id/receipt and /invoice", function () {
+    it("reprints the receipt of a paid booking as a further attachment and answers the booking", async function () {
+      const id = await bookingIn("confirmed");
+
+      const res = await api()
+        .post(`/api/${TENANT}/bookings/${id}/receipt`)
+        .set(h.as(ADMIN));
+
+      expect(res.status).to.equal(200);
+      expect(res.body.success).to.equal(true);
+      expect(
+        res.body.data.attachments.map((att) => att.receiptId),
+      ).to.deep.equal(["RE-1", "RE-2"]);
+      expect(h.takeEffects()).to.deep.equal([
+        "documents.receipt B1",
+        "store.save B1 confirmed [receipt,receipt]",
+      ]);
+    });
+
+    it("refuses the receipt of an unpaid booking as a consistency error, 200", async function () {
+      const id = await bookingIn("payment_due");
+
+      const res = await api()
+        .post(`/api/${TENANT}/bookings/${id}/receipt`)
+        .set(h.as(ADMIN));
+
+      expect(res.status).to.equal(200);
+      expect(res.body.success).to.equal(false);
+      expect(res.body.errors.map((error) => error.code)).to.deep.equal([
+        "PAYED_STATUS",
+      ]);
+      expect(h.takeEffects()).to.deep.equal([]);
+    });
+
+    it("issues an invoice on demand and mails it unless told not to", async function () {
+      const id = await bookingIn("payment_due");
+
+      const silent = await api()
+        .post(`/api/${TENANT}/bookings/${id}/invoice?sendEmail=false`)
+        .set(h.as(ADMIN));
+
+      expect(silent.status).to.equal(200);
+      expect(silent.body).to.include({ success: true, emailSent: false });
+      expect(silent.body.invoice).to.deep.equal({
+        name: "RG-1.pdf",
+        invoiceId: "RG-1",
+        revision: 1,
+      });
+      expect(h.takeEffects()).to.deep.equal([
+        "documents.invoice B1",
+        "store.save B1 payment_due [invoice]",
+      ]);
+
+      const mailed = await api()
+        .post(`/api/${TENANT}/bookings/${id}/invoice`)
+        .set(h.as(ADMIN));
+
+      expect(mailed.status).to.equal(200);
+      expect(mailed.body).to.include({ emailSent: true });
+      expect(h.takeEffects()).to.deep.equal([
+        "documents.invoice B1",
+        "store.save B1 payment_due [invoice,invoice]",
+        "mail.sendInvoice B1 [RG-2.pdf]",
+      ]);
+    });
+
+    it("refuses the invoice when the invoice app is inactive, 400", async function () {
+      const id = await bookingIn("payment_due");
+      h.tenant.applications.find((app) => app.id === "invoice").active = false;
+
+      const res = await api()
+        .post(`/api/${TENANT}/bookings/${id}/invoice`)
+        .set(h.as(ADMIN));
+
+      expect(res.status).to.equal(400);
+      expect(h.takeEffects()).to.deep.equal([]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+
+  describe("the workflow action calls the transitions without their workflow event", function () {
+    const run = (bookingStatus, id) =>
+      new BookingStatusAction({ bookingStatus }, id, TENANT).execute();
+
+    it("commit", async function () {
+      const id = await bookingIn("requested");
+
+      await run(["commit"], id);
+
+      expect(stateOf(h.stored(id))).to.equal("payment_due");
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 payment_due",
+        "payment.paymentRequest B1",
+      ]);
+    });
+
+    it("paid", async function () {
+      const id = await bookingIn("payment_due");
+
+      await run(["paid"], id);
+
+      expect(stateOf(h.stored(id))).to.equal("confirmed");
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 confirmed",
+        "access.provision B1",
+        "documents.receipt B1",
+        "store.save B1 confirmed [receipt]",
+        "mail.sendBookingConfirmation B1 [RE-1.pdf]",
+      ]);
+    });
+
+    it("reject, as the system with a full refund and the document", async function () {
+      const id = await bookingIn("confirmed");
+
+      await run(["reject"], id);
+
+      expect(stateOf(h.stored(id))).to.equal("cancelled");
+      expect(h.stored(id).cancellationRefund).to.include({
+        origin: "system",
+        appliedRefundPercentage: 100,
+      });
+      expect(h.takeEffects()).to.deep.equal([
+        "documents.cancellation B1",
+        "store.save B1 cancelled [receipt,cancellation]",
+        "access.revoke B1",
+        "mail.sendBookingCancel B1 [ST-1.pdf]",
+      ]);
+    });
+  });
+});

--- a/tests/group-booking-lifecycle-characterization.test.js
+++ b/tests/group-booking-lifecycle-characterization.test.js
@@ -1,0 +1,717 @@
+/**
+ * Characterization of the group booking lifecycle as it is today, seen
+ * through the HTTP form: admission by the group checkout, confirmation,
+ * payment (administration and aggregated webhook), cancellation and the
+ * two reprint endpoints of a group. Companion of
+ * `booking-lifecycle-characterization.test.js`, written for the same
+ * ticket: the group variants and the known defects that belong to them
+ * (turned by ticket 8 of the chain).
+ *
+ * The group runs its transitions member by member without rollback, then
+ * issues one document and one mail for the group. Each case lists the
+ * effects at the seam in the order they happen today; the member labels
+ * B1, B2 follow the order of the first write.
+ */
+
+const { expect } = require("chai");
+const sinon = require("sinon");
+
+const {
+  installHarness,
+  stateOf,
+  TENANT,
+  ADMIN,
+  CUSTOMER,
+  TIME_BEGIN,
+  TIME_END,
+  DAY,
+} = require("./helpers/booking-lifecycle-harness");
+const GroupBookingManager = require("../src/commons/data-managers/group-booking-manager");
+
+describe("group booking lifecycle today: what each state change does at the seam", function () {
+  let h;
+
+  beforeEach(async function () {
+    h = await installHarness();
+  });
+
+  afterEach(async function () {
+    sinon.restore();
+    await h.close();
+  });
+
+  // --- the requests ------------------------------------------------------
+
+  const api = () => h.api();
+
+  /** A customer's group checkout of two slots, a day apart. */
+  async function groupCheckout(bookableId, overrides = {}) {
+    const res = await api()
+      .post(`/api/v2/${TENANT}/checkout/group`)
+      .set(h.as(CUSTOMER))
+      .send({
+        bookableItems: [{ bookableId, amount: 1 }],
+        bookingAttempts: [
+          { timeBegin: TIME_BEGIN, timeEnd: TIME_END },
+          { timeBegin: TIME_BEGIN + DAY, timeEnd: TIME_END + DAY },
+        ],
+        name: "Erika Muster",
+        mail: CUSTOMER,
+        paymentProvider: "giroCockpit",
+        ...overrides,
+      });
+    expect(res.status).to.equal(200);
+    return res.body;
+  }
+
+  /** A stored group over bookings that exist already. */
+  async function seedGroup(bookingIds) {
+    await GroupBookingManager.storeGroupBooking({
+      id: "G-SEED-TEST",
+      tenantId: TENANT,
+      bookingIds,
+      assignedUserId: CUSTOMER,
+      mail: CUSTOMER,
+    });
+    h.clearEffects();
+    return "G-SEED-TEST";
+  }
+
+  const commit = (id) =>
+    api().post(`/api/${TENANT}/group-bookings/${id}/commit`).set(h.as(ADMIN));
+  const pay = (id, body = {}) =>
+    api()
+      .post(`/api/${TENANT}/group-bookings/${id}/pay`)
+      .set(h.as(ADMIN))
+      .send(body);
+  const reject = (id, body = {}) =>
+    api()
+      .post(`/api/${TENANT}/group-bookings/${id}/reject`)
+      .set(h.as(ADMIN))
+      .send(body);
+  const states = (groupId) => h.members(groupId).map(stateOf);
+
+  /** A group in a given state, with the rows of getting there forgotten. */
+  async function groupIn(state) {
+    let id;
+    switch (state) {
+      case "requested":
+        id = (await groupCheckout("room")).data.groupBooking.id;
+        break;
+      case "payment_due":
+        id = (await groupCheckout("auto-room")).data.groupBooking.id;
+        break;
+      case "confirmed":
+        id = (await groupCheckout("auto-room")).data.groupBooking.id;
+        await pay(id);
+        break;
+      default:
+        throw new Error(`unknown state ${state}`);
+    }
+    expect(states(id)).to.deep.equal([state, state]);
+    h.clearEffects();
+    return id;
+  }
+
+  // -----------------------------------------------------------------------
+
+  describe("admission: the group checkout stores the members one by one and mails once", function () {
+    it("a group of a room to be confirmed arrives requested, one request confirmation for the group", async function () {
+      const body = await groupCheckout("room");
+
+      const { groupBooking, payment } = body.data;
+      expect(groupBooking.id).to.match(/^G-/);
+      expect(groupBooking.bookingIds).to.have.length(2);
+      expect(payment).to.equal(null);
+      expect(states(groupBooking.id)).to.deep.equal(["requested", "requested"]);
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 requested",
+        "workflow.onCreate B1 without skipBookingStatus",
+        "access.hold B1",
+        "store.save B2 requested",
+        "workflow.onCreate B2 without skipBookingStatus",
+        "access.hold B2",
+        "mail.sendBookingRequestConfirmation B1,B2",
+        "mail.sendIncomingBooking B1,B2",
+        "supervisor.notify B1,B2",
+      ]);
+    });
+
+    it("a group confirmed at once arrives payment due and goes on to the aggregated payment link", async function () {
+      const body = await groupCheckout("auto-room");
+
+      const { groupBooking, payment } = body.data;
+      expect(payment).to.deep.equal({
+        provider: "giroCockpit",
+        data: { url: "https://pay.example.test" },
+      });
+      expect(states(groupBooking.id)).to.deep.equal([
+        "payment_due",
+        "payment_due",
+      ]);
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 payment_due",
+        "workflow.onCreate B1 without skipBookingStatus",
+        "access.hold B1",
+        "store.save B2 payment_due",
+        "workflow.onCreate B2 without skipBookingStatus",
+        "access.hold B2",
+        "mail.sendBookingConfirmation B1,B2",
+        "mail.sendIncomingBooking B1,B2",
+        "supervisor.notify B1,B2",
+        "access.refreshHolds B1,B2",
+        "payment.createPayment B1,B2 aggregated",
+      ]);
+    });
+
+    it("a free group confirmed at once arrives confirmed and granted", async function () {
+      const body = await groupCheckout("free-room");
+
+      const { groupBooking, payment } = body.data;
+      expect(payment).to.equal(null);
+      expect(states(groupBooking.id)).to.deep.equal(["confirmed", "confirmed"]);
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 confirmed",
+        "workflow.onCreate B1 without skipBookingStatus",
+        "access.hold B1",
+        "access.provision B1",
+        "store.save B2 confirmed",
+        "workflow.onCreate B2 without skipBookingStatus",
+        "access.hold B2",
+        "access.provision B2",
+        "mail.sendBookingConfirmation B1,B2",
+        "mail.sendIncomingBooking B1,B2",
+        "supervisor.notify B1,B2",
+      ]);
+    });
+
+    it("the legacy group checkout answers the group booking itself and runs the same effects", async function () {
+      const slot = (timeBegin, timeEnd) => ({
+        timeBegin,
+        timeEnd,
+        bookableItems: [
+          { bookableId: "room", amount: 1, bookable: { id: "room" } },
+        ],
+      });
+
+      const res = await api()
+        .post(`/api/${TENANT}/checkout/group`)
+        .set(h.as(CUSTOMER))
+        .send({
+          bookingAttempts: [
+            slot(TIME_BEGIN, TIME_END),
+            slot(TIME_BEGIN + DAY, TIME_END + DAY),
+          ],
+          contactData: { name: "Erika Muster", mail: CUSTOMER },
+          paymentProvider: "giroCockpit",
+        });
+
+      expect(res.status).to.equal(200);
+      expect(res.body.id).to.match(/^G-/);
+      expect(res.body.bookings).to.have.length(2);
+      expect(states(res.body.id)).to.deep.equal(["requested", "requested"]);
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 requested",
+        "workflow.onCreate B1 without skipBookingStatus",
+        "access.hold B1",
+        "store.save B2 requested",
+        "workflow.onCreate B2 without skipBookingStatus",
+        "access.hold B2",
+        "mail.sendBookingRequestConfirmation B1,B2",
+        "mail.sendIncomingBooking B1,B2",
+        "supervisor.notify B1,B2",
+      ]);
+    });
+
+    it("a hold that fails at the second member rolls that member back and leaves the first without a group (ticket 8)", async function () {
+      h.failing.add("access.hold B2");
+
+      const body = await groupCheckout("room");
+
+      expect(body.success).to.equal(false);
+      expect(h.store.size).to.equal(1);
+      expect(h.groups.size).to.equal(0);
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 requested",
+        "workflow.onCreate B1 without skipBookingStatus",
+        "access.hold B1",
+        "store.save B2 requested",
+        "workflow.onCreate B2 without skipBookingStatus",
+        "access.hold B2 FAILED",
+        "store.remove B2",
+      ]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+
+  describe("confirmation: POST /group-bookings/:id/commit", function () {
+    it("confirms member by member, workflow after each write, then one aggregated payment request", async function () {
+      const id = await groupIn("requested");
+
+      const res = await commit(id);
+
+      expect(res.status).to.equal(200);
+      expect(res.body.success).to.equal(true);
+      expect(res.body.data.bookings.map((b) => b.isCommitted)).to.deep.equal([
+        true,
+        true,
+      ]);
+      expect(states(id)).to.deep.equal(["payment_due", "payment_due"]);
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 payment_due",
+        "workflow.onCommit B1",
+        "store.save B2 payment_due",
+        "workflow.onCommit B2",
+        "payment.paymentRequest B1,B2 aggregated",
+      ]);
+    });
+
+    it("confirms a free group, grants each member and sends one free booking confirmation", async function () {
+      const { groupBooking } = (await groupCheckout("free-request-room")).data;
+      expect(states(groupBooking.id)).to.deep.equal(["requested", "requested"]);
+      h.clearEffects();
+
+      const res = await commit(groupBooking.id);
+
+      expect(res.status).to.equal(200);
+      expect(states(groupBooking.id)).to.deep.equal(["confirmed", "confirmed"]);
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 confirmed",
+        "workflow.onCommit B1",
+        "store.save B2 confirmed",
+        "workflow.onCommit B2",
+        "access.provision B1",
+        "access.provision B2",
+        "mail.sendFreeBookingConfirmation B1,B2",
+      ]);
+    });
+
+    it("answers success without a payment service - unlike the single commit (ticket 5)", async function () {
+      const id = await groupIn("requested");
+      h.payment.available = false;
+
+      const res = await commit(id);
+
+      expect(res.status).to.equal(200);
+      expect(res.body.success).to.equal(true);
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 payment_due",
+        "workflow.onCommit B1",
+        "store.save B2 payment_due",
+        "workflow.onCommit B2",
+      ]);
+    });
+
+    it("never mails the organizer of a ticket group: the block reads `type` off the item and, for a priced group, sits after the return (tickets 5, 8)", async function () {
+      const first = await h.manualBooking("ticket", { isPayed: true });
+      const second = await h.manualBooking("ticket", { isPayed: true });
+      const paid = await seedGroup([first.id, second.id]);
+
+      const res = await commit(paid);
+
+      expect(res.status).to.equal(200);
+      // Paid already, the group takes the free-booking way, where the
+      // ticket block is reachable - and still finds no ticket.
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 confirmed",
+        "workflow.onCommit B1",
+        "store.save B2 confirmed",
+        "workflow.onCommit B2",
+        "access.provision B1",
+        "access.provision B2",
+        "mail.sendFreeBookingConfirmation B1,B2",
+      ]);
+
+      // Priced, the commit returns with the payment request, before the
+      // ticket block.
+      const third = await h.manualBooking("ticket");
+      const fourth = await h.manualBooking("ticket");
+      await GroupBookingManager.storeGroupBooking({
+        id: "G-SEED-PRICED",
+        tenantId: TENANT,
+        bookingIds: [third.id, fourth.id],
+        assignedUserId: CUSTOMER,
+        mail: CUSTOMER,
+      });
+      h.clearEffects();
+
+      const priced = await commit("G-SEED-PRICED");
+
+      expect(priced.status).to.equal(200);
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B3 payment_due",
+        "workflow.onCommit B3",
+        "store.save B4 payment_due",
+        "workflow.onCommit B4",
+        "payment.paymentRequest B3,B4 aggregated",
+      ]);
+    });
+
+    it("a write that fails at the second member leaves the first confirmed, 500 (ticket 8: restored)", async function () {
+      const id = await groupIn("requested");
+      h.failing.add("store.save B2");
+
+      const res = await commit(id);
+
+      expect(res.status).to.equal(500);
+      expect(res.body).to.deep.equal({ message: "store.save failed" });
+      expect(states(id)).to.deep.equal(["payment_due", "requested"]);
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 payment_due",
+        "workflow.onCommit B1",
+        "store.save B2 FAILED",
+      ]);
+    });
+
+    it("refuses a group whose members differ in state, 200 with the consistency error, without effect", async function () {
+      const first = await h.manualBooking("room");
+      const second = await h.manualBooking("room", { isCommitted: true });
+      const id = await seedGroup([first.id, second.id]);
+
+      const res = await commit(id);
+
+      expect(res.status).to.equal(200);
+      expect(res.body.success).to.equal(false);
+      expect(res.body.errors.map((error) => error.code)).to.deep.equal([
+        "STATUS_MISMATCH",
+      ]);
+      expect(h.takeEffects()).to.deep.equal([]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+
+  describe("payment: POST /group-bookings/:id/pay and the aggregated webhook", function () {
+    it("pays member by member, then one aggregated receipt attached to each, one confirmation - and no workflow event (ticket 8)", async function () {
+      const id = await groupIn("payment_due");
+
+      const res = await pay(id, { paymentMethod: "CASH" });
+
+      expect(res.status).to.equal(200);
+      expect(res.body.success).to.equal(true);
+      expect(res.body.data.bookings.map((b) => b.isPayed)).to.deep.equal([
+        true,
+        true,
+      ]);
+      expect(states(id)).to.deep.equal(["confirmed", "confirmed"]);
+      for (const member of h.members(id)) {
+        expect(member.paymentMethod).to.equal("CASH");
+        expect(member.attachments.map((att) => att.receiptId)).to.deep.equal([
+          "RE-1",
+        ]);
+      }
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 confirmed",
+        "access.provision B1",
+        "store.save B2 confirmed",
+        "access.provision B2",
+        "documents.aggregatedReceipt B1,B2",
+        "store.save B1 confirmed [receipt]",
+        "store.save B2 confirmed [receipt]",
+        "mail.sendBookingConfirmation B1,B2 [RE-1.pdf]",
+      ]);
+    });
+
+    it("the aggregated webhook runs the same transition, whether it names the members or the group", async function () {
+      const id = await groupIn("payment_due");
+      const [first, second] = h.groups.get(id).bookingIds;
+
+      const byMembers = await h.webhook(
+        `ids=${first},${second}&aggregated=true`,
+      );
+
+      expect(byMembers.status).to.equal(200);
+      expect(states(id)).to.deep.equal(["confirmed", "confirmed"]);
+      expect(h.members(id).map((m) => m.paymentMethod)).to.deep.equal([
+        "CREDIT_CARD",
+        "CREDIT_CARD",
+      ]);
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 confirmed",
+        "access.provision B1",
+        "store.save B2 confirmed",
+        "access.provision B2",
+        "documents.aggregatedReceipt B1,B2",
+        "store.save B1 confirmed [receipt]",
+        "store.save B2 confirmed [receipt]",
+        "mail.sendBookingConfirmation B1,B2 [RE-1.pdf]",
+      ]);
+
+      const other = await groupIn("payment_due");
+      const byGroup = await h.webhook(`id=${other}&aggregated=true`);
+
+      expect(byGroup.status).to.equal(200);
+      expect(states(other)).to.deep.equal(["confirmed", "confirmed"]);
+      expect(h.takeEffects()).to.include(
+        "mail.sendBookingConfirmation B3,B4 [RE-2.pdf]",
+      );
+    });
+
+    it("a receipt that fails answers 500 for a group that is paid (ticket 8: recorded instead)", async function () {
+      const id = await groupIn("payment_due");
+      h.failing.add("documents.aggregatedReceipt");
+
+      const res = await pay(id);
+
+      expect(res.status).to.equal(500);
+      // The service's `BaseError` carries its message as the code; the
+      // cause stays in the log.
+      expect(res.body).to.deep.equal({
+        message: "set_aggregated_booking_payed_failed",
+      });
+      expect(states(id)).to.deep.equal(["confirmed", "confirmed"]);
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 confirmed",
+        "access.provision B1",
+        "store.save B2 confirmed",
+        "access.provision B2",
+        "documents.aggregatedReceipt B1,B2 FAILED",
+      ]);
+    });
+
+    it("a grant that fails at one member is logged; the group is paid and mailed", async function () {
+      const id = await groupIn("payment_due");
+      h.failing.add("access.provision B1");
+
+      const res = await pay(id);
+
+      expect(res.status).to.equal(200);
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 confirmed",
+        "access.provision B1 FAILED",
+        "store.save B2 confirmed",
+        "access.provision B2",
+        "documents.aggregatedReceipt B1,B2",
+        "store.save B1 confirmed [receipt]",
+        "store.save B2 confirmed [receipt]",
+        "mail.sendBookingConfirmation B1,B2 [RE-1.pdf]",
+      ]);
+    });
+
+    it("the aggregated receipt replaces the `mailAttach` documents in the confirmation instead of joining them (ticket 8)", async function () {
+      // Unpaid, the document of the room goes out once for the group.
+      const { groupBooking } = (await groupCheckout("room-with-doc")).data;
+      expect(h.takeEffects()).to.include(
+        "mail.sendBookingConfirmation B1,B2 [Hausordnung.pdf]",
+      );
+
+      await pay(groupBooking.id);
+
+      expect(h.takeEffects()).to.include(
+        "mail.sendBookingConfirmation B1,B2 [RE-1.pdf]",
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+
+  describe("cancellation: POST /group-bookings/:id/reject", function () {
+    it("renders one cancellation document first, cancels member by member with revoke and workflow, then one cancel mail", async function () {
+      const id = await groupIn("confirmed");
+
+      const res = await reject(id, { reason: "Halle gesperrt" });
+
+      expect(res.status).to.equal(200);
+      expect(res.body.success).to.equal(true);
+      expect(states(id)).to.deep.equal(["cancelled", "cancelled"]);
+      for (const member of h.members(id)) {
+        expect(member.rejectionReason).to.equal("Halle gesperrt");
+        expect(member.cancellationRefund).to.include({
+          origin: "admin",
+          cancelledByUserId: ADMIN,
+        });
+        expect(member.attachments.map((att) => att.type)).to.deep.equal([
+          "receipt",
+          "cancellation",
+        ]);
+      }
+      expect(h.takeEffects()).to.deep.equal([
+        "documents.aggregatedCancellation B1,B2",
+        "store.save B1 cancelled [receipt,cancellation]",
+        "access.revoke B1",
+        "workflow.onReject B1",
+        "store.save B2 cancelled [receipt,cancellation]",
+        "access.revoke B2",
+        "workflow.onReject B2",
+        "mail.sendBookingCancel B1,B2 [ST-1.pdf]",
+      ]);
+    });
+
+    it("`skipCancellation` leaves the document out", async function () {
+      const id = await groupIn("confirmed");
+
+      const res = await reject(id, { reason: "", skipCancellation: true });
+
+      expect(res.status).to.equal(200);
+      expect(h.takeEffects()).to.deep.equal([
+        "store.save B1 cancelled [receipt]",
+        "access.revoke B1",
+        "workflow.onReject B1",
+        "store.save B2 cancelled [receipt]",
+        "access.revoke B2",
+        "workflow.onReject B2",
+        "mail.sendBookingCancel B1,B2",
+      ]);
+    });
+
+    it("rejects a requested group with the document and the rejection mail", async function () {
+      const id = await groupIn("requested");
+
+      const res = await reject(id, { reason: "Kein Platz" });
+
+      expect(res.status).to.equal(200);
+      expect(states(id)).to.deep.equal(["rejected", "rejected"]);
+      expect(h.takeEffects()).to.deep.equal([
+        "documents.aggregatedCancellation B1,B2",
+        "store.save B1 rejected [cancellation]",
+        "access.revoke B1",
+        "workflow.onReject B1",
+        "store.save B2 rejected [cancellation]",
+        "access.revoke B2",
+        "workflow.onReject B2",
+        "mail.sendBookingRejection B1,B2 [ST-1.pdf]",
+      ]);
+    });
+
+    it("refuses a group whose members differ in state, without effect", async function () {
+      const first = await h.manualBooking("room");
+      const second = await h.manualBooking("room", { isCommitted: true });
+      const id = await seedGroup([first.id, second.id]);
+
+      const res = await reject(id, { reason: "" });
+
+      expect(res.status).to.equal(200);
+      expect(res.body.success).to.equal(false);
+      expect(res.body.errors.map((error) => error.code)).to.deep.equal([
+        "STATUS_MISMATCH",
+      ]);
+      expect(h.takeEffects()).to.deep.equal([]);
+    });
+
+    it("a cancel mail that fails answers 500 for a group that is cancelled (ticket 8: recorded instead)", async function () {
+      const id = await groupIn("confirmed");
+      h.failing.add("mail.sendBookingCancel");
+
+      const res = await reject(id, { reason: "" });
+
+      expect(res.status).to.equal(500);
+      expect(states(id)).to.deep.equal(["cancelled", "cancelled"]);
+      expect(h.takeEffects().at(-1)).to.equal(
+        "mail.sendBookingCancel B1,B2 [ST-1.pdf] FAILED",
+      );
+    });
+
+    it("a revoke that fails at one member is logged; the group is cancelled and mailed", async function () {
+      const id = await groupIn("confirmed");
+      h.failing.add("access.revoke B2");
+
+      const res = await reject(id, { reason: "" });
+
+      expect(res.status).to.equal(200);
+      expect(h.takeEffects()).to.deep.equal([
+        "documents.aggregatedCancellation B1,B2",
+        "store.save B1 cancelled [receipt,cancellation]",
+        "access.revoke B1",
+        "workflow.onReject B1",
+        "store.save B2 cancelled [receipt,cancellation]",
+        "access.revoke B2 FAILED",
+        "workflow.onReject B2",
+        "mail.sendBookingCancel B1,B2 [ST-1.pdf]",
+      ]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+
+  describe("reprint: POST /group-bookings/:id/receipt and /invoice", function () {
+    it("reprints one aggregated receipt attached to every member and answers the group", async function () {
+      const id = await groupIn("confirmed");
+
+      const res = await api()
+        .post(`/api/${TENANT}/group-bookings/${id}/receipt`)
+        .set(h.as(ADMIN));
+
+      expect(res.status).to.equal(200);
+      expect(res.body.success).to.equal(true);
+      for (const member of res.body.data.bookings) {
+        expect(member.attachments.map((att) => att.receiptId)).to.deep.equal([
+          "RE-1",
+          "RE-2",
+        ]);
+      }
+      expect(h.takeEffects()).to.deep.equal([
+        "documents.aggregatedReceipt B1,B2",
+        "store.save B1 confirmed [receipt,receipt]",
+        "store.save B2 confirmed [receipt,receipt]",
+      ]);
+    });
+
+    it("refuses the receipt of an unpaid group as a consistency error", async function () {
+      const id = await groupIn("payment_due");
+
+      const res = await api()
+        .post(`/api/${TENANT}/group-bookings/${id}/receipt`)
+        .set(h.as(ADMIN));
+
+      expect(res.status).to.equal(200);
+      expect(res.body.success).to.equal(false);
+      expect(res.body.errors.map((error) => error.code)).to.deep.equal([
+        "PAYED_STATUS",
+      ]);
+      expect(h.takeEffects()).to.deep.equal([]);
+    });
+
+    it("issues one aggregated invoice for a group paying by invoice and mails it unless told not to", async function () {
+      const { groupBooking } = (
+        await groupCheckout("auto-room", { paymentProvider: "invoice" })
+      ).data;
+      const id = groupBooking.id;
+      h.clearEffects();
+
+      const silent = await api()
+        .post(`/api/${TENANT}/group-bookings/${id}/invoice?sendEmail=false`)
+        .set(h.as(ADMIN));
+
+      expect(silent.status).to.equal(200);
+      expect(silent.body.success).to.equal(true);
+      for (const member of silent.body.data.bookings) {
+        expect(member.attachments.map((att) => att.invoiceId)).to.deep.equal([
+          "RG-1",
+        ]);
+      }
+      expect(h.takeEffects()).to.deep.equal([
+        "documents.aggregatedInvoice B1,B2",
+        "store.save B1 payment_due [invoice]",
+        "store.save B2 payment_due [invoice]",
+      ]);
+
+      const mailed = await api()
+        .post(`/api/${TENANT}/group-bookings/${id}/invoice`)
+        .set(h.as(ADMIN));
+
+      expect(mailed.status).to.equal(200);
+      expect(h.takeEffects()).to.deep.equal([
+        "documents.aggregatedInvoice B1,B2",
+        "store.save B1 payment_due [invoice,invoice]",
+        "store.save B2 payment_due [invoice,invoice]",
+        "mail.sendInvoice B1,B2 [RG-2.pdf]",
+      ]);
+    });
+
+    it("refuses the invoice of a group not paying by invoice as a consistency error", async function () {
+      const id = await groupIn("payment_due");
+
+      const res = await api()
+        .post(`/api/${TENANT}/group-bookings/${id}/invoice`)
+        .set(h.as(ADMIN));
+
+      expect(res.status).to.equal(200);
+      expect(res.body.success).to.equal(false);
+      expect(res.body.errors.map((error) => error.code)).to.deep.equal([
+        "INVOICE_PAYMENT_REQUIRED",
+      ]);
+      expect(h.takeEffects()).to.deep.equal([]);
+    });
+  });
+});

--- a/tests/helpers/booking-lifecycle-harness.js
+++ b/tests/helpers/booking-lifecycle-harness.js
@@ -1,0 +1,689 @@
+/**
+ * The harness of the booking lifecycle characterization tests: the real
+ * routers of the API on a bare express app, driven with `supertest`, with
+ * the world below the services stubbed at the data managers and every
+ * effect at the seam recorded as one row.
+ *
+ * What runs for real: the routers (with the JWT middleware, its token
+ * verification stubbed), the controllers, `BookingService`, the checkout
+ * (`BundleCheckoutService`, `ItemCheckoutService`), the entities, the
+ * refund calculation and the base `PaymentService` webhook path.
+ *
+ * What is a fake: the booking and group booking stores (in memory, with
+ * the `$set` semantics of `updateOne`, so a restore leaves behind what the
+ * old document did not carry), and the effect seams - access, documents,
+ * mail, workflow, payment provider, supervisor mail - which record a row
+ * and, when told to, fail.
+ *
+ * The rows are the effect table of a transition (spec part 1, 4.3):
+ *
+ *   store.save B1 payment_due [receipt]     a store write, state and documents
+ *   access.provision B1                     an access seam call
+ *   documents.receipt B1                    a document rendered
+ *   mail.sendBookingConfirmation B1 [RE-1.pdf]   a mail with its attachments
+ *   workflow.onPay B1                       a workflow event
+ *   payment.paymentRequest B1               the payment provider asked
+ *
+ * Booking ids are random; the table names bookings B1, B2, ... in the
+ * order their first write happened.
+ */
+
+const express = require("express");
+const http = require("http");
+const jwt = require("jsonwebtoken");
+const sinon = require("sinon");
+const request = require("supertest");
+
+process.env.CRYPTO_SECRET =
+  process.env.CRYPTO_SECRET || "0123456789abcdef0123456789abcdef";
+process.env.JWT_SECRET = process.env.JWT_SECRET || "characterization-secret";
+
+const { errorHandler } = require("../../src/middleware/error-handler");
+const JwtHelper = require("../../src/commons/utilities/jwt-helper");
+const BookingManager = require("../../src/commons/data-managers/booking-manager");
+const GroupBookingManager = require("../../src/commons/data-managers/group-booking-manager");
+const {
+  BookableManager,
+} = require("../../src/commons/data-managers/bookable-manager");
+const TenantManager = require("../../src/commons/data-managers/tenant-manager");
+const UserManager = require("../../src/commons/data-managers/user-manager");
+const EventManager = require("../../src/commons/data-managers/event-manager");
+const MembershipManager = require("../../src/commons/data-managers/membership-manager");
+const AccessPointManager = require("../../src/commons/data-managers/access-point-manager");
+const MediaManager = require("../../src/commons/data-managers/media-manager");
+const WorkflowManager = require("../../src/commons/data-managers/workflow-manager");
+const OpeningHoursManager = require("../../src/commons/utilities/opening-hours-manager");
+const PaymentUtils = require("../../src/commons/utilities/payment-utils");
+const PermissionsService = require("../../src/commons/services/permission-service");
+const CouponService = require("../../src/commons/services/coupon-service");
+const WorkflowService = require("../../src/commons/services/workflow/workflow-service");
+const MailController = require("../../src/commons/mail-service/mail-controller");
+const AccessService = require("../../src/commons/services/access/access-service");
+const AccessLogService = require("../../src/commons/services/access/access-log-service");
+const ReceiptService = require("../../src/commons/services/payment/receipt-service");
+const CancellationService = require("../../src/commons/services/payment/cancellation-service");
+const InvoiceService = require("../../src/commons/services/payment/invoice-service");
+const MediaService = require("../../src/commons/services/media/media-service");
+const SupervisorNotificationService = require("../../src/commons/services/supervisor-notification-service");
+const PaymentService = require("../../src/commons/services/payment/providers/payment-service");
+const { Bookable } = require("../../src/commons/entities/bookable/bookable");
+const { Booking } = require("../../src/commons/entities/booking/booking");
+const {
+  GroupBooking,
+} = require("../../src/commons/entities/groupBooking/groupBooking");
+
+const TENANT = "tenant-1";
+const TENANT_MAIL = "stadt@example.test";
+const ADMIN = "admin@example.test";
+const CUSTOMER = "erika@example.test";
+const ORGANIZER = "orga@example.test";
+const CUSTOMER_DB_ID = "64f1";
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+// A weekday slot well in the future: what a customer books today.
+const TIME_BEGIN = Date.UTC(2027, 5, 21, 10, 0, 0);
+const TIME_END = Date.UTC(2027, 5, 21, 12, 0, 0);
+
+const ROUTER = "../../src/platform/api/api-router-tenant-related";
+const ROUTER_V2 = "../../src/platform/api/v2/routes";
+
+/**
+ * The state a booking is in today, read off its three flags the way the
+ * spec's table (part 1, 3.2) reads them. `paid_unconfirmed` is the
+ * combination the spec abolishes; it is named so it shows in the table.
+ * A free booking carries `isPayed` from the checkout on, whatever its
+ * state, so the flag only counts where there is a price.
+ */
+function stateOf(booking) {
+  if (booking.isRejected) {
+    return booking.isCommitted ? "cancelled" : "rejected";
+  }
+  if (!booking.isCommitted) {
+    return booking.isPayed && booking.priceEur > 0
+      ? "paid_unconfirmed"
+      : "requested";
+  }
+  if (booking.priceEur > 0 && !booking.isPayed) {
+    return "payment_due";
+  }
+  return "confirmed";
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function bookable(overrides = {}) {
+  return new Bookable({
+    tenantId: TENANT,
+    type: "room",
+    isBookable: true,
+    isScheduleRelated: true,
+    autoCommitBooking: false,
+    amount: 10,
+    permittedUsers: [],
+    permittedRoles: [],
+    bookingDiscounts: { users: [], roles: [] },
+    checkoutBookableIds: [],
+    externalProviders: [],
+    attachments: [],
+    priceType: "per-item",
+    priceValueAddedTax: 0,
+    priceCategories: [{ priceEur: 40, interval: { start: null, end: null } }],
+    cancellationPolicy: { userCancellable: true, contactHint: "" },
+    groupBooking: { enabled: true, permittedRoles: [] },
+    ...overrides,
+  });
+}
+
+/** The bookables of the tenant, keyed by id. */
+function defaultBookables() {
+  return {
+    // A room that has to be confirmed by the administration.
+    room: bookable({ id: "room", title: "Raum" }),
+    // A room confirmed at once, to be paid.
+    "auto-room": bookable({
+      id: "auto-room",
+      title: "Raum (sofort)",
+      autoCommitBooking: true,
+    }),
+    // A free room, confirmed at once.
+    "free-room": bookable({
+      id: "free-room",
+      title: "Freier Raum",
+      autoCommitBooking: true,
+      priceCategories: [{ priceEur: 0, interval: { start: null, end: null } }],
+    }),
+    // A free room that has to be confirmed.
+    "free-request-room": bookable({
+      id: "free-request-room",
+      title: "Freier Raum (Anfrage)",
+      priceCategories: [{ priceEur: 0, interval: { start: null, end: null } }],
+    }),
+    // A ticket of an event with an organizer.
+    ticket: bookable({
+      id: "ticket",
+      title: "Ticket",
+      type: "ticket",
+      eventId: "E1",
+      isScheduleRelated: false,
+    }),
+    // A room with a document the mail path attaches (`mailAttach`).
+    "room-with-doc": bookable({
+      id: "room-with-doc",
+      title: "Raum mit Hausordnung",
+      autoCommitBooking: true,
+      attachments: [
+        {
+          id: "att-1",
+          title: "Hausordnung",
+          type: "file",
+          reference: { source: "media", mediaId: "M1" },
+          mailAttach: true,
+        },
+      ],
+    }),
+  };
+}
+
+function tenant(overrides = {}) {
+  return {
+    id: TENANT,
+    mail: TENANT_MAIL,
+    notifyOnNewBooking: true,
+    cancellationRefundTiers: [],
+    applications: [
+      { type: "payment", id: "giroCockpit", active: true },
+      { type: "payment", id: "invoice", active: true },
+    ],
+    ...overrides,
+  };
+}
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  // The same mounting order as `server.js`.
+  app.use("/api/v2", require(ROUTER_V2));
+  app.use("/api/:tenant", require(ROUTER));
+  app.use(errorHandler);
+  return app;
+}
+
+/**
+ * Installs every stub, starts the app on the IPv4 loopback and returns the
+ * handles the tests use. Call from `beforeEach`; `sinon.restore()` and
+ * `close()` in `afterEach` take it all down.
+ *
+ * The server is the harness' own, bound to `127.0.0.1`: supertest's
+ * server-per-request listens on `::` and connects to `127.0.0.1`, which on
+ * macOS now and then reaches a foreign process holding the same port on
+ * the IPv4 loopback.
+ *
+ * @param {Object} [options]
+ * @param {Object} [options.tenant] - Overrides of the tenant.
+ * @param {Object} [options.bookables] - Additional or replaced bookables.
+ */
+async function installHarness({ tenant: tenantOverrides, bookables } = {}) {
+  const store = new Map();
+  const groups = new Map();
+  const labels = new Map();
+  const effects = [];
+  /** Effect names that throw when called, e.g. "access.provision". */
+  const failing = new Set();
+  const counters = { receipt: 0, cancellation: 0, invoice: 0 };
+  const catalogue = { ...defaultBookables(), ...(bookables || {}) };
+  const tenantRecord = tenant(tenantOverrides);
+  const paymentSettings = { available: true };
+
+  const label = (id) => {
+    if (!labels.has(id)) {
+      labels.set(id, `B${labels.size + 1}`);
+    }
+    return labels.get(id);
+  };
+  const labelsOf = (ids) =>
+    (Array.isArray(ids) ? ids : [ids]).map(label).join(",");
+
+  /** Whether an effect is told to fail: by name, or by name and booking. */
+  const shouldFail = (name, detail) =>
+    failing.has(name) || failing.has(`${name} ${detail.split(" ")[0]}`);
+
+  function record(name, detail = "") {
+    const row = detail ? `${name} ${detail}` : name;
+    if (shouldFail(name, detail)) {
+      effects.push(`${row} FAILED`);
+      throw new Error(`${name} failed`);
+    }
+    effects.push(row);
+  }
+
+  // --- the booking store -------------------------------------------------
+
+  sinon
+    .stub(BookingManager, "getBooking")
+    .callsFake(async (id) =>
+      store.has(id) ? new Booking(clone(store.get(id))) : null,
+    );
+  sinon
+    .stub(BookingManager, "getBookings")
+    .callsFake(async (tenantId, ids) =>
+      [...store.values()]
+        .filter((doc) => ids.includes(doc.id))
+        .map((doc) => new Booking(clone(doc))),
+    );
+  sinon
+    .stub(BookingManager, "storeBooking")
+    .callsFake(async (booking, upsert, options = {}) => {
+      const entity =
+        booking instanceof Booking ? booking : new Booking(booking);
+      entity.validate();
+      const unset = Array.isArray(options.unset) ? options.unset : [];
+      for (const field of unset) {
+        delete entity[field];
+      }
+      // A write told to fail fails before anything is written.
+      if (shouldFail("store.save", label(entity.id))) {
+        record("store.save", label(entity.id));
+      }
+      // `updateOne(filter, document)` is a `$set` of the document's fields:
+      // what the document does not carry stays as it was.
+      const merged = { ...(store.get(entity.id) || {}), ...clone(entity) };
+      for (const field of unset) {
+        delete merged[field];
+      }
+      store.set(entity.id, merged);
+      const docs = merged.attachments
+        .filter((att) =>
+          ["receipt", "invoice", "cancellation"].includes(att.type),
+        )
+        .map((att) => att.type);
+      record(
+        "store.save",
+        `${label(entity.id)} ${stateOf(merged)}${docs.length ? ` [${docs.join(",")}]` : ""}`,
+      );
+      return entity;
+    });
+  sinon.stub(BookingManager, "removeBooking").callsFake(async (id) => {
+    store.delete(id);
+    record("store.remove", label(id));
+  });
+  sinon.stub(BookingManager, "getConcurrentBookings").resolves([]);
+  sinon.stub(BookingManager, "getRelatedBookings").resolves([]);
+  sinon.stub(BookingManager, "getEventBookings").resolves([]);
+
+  // --- the group booking store -------------------------------------------
+
+  const populated = (doc) =>
+    new GroupBooking({
+      ...clone(doc),
+      bookings: doc.bookingIds
+        .filter((id) => store.has(id))
+        .map((id) => clone(store.get(id))),
+    });
+  sinon
+    .stub(GroupBookingManager, "getGroupBooking")
+    .callsFake(async (tenantId, id, populate = false) => {
+      const doc = groups.get(id);
+      if (!doc) return null;
+      return populate ? populated(doc) : new GroupBooking(clone(doc));
+    });
+  sinon
+    .stub(GroupBookingManager, "getGroupBookingByBookingId")
+    .callsFake(async (tenantId, bookingId, populate = false) => {
+      const doc = [...groups.values()].find((group) =>
+        group.bookingIds.includes(bookingId),
+      );
+      if (!doc) return null;
+      return populate ? populated(doc) : new GroupBooking(clone(doc));
+    });
+  sinon
+    .stub(GroupBookingManager, "storeGroupBooking")
+    .callsFake(async (groupBooking) => {
+      const entity =
+        groupBooking instanceof GroupBooking
+          ? groupBooking
+          : new GroupBooking(groupBooking);
+      entity.validate();
+      const doc = clone(entity);
+      delete doc.bookings;
+      groups.set(entity.id, doc);
+      return entity;
+    });
+  sinon
+    .stub(GroupBookingManager, "deleteGroupBooking")
+    .callsFake(async (tenantId, id) => {
+      groups.delete(id);
+    });
+
+  // --- everything else the checkout reads --------------------------------
+
+  sinon
+    .stub(BookableManager, "getBookable")
+    .callsFake(async (id) => catalogue[id] || null);
+  sinon
+    .stub(BookableManager, "getBookablesByIds")
+    .callsFake(async (tenantId, ids) =>
+      ids.map((id) => catalogue[id]).filter(Boolean),
+    );
+  sinon.stub(BookableManager, "getAncestorBookables").resolves([]);
+  sinon.stub(BookableManager, "getAllParentBookables").resolves([]);
+  sinon.stub(BookableManager, "getRelatedBookables").resolves([]);
+  sinon.stub(BookableManager, "getCustomFieldDefinitions").resolves({
+    instanceFields: [],
+    tenantFields: [],
+  });
+
+  sinon.stub(TenantManager, "getTenant").resolves(tenantRecord);
+  sinon
+    .stub(TenantManager, "getTenantApp")
+    .callsFake(
+      async (tenantId, appId) =>
+        tenantRecord.applications.find((app) => app.id === appId) || null,
+    );
+  sinon.stub(UserManager, "getRawUser").resolves({ _id: CUSTOMER_DB_ID });
+  sinon.stub(UserManager, "getUser").callsFake(async (id) => ({ id }));
+  sinon
+    .stub(UserManager, "hasPermission")
+    .callsFake(async (userId) => userId === ADMIN);
+  sinon
+    .stub(PermissionsService, "_isInstanceOwner")
+    .callsFake(async (userId) => userId === ADMIN);
+  sinon.stub(PermissionsService, "_isTenantOwner").resolves(false);
+  sinon
+    .stub(MembershipManager, "getMembershipByTenantAndUserID")
+    .callsFake(async (tenantId, userId) => ({ userId, roles: [] }));
+  sinon.stub(MembershipManager, "getMembershipsByTenantAndRoles").resolves([]);
+  sinon.stub(EventManager, "getEvent").resolves({
+    id: "E1",
+    eventOrganizer: { contactPersonEmailAddress: ORGANIZER },
+  });
+  sinon.stub(OpeningHoursManager, "hasOpeningHoursConflict").resolves(false);
+  sinon.stub(AccessPointManager, "getAccessPointsByIds").resolves([]);
+  sinon.stub(MediaManager, "getBookingDocuments").resolves([]);
+  sinon.stub(MediaManager, "getMedia").resolves({
+    id: "M1",
+    tenantId: TENANT,
+    originalFileName: "hausordnung.pdf",
+    mimeType: "application/pdf",
+    storage: { provider: "local", key: "m1" },
+  });
+  sinon.stub(MediaService, "getBuffer").resolves(Buffer.from("%PDF-house"));
+  sinon.stub(WorkflowManager, "getWorkflow").resolves(null);
+  sinon.stub(CouponService, "incrementCouponUsage").resolves();
+  sinon.stub(CouponService, "decrementCouponUsage").resolves();
+  sinon.stub(PaymentUtils, "checkInvoicePermission").resolves(true);
+  sinon.stub(AccessLogService, "log").resolves();
+
+  // --- the JWT middleware: any signed token names its user ---------------
+
+  sinon.stub(JwtHelper, "verifyToken").callsFake((token) => ({
+    sub: jwt.decode(token).sub,
+    v: 2,
+    type: "access",
+  }));
+
+  // --- the effect seams --------------------------------------------------
+
+  for (const op of [
+    "holdForBooking",
+    "provisionForBooking",
+    "revokeForBooking",
+  ]) {
+    sinon.stub(AccessService, op).callsFake(async (tenantId, bookingId) => {
+      record(`access.${op.replace("ForBooking", "")}`, label(bookingId));
+      return [];
+    });
+  }
+  sinon
+    .stub(AccessService, "updateForBooking")
+    .callsFake(async (tenantId, oldBooking, newBooking) => {
+      record("access.update", label(newBooking.id));
+      return [];
+    });
+  sinon
+    .stub(AccessService, "refreshHolds")
+    .callsFake(async (tenantId, bookingIds) => {
+      record("access.refreshHolds", labelsOf(bookingIds));
+      return [];
+    });
+
+  sinon
+    .stub(WorkflowService, "handleWorkflowEvent")
+    .callsFake(async (tenantId, bookingId, event, skipBookingStatus) => {
+      record(
+        `workflow.${event}`,
+        `${label(bookingId)}${skipBookingStatus ? "" : " without skipBookingStatus"}`,
+      );
+      return true;
+    });
+
+  // Every `send*` of the mail controller takes the booking id(s) second
+  // and, where it sends files, one array of nodemailer attachments; the
+  // row is read off the arguments by that shape.
+  for (const name of Object.getOwnPropertyNames(MailController)) {
+    if (
+      typeof MailController[name] !== "function" ||
+      !name.startsWith("send")
+    ) {
+      continue;
+    }
+    sinon.stub(MailController, name).callsFake(async (...args) => {
+      const ids = args[1];
+      const attachments = args.find(
+        (arg) => Array.isArray(arg) && arg.length > 0 && arg[0]?.filename,
+      );
+      const files = attachments
+        ? ` [${attachments.map((att) => att.filename).join(",")}]`
+        : "";
+      record(`mail.${name}`, `${labelsOf(ids)}${files}`);
+    });
+  }
+  sinon
+    .stub(SupervisorNotificationService, "notifySupervisorsOnBookingCreated")
+    .callsFake(async ({ bookingIds }) => {
+      record("supervisor.notify", labelsOf(bookingIds));
+    });
+
+  const pdf = (name) => ({ name, buffer: Buffer.from(`%PDF-${name}`) });
+  /**
+   * A renderer of receipts or invoices, single or aggregated: numbers the
+   * document (`RE-1`, `RG-2`, ...) and records the row. The numbers are
+   * the harness', not the tenant's.
+   */
+  const renderer = (row, kind, prefix) => async (tenantId, bookingIds) => {
+    record(row, labelsOf(bookingIds));
+    const id = `${prefix}-${++counters[kind]}`;
+    return {
+      [kind]: pdf(`${id}.pdf`),
+      name: `${id}.pdf`,
+      [`${kind}Id`]: id,
+      revision: 1,
+      timeCreated: Date.now(),
+    };
+  };
+  sinon
+    .stub(ReceiptService, "createSingleReceipt")
+    .callsFake(renderer("documents.receipt", "receipt", "RE"));
+  sinon
+    .stub(ReceiptService, "createAggregatedReceipt")
+    .callsFake(renderer("documents.aggregatedReceipt", "receipt", "RE"));
+  sinon
+    .stub(InvoiceService, "createSingleInvoice")
+    .callsFake(renderer("documents.invoice", "invoice", "RG"));
+  // The renderer only: `issueAggregatedInvoice` attaches for real.
+  sinon
+    .stub(InvoiceService, "createAggregatedInvoice")
+    .callsFake(renderer("documents.aggregatedInvoice", "invoice", "RG"));
+  const cancellation = (cancellationId, options) => ({
+    cancellation: pdf(`${cancellationId}.pdf`),
+    name: `${cancellationId}.pdf`,
+    cancellationId,
+    cancellationNumber: cancellationId,
+    originalInvoiceNumber: "",
+    originalInvoiceDate: null,
+    revision: 1,
+    timeCreated:
+      options.refundCalculation?.cancelledAt ??
+      options.refundCalculations?.[0]?.cancelledAt ??
+      Date.now(),
+  });
+  sinon
+    .stub(CancellationService, "createSingleCancellation")
+    .callsFake(async ({ bookingId, options = {} }) => {
+      record("documents.cancellation", label(bookingId));
+      return cancellation(`ST-${++counters.cancellation}`, options);
+    });
+  sinon
+    .stub(CancellationService, "createAggregatedCancellation")
+    .callsFake(async ({ bookingIds, options = {} }) => {
+      record("documents.aggregatedCancellation", labelsOf(bookingIds));
+      return cancellation(`ST-${++counters.cancellation}`, options);
+    });
+  /**
+   * The payment provider at its seam: records the payment request and the
+   * payment link. A webhook counts as a successful payment and goes the
+   * base class' way from there - `handleSuccessfulPayment` is the one
+   * thing of `PaymentService` that runs for real.
+   */
+  class FakePaymentProvider extends PaymentService {
+    async paymentRequest() {
+      record(
+        "payment.paymentRequest",
+        `${labelsOf(this.bookingIds)}${this.aggregated ? " aggregated" : ""}`,
+      );
+    }
+
+    async createPayment() {
+      record(
+        "payment.createPayment",
+        `${labelsOf(this.bookingIds)}${this.aggregated ? " aggregated" : ""}`,
+      );
+      return { url: "https://pay.example.test" };
+    }
+
+    async paymentNotification() {
+      await this.handleSuccessfulPayment({
+        bookingIds: this.bookingIds,
+        tenantId: this.tenantId,
+        paymentMethod: "CREDIT_CARD",
+      });
+      return true;
+    }
+  }
+  sinon
+    .stub(PaymentUtils, "getPaymentService")
+    .callsFake(async (tenantId, bookingIds, paymentProvider, options) =>
+      paymentSettings.available
+        ? new FakePaymentProvider(tenantId, bookingIds, options)
+        : null,
+    );
+
+  const app = createApp();
+  const server = http.createServer(app);
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const api = () => request(server);
+  /** The authorization header of a signed-in user. */
+  const as = (userId) => ({
+    Authorization: `Bearer ${jwt.sign({ sub: userId }, "irrelevant")}`,
+  });
+
+  /** The administration books manually with the flags it chooses. */
+  async function manualBooking(bookableId, flags = {}, overrides = {}) {
+    const res = await api()
+      .put(`/api/${TENANT}/bookings`)
+      .set(as(ADMIN))
+      .send({
+        tenantId: TENANT,
+        ...checkoutBody(bookableId, overrides),
+        ...flags,
+      });
+    if (res.status !== 200) {
+      throw new Error(`manual booking answered ${res.status}: ${res.text}`);
+    }
+    return res.body;
+  }
+
+  /** A payment provider's webhook, e.g. `id=<bookingId>`. */
+  const webhook = (query, body = {}) =>
+    api().post(`/api/${TENANT}/payments/notify?${query}`).send(body);
+
+  return {
+    /** A supertest request against the app. */
+    api,
+    /** Stops the server. */
+    close: () =>
+      new Promise((resolve) => {
+        server.closeAllConnections();
+        server.close(() => resolve());
+      }),
+    store,
+    groups,
+    effects,
+    failing,
+    /** Whether `PaymentUtils.getPaymentService` finds a provider. */
+    payment: paymentSettings,
+    tenant: tenantRecord,
+    bookables: catalogue,
+    as,
+    manualBooking,
+    webhook,
+    /** The stored document of a booking. */
+    stored: (id) => store.get(id),
+    /** The stored documents of a group's members, in group order. */
+    members: (groupId) =>
+      groups.get(groupId).bookingIds.map((id) => store.get(id)),
+    /** Forgets the rows so far; the store stays. */
+    clearEffects: () => {
+      effects.length = 0;
+    },
+    /** Every row so far, then forgets them. */
+    takeEffects: () => effects.splice(0, effects.length),
+  };
+}
+
+/** A customer's checkout body for one bookable. */
+function checkoutBody(bookableId, overrides = {}) {
+  return {
+    timeBegin: TIME_BEGIN,
+    timeEnd: TIME_END,
+    bookableItems: [{ bookableId, amount: 1 }],
+    name: "Erika Muster",
+    mail: CUSTOMER,
+    paymentProvider: "giroCockpit",
+    attachmentStatus: [],
+    ...overrides,
+  };
+}
+
+/** A stored booking as the admin form sends it back, with changes. */
+function adminForm(stored, changes = {}) {
+  const form = { ...stored };
+  for (const field of [
+    "_couponUsed",
+    "attachments",
+    "accessInfo",
+    "hooks",
+    "cancellationRefund",
+    "lockerInfo",
+  ]) {
+    delete form[field];
+  }
+  return { ...form, ...changes };
+}
+
+module.exports = {
+  installHarness,
+  bookable,
+  checkoutBody,
+  adminForm,
+  stateOf,
+  request,
+  TENANT,
+  ADMIN,
+  CUSTOMER,
+  TIME_BEGIN,
+  TIME_END,
+  DAY,
+};


### PR DESCRIPTION
## Summary

First ticket of the BookingLifecycle chain: characterization tests, no production code changed.

- `tests/helpers/booking-lifecycle-harness.js`: the real routers on a bare express app, driven with `supertest` (new dev dependency), the world below the services stubbed at the data managers (in-memory store with `$set` semantics), every effect at the seam recorded as one row.
- `tests/booking-lifecycle-characterization.test.js` (59 cases): admission by both checkouts and the manual booking, commit, pay by the administration and by the payment webhook, reject with and without cancellation document and through a cancellation request, the admin PUT with its flag flips and the hidden reinstatement, the reprint endpoints, the workflow action.
- `tests/group-booking-lifecycle-characterization.test.js` (25 cases): the group variants incl. the legacy group checkout, the aggregated webhook and the two group reprint endpoints.
- Each case lists the effects (store writes, access calls, documents, mails, workflow events) as a table in the order they happen today.
- The known defects (spec part 2 §13) are pinned as today's behaviour; each test names the ticket of the chain that turns it.
- Also committed: the "Buchungslebenszyklus" glossary in `CONTEXT.md` from the spec session.

## Found on the way

- `BookingService` builds its `BaseError`s as `new BaseError(code, { message })`, so the params object lands where the status code goes. The error handler then fails on `res.status(...)` and express answers a bare 500; `requestRejectBooking` answers its plain 500 text. Pinned, not fixed.
- A free request is stored with `isPayed: true` (the checkout sets the flag from the price). Pinned.

## Test plan

- `npm test` (1718 passing), `npm run lint:check` (0 errors), `npm run format:check`
- The two characterization files ran 40 times in a row without a failure after binding the harness server to `127.0.0.1` (supertest's server-per-request on `::` collided now and then with a foreign IPv4 listener on the same port).